### PR TITLE
bump: Shaded protobuf-java 3.24.0

### DIFF
--- a/akka-cluster-metrics/src/main/java/akka/cluster/metrics/protobuf/msg/ClusterMetricsMessages.java
+++ b/akka-cluster-metrics/src/main/java/akka/cluster/metrics/protobuf/msg/ClusterMetricsMessages.java
@@ -90,11 +90,6 @@ public final class ClusterMetricsMessages {
       return new MetricsGossipEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_MetricsGossipEnvelope_descriptor;
@@ -347,11 +342,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsGossipEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsGossipEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -699,8 +696,10 @@ public final class ClusterMetricsMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -818,8 +817,10 @@ public final class ClusterMetricsMessages {
         } else {
           gossipBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (gossip_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -894,7 +895,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setReply(boolean value) {
-        
+
         reply_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1070,7 +1071,8 @@ public final class ClusterMetricsMessages {
     }
     private MetricsGossip() {
       allAddresses_ = java.util.Collections.emptyList();
-      allMetricNames_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      allMetricNames_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       nodeMetrics_ = java.util.Collections.emptyList();
     }
 
@@ -1081,11 +1083,6 @@ public final class ClusterMetricsMessages {
       return new MetricsGossip();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_MetricsGossip_descriptor;
@@ -1142,7 +1139,8 @@ public final class ClusterMetricsMessages {
 
     public static final int ALLMETRICNAMES_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList allMetricNames_;
+    private akka.protobufv3.internal.LazyStringArrayList allMetricNames_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string allMetricNames = 2;</code>
      * @return A list containing the allMetricNames.
@@ -1370,11 +1368,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsGossip parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsGossip parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1462,8 +1462,8 @@ public final class ClusterMetricsMessages {
           allAddressesBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        allMetricNames_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        allMetricNames_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         if (nodeMetricsBuilder_ == null) {
           nodeMetrics_ = java.util.Collections.emptyList();
         } else {
@@ -1513,11 +1513,6 @@ public final class ClusterMetricsMessages {
         } else {
           result.allAddresses_ = allAddressesBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
-          allMetricNames_ = allMetricNames_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.allMetricNames_ = allMetricNames_;
         if (nodeMetricsBuilder_ == null) {
           if (((bitField0_ & 0x00000004) != 0)) {
             nodeMetrics_ = java.util.Collections.unmodifiableList(nodeMetrics_);
@@ -1531,6 +1526,10 @@ public final class ClusterMetricsMessages {
 
       private void buildPartial0(akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsGossip result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          allMetricNames_.makeImmutable();
+          result.allMetricNames_ = allMetricNames_;
+        }
       }
 
       @java.lang.Override
@@ -1606,7 +1605,7 @@ public final class ClusterMetricsMessages {
         if (!other.allMetricNames_.isEmpty()) {
           if (allMetricNames_.isEmpty()) {
             allMetricNames_ = other.allMetricNames_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureAllMetricNamesIsMutable();
             allMetricNames_.addAll(other.allMetricNames_);
@@ -1964,12 +1963,13 @@ public final class ClusterMetricsMessages {
         return allAddressesBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList allMetricNames_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList allMetricNames_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureAllMetricNamesIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!allMetricNames_.isModifiable()) {
           allMetricNames_ = new akka.protobufv3.internal.LazyStringArrayList(allMetricNames_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string allMetricNames = 2;</code>
@@ -1977,7 +1977,8 @@ public final class ClusterMetricsMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getAllMetricNamesList() {
-        return allMetricNames_.getUnmodifiableView();
+        allMetricNames_.makeImmutable();
+        return allMetricNames_;
       }
       /**
        * <code>repeated string allMetricNames = 2;</code>
@@ -2014,6 +2015,7 @@ public final class ClusterMetricsMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllMetricNamesIsMutable();
         allMetricNames_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2027,6 +2029,7 @@ public final class ClusterMetricsMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllMetricNamesIsMutable();
         allMetricNames_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2040,6 +2043,7 @@ public final class ClusterMetricsMessages {
         ensureAllMetricNamesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, allMetricNames_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2048,8 +2052,9 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder clearAllMetricNames() {
-        allMetricNames_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        allMetricNames_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -2063,6 +2068,7 @@ public final class ClusterMetricsMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllMetricNamesIsMutable();
         allMetricNames_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2448,11 +2454,6 @@ public final class ClusterMetricsMessages {
       return new NodeMetrics();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_NodeMetrics_descriptor;
@@ -2661,11 +2662,6 @@ public final class ClusterMetricsMessages {
         return new Number();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_NodeMetrics_Number_descriptor;
@@ -2921,11 +2917,13 @@ public final class ClusterMetricsMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.Number parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.Number parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3252,7 +3250,7 @@ public final class ClusterMetricsMessages {
          * @return This builder for chaining.
          */
         public Builder setValue32(int value) {
-          
+
           value32_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -3292,7 +3290,7 @@ public final class ClusterMetricsMessages {
          * @return This builder for chaining.
          */
         public Builder setValue64(long value) {
-          
+
           value64_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -3460,11 +3458,6 @@ public final class ClusterMetricsMessages {
         return new EWMA();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_NodeMetrics_EWMA_descriptor;
@@ -3659,11 +3652,13 @@ public final class ClusterMetricsMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.EWMA parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.EWMA parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3918,7 +3913,7 @@ public final class ClusterMetricsMessages {
          * @return This builder for chaining.
          */
         public Builder setValue(double value) {
-          
+
           value_ = value;
           bitField0_ |= 0x00000001;
           onChanged();
@@ -3958,7 +3953,7 @@ public final class ClusterMetricsMessages {
          * @return This builder for chaining.
          */
         public Builder setAlpha(double value) {
-          
+
           alpha_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -4105,11 +4100,6 @@ public final class ClusterMetricsMessages {
         return new Metric();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_NodeMetrics_Metric_descriptor;
@@ -4359,11 +4349,13 @@ public final class ClusterMetricsMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.Metric parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics.Metric parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4662,7 +4654,7 @@ public final class ClusterMetricsMessages {
          * @return This builder for chaining.
          */
         public Builder setNameIndex(int value) {
-          
+
           nameIndex_ = value;
           bitField0_ |= 0x00000001;
           onChanged();
@@ -4745,8 +4737,10 @@ public final class ClusterMetricsMessages {
           } else {
             numberBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (number_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -4864,8 +4858,10 @@ public final class ClusterMetricsMessages {
           } else {
             ewmaBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000004;
-          onChanged();
+          if (ewma_ != null) {
+            bitField0_ |= 0x00000004;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -5218,11 +5214,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.NodeMetrics parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5546,7 +5544,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setAddressIndex(int value) {
-        
+
         addressIndex_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -5586,7 +5584,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -6002,11 +6000,6 @@ public final class ClusterMetricsMessages {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_Address_descriptor;
@@ -6358,11 +6351,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6817,7 +6812,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -7082,11 +7077,6 @@ public final class ClusterMetricsMessages {
       return new AdaptiveLoadBalancingPool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_AdaptiveLoadBalancingPool_descriptor;
@@ -7414,11 +7404,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.AdaptiveLoadBalancingPool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.AdaptiveLoadBalancingPool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7783,8 +7775,10 @@ public final class ClusterMetricsMessages {
         } else {
           metricsSelectorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (metricsSelector_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7875,7 +7869,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setNrOfInstances(int value) {
-        
+
         nrOfInstances_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -8019,7 +8013,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setUsePoolDispatcher(boolean value) {
-        
+
         usePoolDispatcher_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -8170,11 +8164,6 @@ public final class ClusterMetricsMessages {
       return new MetricsSelector();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_MetricsSelector_descriptor;
@@ -8433,11 +8422,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsSelector parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MetricsSelector parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8714,7 +8705,7 @@ public final class ClusterMetricsMessages {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -8965,11 +8956,6 @@ public final class ClusterMetricsMessages {
       return new MixMetricsSelector();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.internal_static_MixMetricsSelector_descriptor;
@@ -9141,11 +9127,13 @@ public final class ClusterMetricsMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MixMetricsSelector parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages.MixMetricsSelector parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)

--- a/akka-cluster-sharding-typed/src/main/java/akka/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
+++ b/akka-cluster-sharding-typed/src/main/java/akka/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
@@ -77,11 +77,6 @@ public final class ShardingMessages {
       return new ShardingEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
@@ -312,11 +307,13 @@ public final class ShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.ShardingEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -713,8 +710,10 @@ public final class ShardingMessages {
         } else {
           messageBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (message_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -899,11 +898,6 @@ public final class ShardingMessages {
       return new DaemonProcessScaleState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_DaemonProcessScaleState_descriptor;
@@ -1175,11 +1169,13 @@ public final class ShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.DaemonProcessScaleState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.DaemonProcessScaleState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1466,7 +1462,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setRevision(long value) {
-        
+
         revision_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -1506,7 +1502,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setNumberOfProcesses(int value) {
-        
+
         numberOfProcesses_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -1546,7 +1542,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setCompleted(boolean value) {
-        
+
         completed_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1586,7 +1582,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setStartedTimestampMillis(long value) {
-        
+
         startedTimestampMillis_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -1721,11 +1717,6 @@ public final class ShardingMessages {
       return new ChangeNumberOfProcesses();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_ChangeNumberOfProcesses_descriptor;
@@ -1945,11 +1936,13 @@ public final class ShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.ChangeNumberOfProcesses parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.ChangeNumberOfProcesses parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2206,7 +2199,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setNewNumberOfProcesses(int value) {
-        
+
         newNumberOfProcesses_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -2410,11 +2403,6 @@ public final class ShardingMessages {
       return new GetNumberOfProcesses();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_GetNumberOfProcesses_descriptor;
@@ -2595,11 +2583,13 @@ public final class ShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.GetNumberOfProcesses parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.GetNumberOfProcesses parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3030,11 +3020,6 @@ public final class ShardingMessages {
       return new GetNumberOfProcessesReply();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_GetNumberOfProcessesReply_descriptor;
@@ -3306,11 +3291,13 @@ public final class ShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.GetNumberOfProcessesReply parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.GetNumberOfProcessesReply parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3597,7 +3584,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setRevision(long value) {
-        
+
         revision_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -3637,7 +3624,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setNumberOfProcesses(int value) {
-        
+
         numberOfProcesses_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -3677,7 +3664,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setRescaleInProgress(boolean value) {
-        
+
         rescaleInProgress_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -3717,7 +3704,7 @@ public final class ShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setStartedTimestampMillis(long value) {
-        
+
         startedTimestampMillis_ = value;
         bitField0_ |= 0x00000008;
         onChanged();

--- a/akka-cluster-sharding/src/main/java/akka/cluster/sharding/protobuf/msg/ClusterShardingMessages.java
+++ b/akka-cluster-sharding/src/main/java/akka/cluster/sharding/protobuf/msg/ClusterShardingMessages.java
@@ -135,9 +135,12 @@ public final class ClusterShardingMessages {
     }
     private CoordinatorState() {
       shards_ = java.util.Collections.emptyList();
-      regions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-      regionProxies_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-      unallocatedShards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      regions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+      regionProxies_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+      unallocatedShards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -147,11 +150,6 @@ public final class ClusterShardingMessages {
       return new CoordinatorState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_CoordinatorState_descriptor;
@@ -227,11 +225,6 @@ public final class ClusterShardingMessages {
         return new ShardEntry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_CoordinatorState_ShardEntry_descriptor;
@@ -480,11 +473,13 @@ public final class ClusterShardingMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CoordinatorState.ShardEntry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CoordinatorState.ShardEntry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -986,7 +981,8 @@ public final class ClusterShardingMessages {
 
     public static final int REGIONS_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList regions_;
+    private akka.protobufv3.internal.LazyStringArrayList regions_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string regions = 2;</code>
      * @return A list containing the regions.
@@ -1022,7 +1018,8 @@ public final class ClusterShardingMessages {
 
     public static final int REGIONPROXIES_FIELD_NUMBER = 3;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList regionProxies_;
+    private akka.protobufv3.internal.LazyStringArrayList regionProxies_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string regionProxies = 3;</code>
      * @return A list containing the regionProxies.
@@ -1058,7 +1055,8 @@ public final class ClusterShardingMessages {
 
     public static final int UNALLOCATEDSHARDS_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList unallocatedShards_;
+    private akka.protobufv3.internal.LazyStringArrayList unallocatedShards_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string unallocatedShards = 4;</code>
      * @return A list containing the unallocatedShards.
@@ -1260,11 +1258,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CoordinatorState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CoordinatorState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1347,12 +1347,12 @@ public final class ClusterShardingMessages {
           shardsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        regions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        regionProxies_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
-        unallocatedShards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        regions_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        regionProxies_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        unallocatedShards_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -1395,25 +1395,22 @@ public final class ClusterShardingMessages {
         } else {
           result.shards_ = shardsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
-          regions_ = regions_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.regions_ = regions_;
-        if (((bitField0_ & 0x00000004) != 0)) {
-          regionProxies_ = regionProxies_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000004);
-        }
-        result.regionProxies_ = regionProxies_;
-        if (((bitField0_ & 0x00000008) != 0)) {
-          unallocatedShards_ = unallocatedShards_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.unallocatedShards_ = unallocatedShards_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CoordinatorState result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          regions_.makeImmutable();
+          result.regions_ = regions_;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          regionProxies_.makeImmutable();
+          result.regionProxies_ = regionProxies_;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          unallocatedShards_.makeImmutable();
+          result.unallocatedShards_ = unallocatedShards_;
+        }
       }
 
       @java.lang.Override
@@ -1489,7 +1486,7 @@ public final class ClusterShardingMessages {
         if (!other.regions_.isEmpty()) {
           if (regions_.isEmpty()) {
             regions_ = other.regions_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureRegionsIsMutable();
             regions_.addAll(other.regions_);
@@ -1499,7 +1496,7 @@ public final class ClusterShardingMessages {
         if (!other.regionProxies_.isEmpty()) {
           if (regionProxies_.isEmpty()) {
             regionProxies_ = other.regionProxies_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            bitField0_ |= 0x00000004;
           } else {
             ensureRegionProxiesIsMutable();
             regionProxies_.addAll(other.regionProxies_);
@@ -1509,7 +1506,7 @@ public final class ClusterShardingMessages {
         if (!other.unallocatedShards_.isEmpty()) {
           if (unallocatedShards_.isEmpty()) {
             unallocatedShards_ = other.unallocatedShards_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ |= 0x00000008;
           } else {
             ensureUnallocatedShardsIsMutable();
             unallocatedShards_.addAll(other.unallocatedShards_);
@@ -1835,12 +1832,13 @@ public final class ClusterShardingMessages {
         return shardsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList regions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList regions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureRegionsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!regions_.isModifiable()) {
           regions_ = new akka.protobufv3.internal.LazyStringArrayList(regions_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string regions = 2;</code>
@@ -1848,7 +1846,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getRegionsList() {
-        return regions_.getUnmodifiableView();
+        regions_.makeImmutable();
+        return regions_;
       }
       /**
        * <code>repeated string regions = 2;</code>
@@ -1885,6 +1884,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionsIsMutable();
         regions_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1898,6 +1898,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionsIsMutable();
         regions_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1911,6 +1912,7 @@ public final class ClusterShardingMessages {
         ensureRegionsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, regions_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1919,8 +1921,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearRegions() {
-        regions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        regions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -1934,16 +1937,18 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionsIsMutable();
         regions_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList regionProxies_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList regionProxies_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureRegionProxiesIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!regionProxies_.isModifiable()) {
           regionProxies_ = new akka.protobufv3.internal.LazyStringArrayList(regionProxies_);
-          bitField0_ |= 0x00000004;
-         }
+        }
+        bitField0_ |= 0x00000004;
       }
       /**
        * <code>repeated string regionProxies = 3;</code>
@@ -1951,7 +1956,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getRegionProxiesList() {
-        return regionProxies_.getUnmodifiableView();
+        regionProxies_.makeImmutable();
+        return regionProxies_;
       }
       /**
        * <code>repeated string regionProxies = 3;</code>
@@ -1988,6 +1994,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionProxiesIsMutable();
         regionProxies_.set(index, value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2001,6 +2008,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionProxiesIsMutable();
         regionProxies_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2014,6 +2022,7 @@ public final class ClusterShardingMessages {
         ensureRegionProxiesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, regionProxies_);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -2022,8 +2031,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearRegionProxies() {
-        regionProxies_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
+        regionProxies_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);;
         onChanged();
         return this;
       }
@@ -2037,16 +2047,18 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRegionProxiesIsMutable();
         regionProxies_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList unallocatedShards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList unallocatedShards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureUnallocatedShardsIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
+        if (!unallocatedShards_.isModifiable()) {
           unallocatedShards_ = new akka.protobufv3.internal.LazyStringArrayList(unallocatedShards_);
-          bitField0_ |= 0x00000008;
-         }
+        }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <code>repeated string unallocatedShards = 4;</code>
@@ -2054,7 +2066,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getUnallocatedShardsList() {
-        return unallocatedShards_.getUnmodifiableView();
+        unallocatedShards_.makeImmutable();
+        return unallocatedShards_;
       }
       /**
        * <code>repeated string unallocatedShards = 4;</code>
@@ -2091,6 +2104,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUnallocatedShardsIsMutable();
         unallocatedShards_.set(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2104,6 +2118,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUnallocatedShardsIsMutable();
         unallocatedShards_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2117,6 +2132,7 @@ public final class ClusterShardingMessages {
         ensureUnallocatedShardsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, unallocatedShards_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2125,8 +2141,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearUnallocatedShards() {
-        unallocatedShards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        unallocatedShards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000008);;
         onChanged();
         return this;
       }
@@ -2140,6 +2157,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUnallocatedShardsIsMutable();
         unallocatedShards_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2251,11 +2269,6 @@ public final class ClusterShardingMessages {
       return new ActorRefMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ActorRefMessage_descriptor;
@@ -2436,11 +2449,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ActorRefMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ActorRefMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2845,11 +2860,6 @@ public final class ClusterShardingMessages {
       return new ShardIdMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardIdMessage_descriptor;
@@ -3030,11 +3040,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardIdMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardIdMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3457,11 +3469,6 @@ public final class ClusterShardingMessages {
       return new ShardHomeAllocated();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardHomeAllocated_descriptor;
@@ -3710,11 +3717,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomeAllocated parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomeAllocated parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4235,11 +4244,6 @@ public final class ClusterShardingMessages {
       return new ShardHome();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardHome_descriptor;
@@ -4488,11 +4492,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHome parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHome parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5015,7 +5021,8 @@ public final class ClusterShardingMessages {
     }
     private ShardHomesEntry() {
       region_ = "";
-      shard_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      shard_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -5025,11 +5032,6 @@ public final class ClusterShardingMessages {
       return new ShardHomesEntry();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardHomesEntry_descriptor;
@@ -5095,7 +5097,8 @@ public final class ClusterShardingMessages {
 
     public static final int SHARD_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList shard_;
+    private akka.protobufv3.internal.LazyStringArrayList shard_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string shard = 2;</code>
      * @return A list containing the shard.
@@ -5263,11 +5266,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5348,8 +5353,8 @@ public final class ClusterShardingMessages {
         super.clear();
         bitField0_ = 0;
         region_ = "";
-        shard_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        shard_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -5376,18 +5381,9 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          shard_ = shard_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.shard_ = shard_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomesEntry result) {
@@ -5396,6 +5392,10 @@ public final class ClusterShardingMessages {
         if (((from_bitField0_ & 0x00000001) != 0)) {
           result.region_ = region_;
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          shard_.makeImmutable();
+          result.shard_ = shard_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -5452,7 +5452,7 @@ public final class ClusterShardingMessages {
         if (!other.shard_.isEmpty()) {
           if (shard_.isEmpty()) {
             shard_ = other.shard_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureShardIsMutable();
             shard_.addAll(other.shard_);
@@ -5596,12 +5596,13 @@ public final class ClusterShardingMessages {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList shard_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList shard_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureShardIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!shard_.isModifiable()) {
           shard_ = new akka.protobufv3.internal.LazyStringArrayList(shard_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string shard = 2;</code>
@@ -5609,7 +5610,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getShardList() {
-        return shard_.getUnmodifiableView();
+        shard_.makeImmutable();
+        return shard_;
       }
       /**
        * <code>repeated string shard = 2;</code>
@@ -5646,6 +5648,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIsMutable();
         shard_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -5659,6 +5662,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIsMutable();
         shard_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -5672,6 +5676,7 @@ public final class ClusterShardingMessages {
         ensureShardIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, shard_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -5680,8 +5685,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearShard() {
-        shard_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        shard_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -5695,6 +5701,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIsMutable();
         shard_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -5813,11 +5820,6 @@ public final class ClusterShardingMessages {
       return new ShardHomes();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardHomes_descriptor;
@@ -5989,11 +5991,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomes parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardHomes parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6600,7 +6604,8 @@ public final class ClusterShardingMessages {
       super(builder);
     }
     private EntityState() {
-      entities_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      entities_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -6610,11 +6615,6 @@ public final class ClusterShardingMessages {
       return new EntityState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_EntityState_descriptor;
@@ -6630,7 +6630,8 @@ public final class ClusterShardingMessages {
 
     public static final int ENTITIES_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList entities_;
+    private akka.protobufv3.internal.LazyStringArrayList entities_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string entities = 1;</code>
      * @return A list containing the entities.
@@ -6779,11 +6780,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6859,8 +6862,8 @@ public final class ClusterShardingMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        entities_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entities_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -6887,22 +6890,17 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          entities_ = entities_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.entities_ = entities_;
-      }
-
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityState result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          entities_.makeImmutable();
+          result.entities_ = entities_;
+        }
       }
 
       @java.lang.Override
@@ -6952,7 +6950,7 @@ public final class ClusterShardingMessages {
         if (!other.entities_.isEmpty()) {
           if (entities_.isEmpty()) {
             entities_ = other.entities_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureEntitiesIsMutable();
             entities_.addAll(other.entities_);
@@ -7008,12 +7006,13 @@ public final class ClusterShardingMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList entities_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList entities_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureEntitiesIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!entities_.isModifiable()) {
           entities_ = new akka.protobufv3.internal.LazyStringArrayList(entities_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string entities = 1;</code>
@@ -7021,7 +7020,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getEntitiesList() {
-        return entities_.getUnmodifiableView();
+        entities_.makeImmutable();
+        return entities_;
       }
       /**
        * <code>repeated string entities = 1;</code>
@@ -7058,6 +7058,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntitiesIsMutable();
         entities_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -7071,6 +7072,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntitiesIsMutable();
         entities_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -7084,6 +7086,7 @@ public final class ClusterShardingMessages {
         ensureEntitiesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, entities_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -7092,8 +7095,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearEntities() {
-        entities_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entities_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -7107,6 +7111,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntitiesIsMutable();
         entities_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -7222,11 +7227,6 @@ public final class ClusterShardingMessages {
       return new EntityStarted();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_EntityStarted_descriptor;
@@ -7407,11 +7407,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityStarted parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityStarted parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7818,7 +7820,8 @@ public final class ClusterShardingMessages {
       super(builder);
     }
     private EntitiesStarted() {
-      entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -7828,11 +7831,6 @@ public final class ClusterShardingMessages {
       return new EntitiesStarted();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_EntitiesStarted_descriptor;
@@ -7848,7 +7846,8 @@ public final class ClusterShardingMessages {
 
     public static final int ENTITYID_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList entityId_;
+    private akka.protobufv3.internal.LazyStringArrayList entityId_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string entityId = 1;</code>
      * @return A list containing the entityId.
@@ -7997,11 +7996,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8077,8 +8078,8 @@ public final class ClusterShardingMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -8105,22 +8106,17 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          entityId_ = entityId_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.entityId_ = entityId_;
-      }
-
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStarted result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          entityId_.makeImmutable();
+          result.entityId_ = entityId_;
+        }
       }
 
       @java.lang.Override
@@ -8170,7 +8166,7 @@ public final class ClusterShardingMessages {
         if (!other.entityId_.isEmpty()) {
           if (entityId_.isEmpty()) {
             entityId_ = other.entityId_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureEntityIdIsMutable();
             entityId_.addAll(other.entityId_);
@@ -8226,12 +8222,13 @@ public final class ClusterShardingMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureEntityIdIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!entityId_.isModifiable()) {
           entityId_ = new akka.protobufv3.internal.LazyStringArrayList(entityId_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string entityId = 1;</code>
@@ -8239,7 +8236,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getEntityIdList() {
-        return entityId_.getUnmodifiableView();
+        entityId_.makeImmutable();
+        return entityId_;
       }
       /**
        * <code>repeated string entityId = 1;</code>
@@ -8276,6 +8274,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8289,6 +8288,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8302,6 +8302,7 @@ public final class ClusterShardingMessages {
         ensureEntityIdIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, entityId_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8310,8 +8311,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearEntityId() {
-        entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -8325,6 +8327,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8440,11 +8443,6 @@ public final class ClusterShardingMessages {
       return new EntityStopped();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_EntityStopped_descriptor;
@@ -8625,11 +8623,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityStopped parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntityStopped parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9036,7 +9036,8 @@ public final class ClusterShardingMessages {
       super(builder);
     }
     private EntitiesStopped() {
-      entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -9046,11 +9047,6 @@ public final class ClusterShardingMessages {
       return new EntitiesStopped();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_EntitiesStopped_descriptor;
@@ -9066,7 +9062,8 @@ public final class ClusterShardingMessages {
 
     public static final int ENTITYID_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList entityId_;
+    private akka.protobufv3.internal.LazyStringArrayList entityId_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string entityId = 1;</code>
      * @return A list containing the entityId.
@@ -9215,11 +9212,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9295,8 +9294,8 @@ public final class ClusterShardingMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -9323,22 +9322,17 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          entityId_ = entityId_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.entityId_ = entityId_;
-      }
-
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.EntitiesStopped result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          entityId_.makeImmutable();
+          result.entityId_ = entityId_;
+        }
       }
 
       @java.lang.Override
@@ -9388,7 +9382,7 @@ public final class ClusterShardingMessages {
         if (!other.entityId_.isEmpty()) {
           if (entityId_.isEmpty()) {
             entityId_ = other.entityId_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureEntityIdIsMutable();
             entityId_.addAll(other.entityId_);
@@ -9444,12 +9438,13 @@ public final class ClusterShardingMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureEntityIdIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!entityId_.isModifiable()) {
           entityId_ = new akka.protobufv3.internal.LazyStringArrayList(entityId_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string entityId = 1;</code>
@@ -9457,7 +9452,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getEntityIdList() {
-        return entityId_.getUnmodifiableView();
+        entityId_.makeImmutable();
+        return entityId_;
       }
       /**
        * <code>repeated string entityId = 1;</code>
@@ -9494,6 +9490,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -9507,6 +9504,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -9520,6 +9518,7 @@ public final class ClusterShardingMessages {
         ensureEntityIdIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, entityId_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -9528,8 +9527,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearEntityId() {
-        entityId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -9543,6 +9543,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdIsMutable();
         entityId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -9665,11 +9666,6 @@ public final class ClusterShardingMessages {
       return new ShardStats();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardStats_descriptor;
@@ -9889,11 +9885,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardStats parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardStats parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10230,7 +10228,7 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setEntityCount(int value) {
-        
+
         entityCount_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -10377,7 +10375,8 @@ public final class ClusterShardingMessages {
     }
     private ShardRegionStats() {
       stats_ = java.util.Collections.emptyList();
-      failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -10387,11 +10386,6 @@ public final class ClusterShardingMessages {
       return new ShardRegionStats();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardRegionStats_descriptor;
@@ -10448,7 +10442,8 @@ public final class ClusterShardingMessages {
 
     public static final int FAILED_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList failed_;
+    private akka.protobufv3.internal.LazyStringArrayList failed_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string failed = 2;</code>
      * @return A list containing the failed.
@@ -10610,11 +10605,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardRegionStats parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardRegionStats parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10697,8 +10694,8 @@ public final class ClusterShardingMessages {
           statsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        failed_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -10741,15 +10738,14 @@ public final class ClusterShardingMessages {
         } else {
           result.stats_ = statsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
-          failed_ = failed_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.failed_ = failed_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardRegionStats result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          failed_.makeImmutable();
+          result.failed_ = failed_;
+        }
       }
 
       @java.lang.Override
@@ -10825,7 +10821,7 @@ public final class ClusterShardingMessages {
         if (!other.failed_.isEmpty()) {
           if (failed_.isEmpty()) {
             failed_ = other.failed_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureFailedIsMutable();
             failed_.addAll(other.failed_);
@@ -11134,12 +11130,13 @@ public final class ClusterShardingMessages {
         return statsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureFailedIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!failed_.isModifiable()) {
           failed_ = new akka.protobufv3.internal.LazyStringArrayList(failed_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string failed = 2;</code>
@@ -11147,7 +11144,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getFailedList() {
-        return failed_.getUnmodifiableView();
+        failed_.makeImmutable();
+        return failed_;
       }
       /**
        * <code>repeated string failed = 2;</code>
@@ -11184,6 +11182,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -11197,6 +11196,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -11210,6 +11210,7 @@ public final class ClusterShardingMessages {
         ensureFailedIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, failed_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -11218,8 +11219,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearFailed() {
-        failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -11233,6 +11235,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -11355,11 +11358,6 @@ public final class ClusterShardingMessages {
       return new MapFieldEntry();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_MapFieldEntry_descriptor;
@@ -11571,11 +11569,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.MapFieldEntry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.MapFieldEntry parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -11906,7 +11906,7 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setValue(int value) {
-        
+
         value_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -12023,11 +12023,6 @@ public final class ClusterShardingMessages {
       return new GetClusterShardingStats();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_GetClusterShardingStats_descriptor;
@@ -12180,11 +12175,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.GetClusterShardingStats parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.GetClusterShardingStats parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -12423,7 +12420,7 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setTimeoutNanos(long value) {
-        
+
         timeoutNanos_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -12554,11 +12551,6 @@ public final class ClusterShardingMessages {
       return new ClusterShardingStats();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ClusterShardingStats_descriptor;
@@ -12730,11 +12722,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ClusterShardingStats parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ClusterShardingStats parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13355,11 +13349,6 @@ public final class ClusterShardingMessages {
       return new ClusterShardingStatsEntry();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ClusterShardingStatsEntry_descriptor;
@@ -13568,11 +13557,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ClusterShardingStatsEntry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ClusterShardingStatsEntry parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13896,8 +13887,10 @@ public final class ClusterShardingMessages {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -14015,8 +14008,10 @@ public final class ClusterShardingMessages {
         } else {
           statsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (stats_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -14182,11 +14177,6 @@ public final class ClusterShardingMessages {
       return new CurrentRegions();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_CurrentRegions_descriptor;
@@ -14358,11 +14348,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentRegions parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentRegions parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -14969,7 +14961,8 @@ public final class ClusterShardingMessages {
       super(builder);
     }
     private StopShards() {
-      shards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      shards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -14979,11 +14972,6 @@ public final class ClusterShardingMessages {
       return new StopShards();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_StopShards_descriptor;
@@ -14999,7 +14987,8 @@ public final class ClusterShardingMessages {
 
     public static final int SHARDS_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList shards_;
+    private akka.protobufv3.internal.LazyStringArrayList shards_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string shards = 1;</code>
      * @return A list containing the shards.
@@ -15148,11 +15137,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15228,8 +15219,8 @@ public final class ClusterShardingMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        shards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        shards_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -15256,22 +15247,17 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          shards_ = shards_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.shards_ = shards_;
-      }
-
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StopShards result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          shards_.makeImmutable();
+          result.shards_ = shards_;
+        }
       }
 
       @java.lang.Override
@@ -15321,7 +15307,7 @@ public final class ClusterShardingMessages {
         if (!other.shards_.isEmpty()) {
           if (shards_.isEmpty()) {
             shards_ = other.shards_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureShardsIsMutable();
             shards_.addAll(other.shards_);
@@ -15377,12 +15363,13 @@ public final class ClusterShardingMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList shards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList shards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureShardsIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!shards_.isModifiable()) {
           shards_ = new akka.protobufv3.internal.LazyStringArrayList(shards_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string shards = 1;</code>
@@ -15390,7 +15377,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getShardsList() {
-        return shards_.getUnmodifiableView();
+        shards_.makeImmutable();
+        return shards_;
       }
       /**
        * <code>repeated string shards = 1;</code>
@@ -15427,6 +15415,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardsIsMutable();
         shards_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -15440,6 +15429,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardsIsMutable();
         shards_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -15453,6 +15443,7 @@ public final class ClusterShardingMessages {
         ensureShardsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, shards_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -15461,8 +15452,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearShards() {
-        shards_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        shards_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -15476,6 +15468,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardsIsMutable();
         shards_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -15639,11 +15632,6 @@ public final class ClusterShardingMessages {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_Address_descriptor;
@@ -15999,11 +15987,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -16541,7 +16531,7 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -16665,11 +16655,6 @@ public final class ClusterShardingMessages {
       return new StartEntity();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_StartEntity_descriptor;
@@ -16850,11 +16835,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StartEntity parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StartEntity parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -17277,11 +17264,6 @@ public final class ClusterShardingMessages {
       return new StartEntityAck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_StartEntityAck_descriptor;
@@ -17530,11 +17512,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StartEntityAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.StartEntityAck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18053,7 +18037,8 @@ public final class ClusterShardingMessages {
     }
     private CurrentShardState() {
       shardId_ = "";
-      entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -18063,11 +18048,6 @@ public final class ClusterShardingMessages {
       return new CurrentShardState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_CurrentShardState_descriptor;
@@ -18133,7 +18113,8 @@ public final class ClusterShardingMessages {
 
     public static final int ENTITYIDS_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList entityIds_;
+    private akka.protobufv3.internal.LazyStringArrayList entityIds_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string entityIds = 2;</code>
      * @return A list containing the entityIds.
@@ -18301,11 +18282,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18382,8 +18365,8 @@ public final class ClusterShardingMessages {
         super.clear();
         bitField0_ = 0;
         shardId_ = "";
-        entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        entityIds_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -18410,18 +18393,9 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          entityIds_ = entityIds_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.entityIds_ = entityIds_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardState result) {
@@ -18430,6 +18404,10 @@ public final class ClusterShardingMessages {
         if (((from_bitField0_ & 0x00000001) != 0)) {
           result.shardId_ = shardId_;
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          entityIds_.makeImmutable();
+          result.entityIds_ = entityIds_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -18486,7 +18464,7 @@ public final class ClusterShardingMessages {
         if (!other.entityIds_.isEmpty()) {
           if (entityIds_.isEmpty()) {
             entityIds_ = other.entityIds_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureEntityIdsIsMutable();
             entityIds_.addAll(other.entityIds_);
@@ -18630,12 +18608,13 @@ public final class ClusterShardingMessages {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureEntityIdsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!entityIds_.isModifiable()) {
           entityIds_ = new akka.protobufv3.internal.LazyStringArrayList(entityIds_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string entityIds = 2;</code>
@@ -18643,7 +18622,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getEntityIdsList() {
-        return entityIds_.getUnmodifiableView();
+        entityIds_.makeImmutable();
+        return entityIds_;
       }
       /**
        * <code>repeated string entityIds = 2;</code>
@@ -18680,6 +18660,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -18693,6 +18674,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -18706,6 +18688,7 @@ public final class ClusterShardingMessages {
         ensureEntityIdsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, entityIds_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -18714,8 +18697,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearEntityIds() {
-        entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -18729,6 +18713,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -18856,7 +18841,8 @@ public final class ClusterShardingMessages {
     }
     private ShardState() {
       shardId_ = "";
-      entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -18866,11 +18852,6 @@ public final class ClusterShardingMessages {
       return new ShardState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_ShardState_descriptor;
@@ -18936,7 +18917,8 @@ public final class ClusterShardingMessages {
 
     public static final int ENTITYIDS_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList entityIds_;
+    private akka.protobufv3.internal.LazyStringArrayList entityIds_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string entityIds = 2;</code>
      * @return A list containing the entityIds.
@@ -19104,11 +19086,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19185,8 +19169,8 @@ public final class ClusterShardingMessages {
         super.clear();
         bitField0_ = 0;
         shardId_ = "";
-        entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        entityIds_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -19213,18 +19197,9 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          entityIds_ = entityIds_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.entityIds_ = entityIds_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.ShardState result) {
@@ -19233,6 +19208,10 @@ public final class ClusterShardingMessages {
         if (((from_bitField0_ & 0x00000001) != 0)) {
           result.shardId_ = shardId_;
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          entityIds_.makeImmutable();
+          result.entityIds_ = entityIds_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -19289,7 +19268,7 @@ public final class ClusterShardingMessages {
         if (!other.entityIds_.isEmpty()) {
           if (entityIds_.isEmpty()) {
             entityIds_ = other.entityIds_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureEntityIdsIsMutable();
             entityIds_.addAll(other.entityIds_);
@@ -19433,12 +19412,13 @@ public final class ClusterShardingMessages {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureEntityIdsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!entityIds_.isModifiable()) {
           entityIds_ = new akka.protobufv3.internal.LazyStringArrayList(entityIds_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string entityIds = 2;</code>
@@ -19446,7 +19426,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getEntityIdsList() {
-        return entityIds_.getUnmodifiableView();
+        entityIds_.makeImmutable();
+        return entityIds_;
       }
       /**
        * <code>repeated string entityIds = 2;</code>
@@ -19483,6 +19464,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -19496,6 +19478,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -19509,6 +19492,7 @@ public final class ClusterShardingMessages {
         ensureEntityIdsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, entityIds_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -19517,8 +19501,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearEntityIds() {
-        entityIds_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        entityIds_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -19532,6 +19517,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureEntityIdsIsMutable();
         entityIds_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -19666,7 +19652,8 @@ public final class ClusterShardingMessages {
     }
     private CurrentShardRegionState() {
       shards_ = java.util.Collections.emptyList();
-      failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -19676,11 +19663,6 @@ public final class ClusterShardingMessages {
       return new CurrentShardRegionState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_CurrentShardRegionState_descriptor;
@@ -19737,7 +19719,8 @@ public final class ClusterShardingMessages {
 
     public static final int FAILED_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList failed_;
+    private akka.protobufv3.internal.LazyStringArrayList failed_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string failed = 2;</code>
      * @return A list containing the failed.
@@ -19905,11 +19888,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardRegionState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardRegionState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19992,8 +19977,8 @@ public final class ClusterShardingMessages {
           shardsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        failed_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -20036,15 +20021,14 @@ public final class ClusterShardingMessages {
         } else {
           result.shards_ = shardsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
-          failed_ = failed_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.failed_ = failed_;
       }
 
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.CurrentShardRegionState result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          failed_.makeImmutable();
+          result.failed_ = failed_;
+        }
       }
 
       @java.lang.Override
@@ -20120,7 +20104,7 @@ public final class ClusterShardingMessages {
         if (!other.failed_.isEmpty()) {
           if (failed_.isEmpty()) {
             failed_ = other.failed_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureFailedIsMutable();
             failed_.addAll(other.failed_);
@@ -20434,12 +20418,13 @@ public final class ClusterShardingMessages {
         return shardsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureFailedIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!failed_.isModifiable()) {
           failed_ = new akka.protobufv3.internal.LazyStringArrayList(failed_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string failed = 2;</code>
@@ -20447,7 +20432,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getFailedList() {
-        return failed_.getUnmodifiableView();
+        failed_.makeImmutable();
+        return failed_;
       }
       /**
        * <code>repeated string failed = 2;</code>
@@ -20484,6 +20470,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -20497,6 +20484,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -20510,6 +20498,7 @@ public final class ClusterShardingMessages {
         ensureFailedIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, failed_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -20518,8 +20507,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearFailed() {
-        failed_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        failed_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -20533,6 +20523,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureFailedIsMutable();
         failed_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -20653,7 +20644,8 @@ public final class ClusterShardingMessages {
       super(builder);
     }
     private RememberedShardState() {
-      shardId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      shardId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -20663,11 +20655,6 @@ public final class ClusterShardingMessages {
       return new RememberedShardState();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.internal_static_RememberedShardState_descriptor;
@@ -20684,7 +20671,8 @@ public final class ClusterShardingMessages {
     private int bitField0_;
     public static final int SHARDID_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList shardId_;
+    private akka.protobufv3.internal.LazyStringArrayList shardId_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string shardId = 1;</code>
      * @return A list containing the shardId.
@@ -20869,11 +20857,13 @@ public final class ClusterShardingMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -20949,8 +20939,8 @@ public final class ClusterShardingMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        shardId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        shardId_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         marker_ = false;
         return this;
       }
@@ -20978,22 +20968,17 @@ public final class ClusterShardingMessages {
       @java.lang.Override
       public akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState buildPartial() {
         akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState result = new akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          shardId_ = shardId_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.shardId_ = shardId_;
-      }
-
       private void buildPartial0(akka.cluster.sharding.protobuf.msg.ClusterShardingMessages.RememberedShardState result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          shardId_.makeImmutable();
+          result.shardId_ = shardId_;
+        }
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.marker_ = marker_;
@@ -21049,7 +21034,7 @@ public final class ClusterShardingMessages {
         if (!other.shardId_.isEmpty()) {
           if (shardId_.isEmpty()) {
             shardId_ = other.shardId_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureShardIdIsMutable();
             shardId_.addAll(other.shardId_);
@@ -21113,12 +21098,13 @@ public final class ClusterShardingMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList shardId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList shardId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureShardIdIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!shardId_.isModifiable()) {
           shardId_ = new akka.protobufv3.internal.LazyStringArrayList(shardId_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string shardId = 1;</code>
@@ -21126,7 +21112,8 @@ public final class ClusterShardingMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getShardIdList() {
-        return shardId_.getUnmodifiableView();
+        shardId_.makeImmutable();
+        return shardId_;
       }
       /**
        * <code>repeated string shardId = 1;</code>
@@ -21163,6 +21150,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIdIsMutable();
         shardId_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -21176,6 +21164,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIdIsMutable();
         shardId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -21189,6 +21178,7 @@ public final class ClusterShardingMessages {
         ensureShardIdIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, shardId_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -21197,8 +21187,9 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder clearShardId() {
-        shardId_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        shardId_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -21212,6 +21203,7 @@ public final class ClusterShardingMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureShardIdIsMutable();
         shardId_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -21239,7 +21231,7 @@ public final class ClusterShardingMessages {
        * @return This builder for chaining.
        */
       public Builder setMarker(boolean value) {
-        
+
         marker_ = value;
         bitField0_ |= 0x00000002;
         onChanged();

--- a/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
+++ b/akka-cluster-tools/src/main/java/akka/cluster/pubsub/protobuf/msg/DistributedPubSubMessages.java
@@ -80,11 +80,6 @@ public final class DistributedPubSubMessages {
       return new Status();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Status_descriptor;
@@ -150,11 +145,6 @@ public final class DistributedPubSubMessages {
         return new Version();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Status_Version_descriptor;
@@ -357,11 +347,13 @@ public final class DistributedPubSubMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.Version parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status.Version parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -676,8 +668,10 @@ public final class DistributedPubSubMessages {
           } else {
             addressBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000001;
-          onChanged();
+          if (address_ != null) {
+            bitField0_ |= 0x00000001;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -752,7 +746,7 @@ public final class DistributedPubSubMessages {
          * @return This builder for chaining.
          */
         public Builder setTimestamp(long value) {
-          
+
           timestamp_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -1027,11 +1021,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Status parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1571,7 +1567,7 @@ public final class DistributedPubSubMessages {
        * @return This builder for chaining.
        */
       public Builder setReplyToStatus(boolean value) {
-        
+
         replyToStatus_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -1702,11 +1698,6 @@ public final class DistributedPubSubMessages {
       return new Delta();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Delta_descriptor;
@@ -1793,11 +1784,6 @@ public final class DistributedPubSubMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Delta_Entry_descriptor;
@@ -2082,11 +2068,13 @@ public final class DistributedPubSubMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2438,7 +2426,7 @@ public final class DistributedPubSubMessages {
          * @return This builder for chaining.
          */
         public Builder setVersion(long value) {
-          
+
           version_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -2675,11 +2663,6 @@ public final class DistributedPubSubMessages {
         return new Bucket();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Delta_Bucket_descriptor;
@@ -2942,11 +2925,13 @@ public final class DistributedPubSubMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta.Bucket parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta.Bucket parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3326,8 +3311,10 @@ public final class DistributedPubSubMessages {
           } else {
             ownerBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000001;
-          onChanged();
+          if (owner_ != null) {
+            bitField0_ |= 0x00000001;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -3402,7 +3389,7 @@ public final class DistributedPubSubMessages {
          * @return This builder for chaining.
          */
         public Builder setVersion(long value) {
-          
+
           version_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -3880,11 +3867,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Delta parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4545,11 +4534,6 @@ public final class DistributedPubSubMessages {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Address_descriptor;
@@ -4901,11 +4885,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5360,7 +5346,7 @@ public final class DistributedPubSubMessages {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -5595,11 +5581,6 @@ public final class DistributedPubSubMessages {
       return new Send();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Send_descriptor;
@@ -5870,11 +5851,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Send parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Send parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6249,7 +6232,7 @@ public final class DistributedPubSubMessages {
        * @return This builder for chaining.
        */
       public Builder setLocalAffinity(boolean value) {
-        
+
         localAffinity_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -6332,8 +6315,10 @@ public final class DistributedPubSubMessages {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6523,11 +6508,6 @@ public final class DistributedPubSubMessages {
       return new SendToAll();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_SendToAll_descriptor;
@@ -6798,11 +6778,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.SendToAll parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.SendToAll parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7177,7 +7159,7 @@ public final class DistributedPubSubMessages {
        * @return This builder for chaining.
        */
       public Builder setAllButSelf(boolean value) {
-        
+
         allButSelf_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -7260,8 +7242,10 @@ public final class DistributedPubSubMessages {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7440,11 +7424,6 @@ public final class DistributedPubSubMessages {
       return new Publish();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Publish_descriptor;
@@ -7675,11 +7654,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Publish parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Publish parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8081,8 +8062,10 @@ public final class DistributedPubSubMessages {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -8243,11 +8226,6 @@ public final class DistributedPubSubMessages {
       return new SendToOneSubscriber();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_SendToOneSubscriber_descriptor;
@@ -8410,11 +8388,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.SendToOneSubscriber parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.SendToOneSubscriber parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8718,8 +8698,10 @@ public final class DistributedPubSubMessages {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -8895,11 +8877,6 @@ public final class DistributedPubSubMessages {
       return new Payload();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.internal_static_Payload_descriptor;
@@ -9125,11 +9102,13 @@ public final class DistributedPubSubMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Payload parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.pubsub.protobuf.msg.DistributedPubSubMessages.Payload parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9437,7 +9416,7 @@ public final class DistributedPubSubMessages {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();

--- a/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ClusterMessages.java
+++ b/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ClusterMessages.java
@@ -84,11 +84,6 @@ public final class ClusterMessages {
       return new ReceptionistEntry();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_ReceptionistEntry_descriptor;
@@ -345,11 +340,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ClusterMessages.ReceptionistEntry parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -699,7 +696,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setSystemUid(long value) {
-        
+
         systemUid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -739,7 +736,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setCreatedTimestamp(long value) {
-        
+
         createdTimestamp_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -860,11 +857,6 @@ public final class ClusterMessages {
       return new PubSubMessagePublished();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ClusterMessages.internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor;
@@ -1027,11 +1019,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ClusterMessages.PubSubMessagePublished parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1330,8 +1324,10 @@ public final class ClusterMessages {
         } else {
           messageBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (message_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**

--- a/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ReliableDelivery.java
+++ b/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ReliableDelivery.java
@@ -154,11 +154,6 @@ public final class ReliableDelivery {
       return new SequencedMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_SequencedMessage_descriptor;
@@ -649,11 +644,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.SequencedMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1103,7 +1100,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -1143,7 +1140,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setFirst(boolean value) {
-        
+
         first_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1183,7 +1180,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setAck(boolean value) {
-        
+
         ack_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -1346,8 +1343,10 @@ public final class ReliableDelivery {
         } else {
           messageBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000020;
-        onChanged();
+        if (message_ != null) {
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1422,7 +1421,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setFirstChunk(boolean value) {
-        
+
         firstChunk_ = value;
         bitField0_ |= 0x00000040;
         onChanged();
@@ -1462,7 +1461,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setLastChunk(boolean value) {
-        
+
         lastChunk_ = value;
         bitField0_ |= 0x00000080;
         onChanged();
@@ -1590,11 +1589,6 @@ public final class ReliableDelivery {
       return new RegisterConsumer();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_RegisterConsumer_descriptor;
@@ -1775,11 +1769,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.RegisterConsumer parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2218,11 +2214,6 @@ public final class ReliableDelivery {
       return new Request();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Request_descriptor;
@@ -2495,11 +2486,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Request parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Request parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2790,7 +2783,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setConfirmedSeqNr(long value) {
-        
+
         confirmedSeqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -2830,7 +2823,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setRequestUpToSeqNr(long value) {
-        
+
         requestUpToSeqNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -2870,7 +2863,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setSupportResend(boolean value) {
-        
+
         supportResend_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -2910,7 +2903,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setViaTimeout(boolean value) {
-        
+
         viaTimeout_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -3031,11 +3024,6 @@ public final class ReliableDelivery {
       return new Resend();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Resend_descriptor;
@@ -3188,11 +3176,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Resend parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Resend parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3435,7 +3425,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setFromSeqNr(long value) {
-        
+
         fromSeqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -3556,11 +3546,6 @@ public final class ReliableDelivery {
       return new Ack();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Ack_descriptor;
@@ -3713,11 +3698,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Ack parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Ack parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3960,7 +3947,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setConfirmedSeqNr(long value) {
-        
+
         confirmedSeqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -4142,11 +4129,6 @@ public final class ReliableDelivery {
       return new State();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_State_descriptor;
@@ -4459,11 +4441,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.State parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.State parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4846,7 +4830,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setCurrentSeqNr(long value) {
-        
+
         currentSeqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -4886,7 +4870,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setHighestConfirmedSeqNr(long value) {
-        
+
         highestConfirmedSeqNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -5516,11 +5500,6 @@ public final class ReliableDelivery {
       return new Confirmed();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Confirmed_descriptor;
@@ -5781,11 +5760,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Confirmed parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6062,7 +6043,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -6182,7 +6163,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -6380,11 +6361,6 @@ public final class ReliableDelivery {
       return new MessageSent();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_MessageSent_descriptor;
@@ -6807,11 +6783,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.MessageSent parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7163,7 +7141,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -7283,7 +7261,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setAck(boolean value) {
-        
+
         ack_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -7323,7 +7301,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -7406,8 +7384,10 @@ public final class ReliableDelivery {
         } else {
           messageBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (message_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7482,7 +7462,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setFirstChunk(boolean value) {
-        
+
         firstChunk_ = value;
         bitField0_ |= 0x00000020;
         onChanged();
@@ -7522,7 +7502,7 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder setLastChunk(boolean value) {
-        
+
         lastChunk_ = value;
         bitField0_ |= 0x00000040;
         onChanged();
@@ -7648,7 +7628,8 @@ public final class ReliableDelivery {
       super(builder);
     }
     private Cleanup() {
-      qualifiers_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      qualifiers_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -7658,11 +7639,6 @@ public final class ReliableDelivery {
       return new Cleanup();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.typed.internal.protobuf.ReliableDelivery.internal_static_akka_cluster_typed_delivery_Cleanup_descriptor;
@@ -7678,7 +7654,8 @@ public final class ReliableDelivery {
 
     public static final int QUALIFIERS_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList qualifiers_;
+    private akka.protobufv3.internal.LazyStringArrayList qualifiers_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string qualifiers = 1;</code>
      * @return A list containing the qualifiers.
@@ -7827,11 +7804,13 @@ public final class ReliableDelivery {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7911,8 +7890,8 @@ public final class ReliableDelivery {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        qualifiers_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        qualifiers_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -7939,22 +7918,17 @@ public final class ReliableDelivery {
       @java.lang.Override
       public akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup buildPartial() {
         akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup result = new akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          qualifiers_ = qualifiers_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.qualifiers_ = qualifiers_;
-      }
-
       private void buildPartial0(akka.cluster.typed.internal.protobuf.ReliableDelivery.Cleanup result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          qualifiers_.makeImmutable();
+          result.qualifiers_ = qualifiers_;
+        }
       }
 
       @java.lang.Override
@@ -8004,7 +7978,7 @@ public final class ReliableDelivery {
         if (!other.qualifiers_.isEmpty()) {
           if (qualifiers_.isEmpty()) {
             qualifiers_ = other.qualifiers_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureQualifiersIsMutable();
             qualifiers_.addAll(other.qualifiers_);
@@ -8060,12 +8034,13 @@ public final class ReliableDelivery {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList qualifiers_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList qualifiers_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureQualifiersIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!qualifiers_.isModifiable()) {
           qualifiers_ = new akka.protobufv3.internal.LazyStringArrayList(qualifiers_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string qualifiers = 1;</code>
@@ -8073,7 +8048,8 @@ public final class ReliableDelivery {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getQualifiersList() {
-        return qualifiers_.getUnmodifiableView();
+        qualifiers_.makeImmutable();
+        return qualifiers_;
       }
       /**
        * <code>repeated string qualifiers = 1;</code>
@@ -8110,6 +8086,7 @@ public final class ReliableDelivery {
         if (value == null) { throw new NullPointerException(); }
         ensureQualifiersIsMutable();
         qualifiers_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8123,6 +8100,7 @@ public final class ReliableDelivery {
         if (value == null) { throw new NullPointerException(); }
         ensureQualifiersIsMutable();
         qualifiers_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8136,6 +8114,7 @@ public final class ReliableDelivery {
         ensureQualifiersIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, qualifiers_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -8144,8 +8123,9 @@ public final class ReliableDelivery {
        * @return This builder for chaining.
        */
       public Builder clearQualifiers() {
-        qualifiers_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        qualifiers_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -8159,6 +8139,7 @@ public final class ReliableDelivery {
         if (value == null) { throw new NullPointerException(); }
         ensureQualifiersIsMutable();
         qualifiers_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }

--- a/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
+++ b/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
@@ -371,7 +371,8 @@ public final class ClusterMessages {
       super(builder);
     }
     private Join() {
-      roles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      roles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       appVersion_ = "";
     }
 
@@ -382,11 +383,6 @@ public final class ClusterMessages {
       return new Join();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Join_descriptor;
@@ -429,7 +425,8 @@ public final class ClusterMessages {
 
     public static final int ROLES_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList roles_;
+    private akka.protobufv3.internal.LazyStringArrayList roles_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string roles = 2;</code>
      * @return A list containing the roles.
@@ -666,11 +663,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Join parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Join parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -762,8 +761,8 @@ public final class ClusterMessages {
           nodeBuilder_.dispose();
           nodeBuilder_ = null;
         }
-        roles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        roles_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         appVersion_ = "";
         return this;
       }
@@ -791,18 +790,9 @@ public final class ClusterMessages {
       @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.Join buildPartial() {
         akka.cluster.protobuf.msg.ClusterMessages.Join result = new akka.cluster.protobuf.msg.ClusterMessages.Join(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.protobuf.msg.ClusterMessages.Join result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          roles_ = roles_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.roles_ = roles_;
       }
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.Join result) {
@@ -813,6 +803,10 @@ public final class ClusterMessages {
               ? node_
               : nodeBuilder_.build();
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          roles_.makeImmutable();
+          result.roles_ = roles_;
         }
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.appVersion_ = appVersion_;
@@ -871,7 +865,7 @@ public final class ClusterMessages {
         if (!other.roles_.isEmpty()) {
           if (roles_.isEmpty()) {
             roles_ = other.roles_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureRolesIsMutable();
             roles_.addAll(other.roles_);
@@ -1016,8 +1010,10 @@ public final class ClusterMessages {
         } else {
           nodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (node_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1069,12 +1065,13 @@ public final class ClusterMessages {
         return nodeBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList roles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList roles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureRolesIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!roles_.isModifiable()) {
           roles_ = new akka.protobufv3.internal.LazyStringArrayList(roles_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string roles = 2;</code>
@@ -1082,7 +1079,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getRolesList() {
-        return roles_.getUnmodifiableView();
+        roles_.makeImmutable();
+        return roles_;
       }
       /**
        * <code>repeated string roles = 2;</code>
@@ -1119,6 +1117,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRolesIsMutable();
         roles_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1132,6 +1131,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRolesIsMutable();
         roles_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1145,6 +1145,7 @@ public final class ClusterMessages {
         ensureRolesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, roles_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1153,8 +1154,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearRoles() {
-        roles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        roles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -1168,6 +1170,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureRolesIsMutable();
         roles_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1376,11 +1379,6 @@ public final class ClusterMessages {
       return new Welcome();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Welcome_descriptor;
@@ -1593,11 +1591,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Welcome parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Welcome parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1929,8 +1929,10 @@ public final class ClusterMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2048,8 +2050,10 @@ public final class ClusterMessages {
         } else {
           gossipBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (gossip_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2213,11 +2217,6 @@ public final class ClusterMessages {
       return new InitJoin();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_InitJoin_descriptor;
@@ -2394,11 +2393,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.InitJoin parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.InitJoin parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2822,11 +2823,6 @@ public final class ClusterMessages {
       return new InitJoinAck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_InitJoinAck_descriptor;
@@ -3039,11 +3035,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.InitJoinAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.InitJoinAck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3375,8 +3373,10 @@ public final class ClusterMessages {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3494,8 +3494,10 @@ public final class ClusterMessages {
         } else {
           configCheckBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (configCheck_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3666,11 +3668,6 @@ public final class ClusterMessages {
       return new ConfigCheck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_ConfigCheck_descriptor;
@@ -3989,11 +3986,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4486,11 +4485,6 @@ public final class ClusterMessages {
       return new Heartbeat();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Heartbeat_descriptor;
@@ -4725,11 +4719,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Heartbeat parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Heartbeat parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5061,8 +5057,10 @@ public final class ClusterMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5137,7 +5135,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setSequenceNr(long value) {
-        
+
         sequenceNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -5177,7 +5175,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setCreationTime(long value) {
-        
+
         creationTime_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -5327,11 +5325,6 @@ public final class ClusterMessages {
       return new HeartBeatResponse();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_HeartBeatResponse_descriptor;
@@ -5566,11 +5559,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.HeartBeatResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.HeartBeatResponse parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5902,8 +5897,10 @@ public final class ClusterMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5978,7 +5975,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setSequenceNr(long value) {
-        
+
         sequenceNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -6018,7 +6015,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setCreationTime(long value) {
-        
+
         creationTime_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -6171,11 +6168,6 @@ public final class ClusterMessages {
       return new GossipEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_GossipEnvelope_descriptor;
@@ -6427,11 +6419,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6779,8 +6773,10 @@ public final class ClusterMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6898,8 +6894,10 @@ public final class ClusterMessages {
         } else {
           toBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (to_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7142,7 +7140,8 @@ public final class ClusterMessages {
       super(builder);
     }
     private GossipStatus() {
-      allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       seenDigest_ = akka.protobufv3.internal.ByteString.EMPTY;
     }
 
@@ -7153,11 +7152,6 @@ public final class ClusterMessages {
       return new GossipStatus();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_GossipStatus_descriptor;
@@ -7200,7 +7194,8 @@ public final class ClusterMessages {
 
     public static final int ALLHASHES_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList allHashes_;
+    private akka.protobufv3.internal.LazyStringArrayList allHashes_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string allHashes = 2;</code>
      * @return A list containing the allHashes.
@@ -7458,11 +7453,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipStatus parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipStatus parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7555,8 +7552,8 @@ public final class ClusterMessages {
           fromBuilder_.dispose();
           fromBuilder_ = null;
         }
-        allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        allHashes_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         version_ = null;
         if (versionBuilder_ != null) {
           versionBuilder_.dispose();
@@ -7589,18 +7586,9 @@ public final class ClusterMessages {
       @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.GossipStatus buildPartial() {
         akka.cluster.protobuf.msg.ClusterMessages.GossipStatus result = new akka.cluster.protobuf.msg.ClusterMessages.GossipStatus(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.protobuf.msg.ClusterMessages.GossipStatus result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          allHashes_ = allHashes_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.allHashes_ = allHashes_;
       }
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.GossipStatus result) {
@@ -7611,6 +7599,10 @@ public final class ClusterMessages {
               ? from_
               : fromBuilder_.build();
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          allHashes_.makeImmutable();
+          result.allHashes_ = allHashes_;
         }
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.version_ = versionBuilder_ == null
@@ -7675,7 +7667,7 @@ public final class ClusterMessages {
         if (!other.allHashes_.isEmpty()) {
           if (allHashes_.isEmpty()) {
             allHashes_ = other.allHashes_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureAllHashesIsMutable();
             allHashes_.addAll(other.allHashes_);
@@ -7834,8 +7826,10 @@ public final class ClusterMessages {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7887,12 +7881,13 @@ public final class ClusterMessages {
         return fromBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureAllHashesIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!allHashes_.isModifiable()) {
           allHashes_ = new akka.protobufv3.internal.LazyStringArrayList(allHashes_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string allHashes = 2;</code>
@@ -7900,7 +7895,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getAllHashesList() {
-        return allHashes_.getUnmodifiableView();
+        allHashes_.makeImmutable();
+        return allHashes_;
       }
       /**
        * <code>repeated string allHashes = 2;</code>
@@ -7937,6 +7933,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -7950,6 +7947,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -7963,6 +7961,7 @@ public final class ClusterMessages {
         ensureAllHashesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, allHashes_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -7971,8 +7970,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearAllHashes() {
-        allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -7986,6 +7986,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -8056,8 +8057,10 @@ public final class ClusterMessages {
         } else {
           versionBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (version_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -8412,11 +8415,14 @@ public final class ClusterMessages {
     }
     private Gossip() {
       allAddresses_ = java.util.Collections.emptyList();
-      allRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-      allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      allRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+      allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       members_ = java.util.Collections.emptyList();
       tombstones_ = java.util.Collections.emptyList();
-      allAppVersions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      allAppVersions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -8426,11 +8432,6 @@ public final class ClusterMessages {
       return new Gossip();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Gossip_descriptor;
@@ -8488,7 +8489,8 @@ public final class ClusterMessages {
 
     public static final int ALLROLES_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList allRoles_;
+    private akka.protobufv3.internal.LazyStringArrayList allRoles_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string allRoles = 2;</code>
      * @return A list containing the allRoles.
@@ -8524,7 +8526,8 @@ public final class ClusterMessages {
 
     public static final int ALLHASHES_FIELD_NUMBER = 3;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList allHashes_;
+    private akka.protobufv3.internal.LazyStringArrayList allHashes_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string allHashes = 3;</code>
      * @return A list containing the allHashes.
@@ -8694,7 +8697,8 @@ public final class ClusterMessages {
 
     public static final int ALLAPPVERSIONS_FIELD_NUMBER = 8;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList allAppVersions_;
+    private akka.protobufv3.internal.LazyStringArrayList allAppVersions_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string allAppVersions = 8;</code>
      * @return A list containing the allAppVersions.
@@ -8982,11 +8986,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Gossip parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Gossip parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9084,10 +9090,10 @@ public final class ClusterMessages {
           allAddressesBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
-        allRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
-        allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
+        allRoles_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        allHashes_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         if (membersBuilder_ == null) {
           members_ = java.util.Collections.emptyList();
         } else {
@@ -9112,8 +9118,8 @@ public final class ClusterMessages {
           tombstonesBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000040);
-        allAppVersions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000080);
+        allAppVersions_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -9156,16 +9162,6 @@ public final class ClusterMessages {
         } else {
           result.allAddresses_ = allAddressesBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) != 0)) {
-          allRoles_ = allRoles_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.allRoles_ = allRoles_;
-        if (((bitField0_ & 0x00000004) != 0)) {
-          allHashes_ = allHashes_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000004);
-        }
-        result.allHashes_ = allHashes_;
         if (membersBuilder_ == null) {
           if (((bitField0_ & 0x00000008) != 0)) {
             members_ = java.util.Collections.unmodifiableList(members_);
@@ -9184,15 +9180,18 @@ public final class ClusterMessages {
         } else {
           result.tombstones_ = tombstonesBuilder_.build();
         }
-        if (((bitField0_ & 0x00000080) != 0)) {
-          allAppVersions_ = allAppVersions_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000080);
-        }
-        result.allAppVersions_ = allAppVersions_;
       }
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.Gossip result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          allRoles_.makeImmutable();
+          result.allRoles_ = allRoles_;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          allHashes_.makeImmutable();
+          result.allHashes_ = allHashes_;
+        }
         int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000010) != 0)) {
           result.overview_ = overviewBuilder_ == null
@@ -9205,6 +9204,10 @@ public final class ClusterMessages {
               ? version_
               : versionBuilder_.build();
           to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000080) != 0)) {
+          allAppVersions_.makeImmutable();
+          result.allAppVersions_ = allAppVersions_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -9282,7 +9285,7 @@ public final class ClusterMessages {
         if (!other.allRoles_.isEmpty()) {
           if (allRoles_.isEmpty()) {
             allRoles_ = other.allRoles_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ |= 0x00000002;
           } else {
             ensureAllRolesIsMutable();
             allRoles_.addAll(other.allRoles_);
@@ -9292,7 +9295,7 @@ public final class ClusterMessages {
         if (!other.allHashes_.isEmpty()) {
           if (allHashes_.isEmpty()) {
             allHashes_ = other.allHashes_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            bitField0_ |= 0x00000004;
           } else {
             ensureAllHashesIsMutable();
             allHashes_.addAll(other.allHashes_);
@@ -9360,7 +9363,7 @@ public final class ClusterMessages {
         if (!other.allAppVersions_.isEmpty()) {
           if (allAppVersions_.isEmpty()) {
             allAppVersions_ = other.allAppVersions_;
-            bitField0_ = (bitField0_ & ~0x00000080);
+            bitField0_ |= 0x00000080;
           } else {
             ensureAllAppVersionsIsMutable();
             allAppVersions_.addAll(other.allAppVersions_);
@@ -9748,12 +9751,13 @@ public final class ClusterMessages {
         return allAddressesBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList allRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList allRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureAllRolesIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
+        if (!allRoles_.isModifiable()) {
           allRoles_ = new akka.protobufv3.internal.LazyStringArrayList(allRoles_);
-          bitField0_ |= 0x00000002;
-         }
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated string allRoles = 2;</code>
@@ -9761,7 +9765,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getAllRolesList() {
-        return allRoles_.getUnmodifiableView();
+        allRoles_.makeImmutable();
+        return allRoles_;
       }
       /**
        * <code>repeated string allRoles = 2;</code>
@@ -9798,6 +9803,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllRolesIsMutable();
         allRoles_.set(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -9811,6 +9817,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllRolesIsMutable();
         allRoles_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -9824,6 +9831,7 @@ public final class ClusterMessages {
         ensureAllRolesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, allRoles_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -9832,8 +9840,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearAllRoles() {
-        allRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        allRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);;
         onChanged();
         return this;
       }
@@ -9847,16 +9856,18 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllRolesIsMutable();
         allRoles_.add(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureAllHashesIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!allHashes_.isModifiable()) {
           allHashes_ = new akka.protobufv3.internal.LazyStringArrayList(allHashes_);
-          bitField0_ |= 0x00000004;
-         }
+        }
+        bitField0_ |= 0x00000004;
       }
       /**
        * <code>repeated string allHashes = 3;</code>
@@ -9864,7 +9875,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getAllHashesList() {
-        return allHashes_.getUnmodifiableView();
+        allHashes_.makeImmutable();
+        return allHashes_;
       }
       /**
        * <code>repeated string allHashes = 3;</code>
@@ -9901,6 +9913,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.set(index, value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -9914,6 +9927,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -9927,6 +9941,7 @@ public final class ClusterMessages {
         ensureAllHashesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, allHashes_);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -9935,8 +9950,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearAllHashes() {
-        allHashes_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
+        allHashes_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);;
         onChanged();
         return this;
       }
@@ -9950,6 +9966,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllHashesIsMutable();
         allHashes_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -10260,8 +10277,10 @@ public final class ClusterMessages {
         } else {
           overviewBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (overview_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -10379,8 +10398,10 @@ public final class ClusterMessages {
         } else {
           versionBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000020;
-        onChanged();
+        if (version_ != null) {
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -10672,12 +10693,13 @@ public final class ClusterMessages {
         return tombstonesBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList allAppVersions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList allAppVersions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureAllAppVersionsIsMutable() {
-        if (!((bitField0_ & 0x00000080) != 0)) {
+        if (!allAppVersions_.isModifiable()) {
           allAppVersions_ = new akka.protobufv3.internal.LazyStringArrayList(allAppVersions_);
-          bitField0_ |= 0x00000080;
-         }
+        }
+        bitField0_ |= 0x00000080;
       }
       /**
        * <code>repeated string allAppVersions = 8;</code>
@@ -10685,7 +10707,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getAllAppVersionsList() {
-        return allAppVersions_.getUnmodifiableView();
+        allAppVersions_.makeImmutable();
+        return allAppVersions_;
       }
       /**
        * <code>repeated string allAppVersions = 8;</code>
@@ -10722,6 +10745,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllAppVersionsIsMutable();
         allAppVersions_.set(index, value);
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -10735,6 +10759,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllAppVersionsIsMutable();
         allAppVersions_.add(value);
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -10748,6 +10773,7 @@ public final class ClusterMessages {
         ensureAllAppVersionsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, allAppVersions_);
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -10756,8 +10782,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearAllAppVersions() {
-        allAppVersions_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000080);
+        allAppVersions_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000080);;
         onChanged();
         return this;
       }
@@ -10771,6 +10798,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureAllAppVersionsIsMutable();
         allAppVersions_.add(value);
+        bitField0_ |= 0x00000080;
         onChanged();
         return this;
       }
@@ -10924,11 +10952,6 @@ public final class ClusterMessages {
       return new GossipOverview();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_GossipOverview_descriptor;
@@ -10944,7 +10967,8 @@ public final class ClusterMessages {
 
     public static final int SEEN_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList seen_;
+    private akka.protobufv3.internal.Internal.IntList seen_ =
+        emptyIntList();
     /**
      * <pre>
      * This is the address indexes for the nodes that have seen this gossip 
@@ -11158,11 +11182,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipOverview parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.GossipOverview parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -11284,11 +11310,6 @@ public final class ClusterMessages {
       }
 
       private void buildPartialRepeatedFields(akka.cluster.protobuf.msg.ClusterMessages.GossipOverview result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          seen_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.seen_ = seen_;
         if (observerReachabilityBuilder_ == null) {
           if (((bitField0_ & 0x00000002) != 0)) {
             observerReachability_ = java.util.Collections.unmodifiableList(observerReachability_);
@@ -11302,6 +11323,10 @@ public final class ClusterMessages {
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.GossipOverview result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          seen_.makeImmutable();
+          result.seen_ = seen_;
+        }
       }
 
       @java.lang.Override
@@ -11351,7 +11376,8 @@ public final class ClusterMessages {
         if (!other.seen_.isEmpty()) {
           if (seen_.isEmpty()) {
             seen_ = other.seen_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            seen_.makeImmutable();
+            bitField0_ |= 0x00000001;
           } else {
             ensureSeenIsMutable();
             seen_.addAll(other.seen_);
@@ -11463,10 +11489,10 @@ public final class ClusterMessages {
 
       private akka.protobufv3.internal.Internal.IntList seen_ = emptyIntList();
       private void ensureSeenIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
-          seen_ = mutableCopy(seen_);
-          bitField0_ |= 0x00000001;
+        if (!seen_.isModifiable()) {
+          seen_ = makeMutableCopy(seen_);
         }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <pre>
@@ -11478,8 +11504,8 @@ public final class ClusterMessages {
        */
       public java.util.List<java.lang.Integer>
           getSeenList() {
-        return ((bitField0_ & 0x00000001) != 0) ?
-                 java.util.Collections.unmodifiableList(seen_) : seen_;
+        seen_.makeImmutable();
+        return seen_;
       }
       /**
        * <pre>
@@ -11516,9 +11542,10 @@ public final class ClusterMessages {
        */
       public Builder setSeen(
           int index, int value) {
-        
+
         ensureSeenIsMutable();
         seen_.setInt(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -11532,9 +11559,10 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder addSeen(int value) {
-        
+
         ensureSeenIsMutable();
         seen_.addInt(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -11552,6 +11580,7 @@ public final class ClusterMessages {
         ensureSeenIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, seen_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -11951,11 +11980,6 @@ public final class ClusterMessages {
       return new ObserverReachability();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_ObserverReachability_descriptor;
@@ -12207,11 +12231,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ObserverReachability parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ObserverReachability parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -12535,7 +12561,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAddressIndex(int value) {
-        
+
         addressIndex_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -12575,7 +12601,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setVersion(long value) {
-        
+
         version_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -12955,11 +12981,6 @@ public final class ClusterMessages {
       return new SubjectReachability();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_SubjectReachability_descriptor;
@@ -13188,11 +13209,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.SubjectReachability parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.SubjectReachability parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13470,7 +13493,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAddressIndex(int value) {
-        
+
         addressIndex_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -13552,7 +13575,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setVersion(long value) {
-        
+
         version_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -13680,11 +13703,6 @@ public final class ClusterMessages {
       return new Tombstone();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Tombstone_descriptor;
@@ -13876,11 +13894,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Tombstone parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Tombstone parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -14135,7 +14155,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAddressIndex(int value) {
-        
+
         addressIndex_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -14175,7 +14195,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -14349,11 +14369,6 @@ public final class ClusterMessages {
       return new Member();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Member_descriptor;
@@ -14426,7 +14441,8 @@ public final class ClusterMessages {
 
     public static final int ROLESINDEXES_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList rolesIndexes_;
+    private akka.protobufv3.internal.Internal.IntList rolesIndexes_ =
+        emptyIntList();
     /**
      * <code>repeated int32 rolesIndexes = 4 [packed = true];</code>
      * @return A list containing the rolesIndexes.
@@ -14673,11 +14689,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Member parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Member parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -14789,18 +14807,9 @@ public final class ClusterMessages {
       @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.Member buildPartial() {
         akka.cluster.protobuf.msg.ClusterMessages.Member result = new akka.cluster.protobuf.msg.ClusterMessages.Member(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.protobuf.msg.ClusterMessages.Member result) {
-        if (((bitField0_ & 0x00000008) != 0)) {
-          rolesIndexes_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.rolesIndexes_ = rolesIndexes_;
       }
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.Member result) {
@@ -14817,6 +14826,10 @@ public final class ClusterMessages {
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.status_ = status_;
           to_bitField0_ |= 0x00000004;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          rolesIndexes_.makeImmutable();
+          result.rolesIndexes_ = rolesIndexes_;
         }
         if (((from_bitField0_ & 0x00000010) != 0)) {
           result.appVersionIndex_ = appVersionIndex_;
@@ -14881,7 +14894,8 @@ public final class ClusterMessages {
         if (!other.rolesIndexes_.isEmpty()) {
           if (rolesIndexes_.isEmpty()) {
             rolesIndexes_ = other.rolesIndexes_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            rolesIndexes_.makeImmutable();
+            bitField0_ |= 0x00000008;
           } else {
             ensureRolesIndexesIsMutable();
             rolesIndexes_.addAll(other.rolesIndexes_);
@@ -15009,7 +15023,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAddressIndex(int value) {
-        
+
         addressIndex_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -15049,7 +15063,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setUpNumber(int value) {
-        
+
         upNumber_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -15110,10 +15124,10 @@ public final class ClusterMessages {
 
       private akka.protobufv3.internal.Internal.IntList rolesIndexes_ = emptyIntList();
       private void ensureRolesIndexesIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
-          rolesIndexes_ = mutableCopy(rolesIndexes_);
-          bitField0_ |= 0x00000008;
+        if (!rolesIndexes_.isModifiable()) {
+          rolesIndexes_ = makeMutableCopy(rolesIndexes_);
         }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <code>repeated int32 rolesIndexes = 4 [packed = true];</code>
@@ -15121,8 +15135,8 @@ public final class ClusterMessages {
        */
       public java.util.List<java.lang.Integer>
           getRolesIndexesList() {
-        return ((bitField0_ & 0x00000008) != 0) ?
-                 java.util.Collections.unmodifiableList(rolesIndexes_) : rolesIndexes_;
+        rolesIndexes_.makeImmutable();
+        return rolesIndexes_;
       }
       /**
        * <code>repeated int32 rolesIndexes = 4 [packed = true];</code>
@@ -15147,9 +15161,10 @@ public final class ClusterMessages {
        */
       public Builder setRolesIndexes(
           int index, int value) {
-        
+
         ensureRolesIndexesIsMutable();
         rolesIndexes_.setInt(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -15159,9 +15174,10 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder addRolesIndexes(int value) {
-        
+
         ensureRolesIndexesIsMutable();
         rolesIndexes_.addInt(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -15175,6 +15191,7 @@ public final class ClusterMessages {
         ensureRolesIndexesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, rolesIndexes_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -15212,7 +15229,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAppVersionIndex(int value) {
-        
+
         appVersionIndex_ = value;
         bitField0_ |= 0x00000010;
         onChanged();
@@ -15367,11 +15384,6 @@ public final class ClusterMessages {
       return new VectorClock();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_VectorClock_descriptor;
@@ -15433,11 +15445,6 @@ public final class ClusterMessages {
         return new Version();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.protobuf.msg.ClusterMessages.internal_static_VectorClock_Version_descriptor;
@@ -15629,11 +15636,13 @@ public final class ClusterMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.protobuf.msg.ClusterMessages.VectorClock.Version parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.protobuf.msg.ClusterMessages.VectorClock.Version parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15888,7 +15897,7 @@ public final class ClusterMessages {
          * @return This builder for chaining.
          */
         public Builder setHashIndex(int value) {
-          
+
           hashIndex_ = value;
           bitField0_ |= 0x00000001;
           onChanged();
@@ -15928,7 +15937,7 @@ public final class ClusterMessages {
          * @return This builder for chaining.
          */
         public Builder setTimestamp(long value) {
-          
+
           timestamp_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -16211,11 +16220,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.VectorClock parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.VectorClock parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -16532,7 +16543,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -16887,11 +16898,6 @@ public final class ClusterMessages {
       return new Empty();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Empty_descriptor;
@@ -17003,11 +17009,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Empty parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Empty parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -17362,11 +17370,6 @@ public final class ClusterMessages {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Address_descriptor;
@@ -17718,11 +17721,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18177,7 +18182,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -18413,11 +18418,6 @@ public final class ClusterMessages {
       return new UniqueAddress();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_UniqueAddress_descriptor;
@@ -18662,11 +18662,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18999,8 +19001,10 @@ public final class ClusterMessages {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -19075,7 +19079,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setUid(int value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -19127,7 +19131,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setUid2(int value) {
-        
+
         uid2_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -19267,11 +19271,6 @@ public final class ClusterMessages {
       return new ClusterRouterPool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_ClusterRouterPool_descriptor;
@@ -19484,11 +19483,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19815,8 +19816,10 @@ public final class ClusterMessages {
         } else {
           poolBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (pool_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -19934,8 +19937,10 @@ public final class ClusterMessages {
         } else {
           settingsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (settings_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -20117,11 +20122,6 @@ public final class ClusterMessages {
       return new Pool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_Pool_descriptor;
@@ -20380,11 +20380,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Pool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.Pool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -20657,7 +20659,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -20950,7 +20952,8 @@ public final class ClusterMessages {
     }
     private ClusterRouterPoolSettings() {
       useRole_ = "";
-      useRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      useRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -20960,11 +20963,6 @@ public final class ClusterMessages {
       return new ClusterRouterPoolSettings();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.protobuf.msg.ClusterMessages.internal_static_ClusterRouterPoolSettings_descriptor;
@@ -21087,7 +21085,8 @@ public final class ClusterMessages {
 
     public static final int USEROLES_FIELD_NUMBER = 5;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList useRoles_;
+    private akka.protobufv3.internal.LazyStringArrayList useRoles_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string useRoles = 5;</code>
      * @return A list containing the useRoles.
@@ -21312,11 +21311,13 @@ public final class ClusterMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -21396,8 +21397,8 @@ public final class ClusterMessages {
         maxInstancesPerNode_ = 0;
         allowLocalRoutees_ = false;
         useRole_ = "";
-        useRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
+        useRoles_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -21424,18 +21425,9 @@ public final class ClusterMessages {
       @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings buildPartial() {
         akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings result = new akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings result) {
-        if (((bitField0_ & 0x00000010) != 0)) {
-          useRoles_ = useRoles_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.useRoles_ = useRoles_;
       }
 
       private void buildPartial0(akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings result) {
@@ -21456,6 +21448,10 @@ public final class ClusterMessages {
         if (((from_bitField0_ & 0x00000008) != 0)) {
           result.useRole_ = useRole_;
           to_bitField0_ |= 0x00000008;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          useRoles_.makeImmutable();
+          result.useRoles_ = useRoles_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -21521,7 +21517,7 @@ public final class ClusterMessages {
         if (!other.useRoles_.isEmpty()) {
           if (useRoles_.isEmpty()) {
             useRoles_ = other.useRoles_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            bitField0_ |= 0x00000010;
           } else {
             ensureUseRolesIsMutable();
             useRoles_.addAll(other.useRoles_);
@@ -21629,7 +21625,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setTotalInstances(int value) {
-        
+
         totalInstances_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -21669,7 +21665,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setMaxInstancesPerNode(int value) {
-        
+
         maxInstancesPerNode_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -21709,7 +21705,7 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder setAllowLocalRoutees(boolean value) {
-        
+
         allowLocalRoutees_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -21806,12 +21802,13 @@ public final class ClusterMessages {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList useRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList useRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureUseRolesIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
+        if (!useRoles_.isModifiable()) {
           useRoles_ = new akka.protobufv3.internal.LazyStringArrayList(useRoles_);
-          bitField0_ |= 0x00000010;
-         }
+        }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <code>repeated string useRoles = 5;</code>
@@ -21819,7 +21816,8 @@ public final class ClusterMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getUseRolesList() {
-        return useRoles_.getUnmodifiableView();
+        useRoles_.makeImmutable();
+        return useRoles_;
       }
       /**
        * <code>repeated string useRoles = 5;</code>
@@ -21856,6 +21854,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUseRolesIsMutable();
         useRoles_.set(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -21869,6 +21868,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUseRolesIsMutable();
         useRoles_.add(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -21882,6 +21882,7 @@ public final class ClusterMessages {
         ensureUseRolesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, useRoles_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -21890,8 +21891,9 @@ public final class ClusterMessages {
        * @return This builder for chaining.
        */
       public Builder clearUseRoles() {
-        useRoles_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
+        useRoles_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);;
         onChanged();
         return this;
       }
@@ -21905,6 +21907,7 @@ public final class ClusterMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureUseRolesIsMutable();
         useRoles_.add(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }

--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatedDataMessages.java
@@ -378,11 +378,13 @@ public final class ReplicatedDataMessages {
       super(builder);
     }
     private GSet() {
-      stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       intElements_ = emptyIntList();
       longElements_ = emptyLongList();
       otherElements_ = java.util.Collections.emptyList();
-      actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -392,11 +394,6 @@ public final class ReplicatedDataMessages {
       return new GSet();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GSet_descriptor;
@@ -412,7 +409,8 @@ public final class ReplicatedDataMessages {
 
     public static final int STRINGELEMENTS_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList stringElements_;
+    private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string stringElements = 1;</code>
      * @return A list containing the stringElements.
@@ -448,7 +446,8 @@ public final class ReplicatedDataMessages {
 
     public static final int INTELEMENTS_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList intElements_;
+    private akka.protobufv3.internal.Internal.IntList intElements_ =
+        emptyIntList();
     /**
      * <code>repeated sint32 intElements = 2 [packed = true];</code>
      * @return A list containing the intElements.
@@ -477,7 +476,8 @@ public final class ReplicatedDataMessages {
 
     public static final int LONGELEMENTS_FIELD_NUMBER = 3;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.LongList longElements_;
+    private akka.protobufv3.internal.Internal.LongList longElements_ =
+        emptyLongList();
     /**
      * <code>repeated sint64 longElements = 3 [packed = true];</code>
      * @return A list containing the longElements.
@@ -547,7 +547,8 @@ public final class ReplicatedDataMessages {
 
     public static final int ACTORREFELEMENTS_FIELD_NUMBER = 5;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList actorRefElements_;
+    private akka.protobufv3.internal.LazyStringArrayList actorRefElements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <pre>
      * added in Akka 2.5.14
@@ -803,11 +804,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -883,8 +886,8 @@ public final class ReplicatedDataMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        stringElements_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         intElements_ = emptyIntList();
         longElements_ = emptyLongList();
         if (otherElementsBuilder_ == null) {
@@ -894,8 +897,8 @@ public final class ReplicatedDataMessages {
           otherElementsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000008);
-        actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
+        actorRefElements_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -929,21 +932,6 @@ public final class ReplicatedDataMessages {
       }
 
       private void buildPartialRepeatedFields(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          stringElements_ = stringElements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.stringElements_ = stringElements_;
-        if (((bitField0_ & 0x00000002) != 0)) {
-          intElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.intElements_ = intElements_;
-        if (((bitField0_ & 0x00000004) != 0)) {
-          longElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000004);
-        }
-        result.longElements_ = longElements_;
         if (otherElementsBuilder_ == null) {
           if (((bitField0_ & 0x00000008) != 0)) {
             otherElements_ = java.util.Collections.unmodifiableList(otherElements_);
@@ -953,15 +941,26 @@ public final class ReplicatedDataMessages {
         } else {
           result.otherElements_ = otherElementsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000010) != 0)) {
-          actorRefElements_ = actorRefElements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.actorRefElements_ = actorRefElements_;
       }
 
       private void buildPartial0(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GSet result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          stringElements_.makeImmutable();
+          result.stringElements_ = stringElements_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          intElements_.makeImmutable();
+          result.intElements_ = intElements_;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          longElements_.makeImmutable();
+          result.longElements_ = longElements_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          actorRefElements_.makeImmutable();
+          result.actorRefElements_ = actorRefElements_;
+        }
       }
 
       @java.lang.Override
@@ -1011,7 +1010,7 @@ public final class ReplicatedDataMessages {
         if (!other.stringElements_.isEmpty()) {
           if (stringElements_.isEmpty()) {
             stringElements_ = other.stringElements_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureStringElementsIsMutable();
             stringElements_.addAll(other.stringElements_);
@@ -1021,7 +1020,8 @@ public final class ReplicatedDataMessages {
         if (!other.intElements_.isEmpty()) {
           if (intElements_.isEmpty()) {
             intElements_ = other.intElements_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            intElements_.makeImmutable();
+            bitField0_ |= 0x00000002;
           } else {
             ensureIntElementsIsMutable();
             intElements_.addAll(other.intElements_);
@@ -1031,7 +1031,8 @@ public final class ReplicatedDataMessages {
         if (!other.longElements_.isEmpty()) {
           if (longElements_.isEmpty()) {
             longElements_ = other.longElements_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            longElements_.makeImmutable();
+            bitField0_ |= 0x00000004;
           } else {
             ensureLongElementsIsMutable();
             longElements_.addAll(other.longElements_);
@@ -1067,7 +1068,7 @@ public final class ReplicatedDataMessages {
         if (!other.actorRefElements_.isEmpty()) {
           if (actorRefElements_.isEmpty()) {
             actorRefElements_ = other.actorRefElements_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            bitField0_ |= 0x00000010;
           } else {
             ensureActorRefElementsIsMutable();
             actorRefElements_.addAll(other.actorRefElements_);
@@ -1179,12 +1180,13 @@ public final class ReplicatedDataMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureStringElementsIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!stringElements_.isModifiable()) {
           stringElements_ = new akka.protobufv3.internal.LazyStringArrayList(stringElements_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string stringElements = 1;</code>
@@ -1192,7 +1194,8 @@ public final class ReplicatedDataMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getStringElementsList() {
-        return stringElements_.getUnmodifiableView();
+        stringElements_.makeImmutable();
+        return stringElements_;
       }
       /**
        * <code>repeated string stringElements = 1;</code>
@@ -1229,6 +1232,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1242,6 +1246,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1255,6 +1260,7 @@ public final class ReplicatedDataMessages {
         ensureStringElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, stringElements_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -1263,8 +1269,9 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder clearStringElements() {
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -1278,16 +1285,17 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
 
       private akka.protobufv3.internal.Internal.IntList intElements_ = emptyIntList();
       private void ensureIntElementsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
-          intElements_ = mutableCopy(intElements_);
-          bitField0_ |= 0x00000002;
+        if (!intElements_.isModifiable()) {
+          intElements_ = makeMutableCopy(intElements_);
         }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated sint32 intElements = 2 [packed = true];</code>
@@ -1295,8 +1303,8 @@ public final class ReplicatedDataMessages {
        */
       public java.util.List<java.lang.Integer>
           getIntElementsList() {
-        return ((bitField0_ & 0x00000002) != 0) ?
-                 java.util.Collections.unmodifiableList(intElements_) : intElements_;
+        intElements_.makeImmutable();
+        return intElements_;
       }
       /**
        * <code>repeated sint32 intElements = 2 [packed = true];</code>
@@ -1321,9 +1329,10 @@ public final class ReplicatedDataMessages {
        */
       public Builder setIntElements(
           int index, int value) {
-        
+
         ensureIntElementsIsMutable();
         intElements_.setInt(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1333,9 +1342,10 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder addIntElements(int value) {
-        
+
         ensureIntElementsIsMutable();
         intElements_.addInt(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1349,6 +1359,7 @@ public final class ReplicatedDataMessages {
         ensureIntElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, intElements_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -1365,10 +1376,10 @@ public final class ReplicatedDataMessages {
 
       private akka.protobufv3.internal.Internal.LongList longElements_ = emptyLongList();
       private void ensureLongElementsIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
-          longElements_ = mutableCopy(longElements_);
-          bitField0_ |= 0x00000004;
+        if (!longElements_.isModifiable()) {
+          longElements_ = makeMutableCopy(longElements_);
         }
+        bitField0_ |= 0x00000004;
       }
       /**
        * <code>repeated sint64 longElements = 3 [packed = true];</code>
@@ -1376,8 +1387,8 @@ public final class ReplicatedDataMessages {
        */
       public java.util.List<java.lang.Long>
           getLongElementsList() {
-        return ((bitField0_ & 0x00000004) != 0) ?
-                 java.util.Collections.unmodifiableList(longElements_) : longElements_;
+        longElements_.makeImmutable();
+        return longElements_;
       }
       /**
        * <code>repeated sint64 longElements = 3 [packed = true];</code>
@@ -1402,9 +1413,10 @@ public final class ReplicatedDataMessages {
        */
       public Builder setLongElements(
           int index, long value) {
-        
+
         ensureLongElementsIsMutable();
         longElements_.setLong(index, value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -1414,9 +1426,10 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder addLongElements(long value) {
-        
+
         ensureLongElementsIsMutable();
         longElements_.addLong(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -1430,6 +1443,7 @@ public final class ReplicatedDataMessages {
         ensureLongElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, longElements_);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -1684,12 +1698,13 @@ public final class ReplicatedDataMessages {
         return otherElementsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureActorRefElementsIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
+        if (!actorRefElements_.isModifiable()) {
           actorRefElements_ = new akka.protobufv3.internal.LazyStringArrayList(actorRefElements_);
-          bitField0_ |= 0x00000010;
-         }
+        }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <pre>
@@ -1701,7 +1716,8 @@ public final class ReplicatedDataMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getActorRefElementsList() {
-        return actorRefElements_.getUnmodifiableView();
+        actorRefElements_.makeImmutable();
+        return actorRefElements_;
       }
       /**
        * <pre>
@@ -1754,6 +1770,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.set(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -1771,6 +1788,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.add(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -1788,6 +1806,7 @@ public final class ReplicatedDataMessages {
         ensureActorRefElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, actorRefElements_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -1800,8 +1819,9 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder clearActorRefElements() {
-        actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000010);
+        actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);;
         onChanged();
         return this;
       }
@@ -1819,6 +1839,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.add(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -2067,11 +2088,13 @@ public final class ReplicatedDataMessages {
     }
     private ORSet() {
       dots_ = java.util.Collections.emptyList();
-      stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       intElements_ = emptyIntList();
       longElements_ = emptyLongList();
       otherElements_ = java.util.Collections.emptyList();
-      actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -2081,11 +2104,6 @@ public final class ReplicatedDataMessages {
       return new ORSet();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSet_descriptor;
@@ -2169,7 +2187,8 @@ public final class ReplicatedDataMessages {
 
     public static final int STRINGELEMENTS_FIELD_NUMBER = 3;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList stringElements_;
+    private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string stringElements = 3;</code>
      * @return A list containing the stringElements.
@@ -2205,7 +2224,8 @@ public final class ReplicatedDataMessages {
 
     public static final int INTELEMENTS_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList intElements_;
+    private akka.protobufv3.internal.Internal.IntList intElements_ =
+        emptyIntList();
     /**
      * <code>repeated sint32 intElements = 4 [packed = true];</code>
      * @return A list containing the intElements.
@@ -2234,7 +2254,8 @@ public final class ReplicatedDataMessages {
 
     public static final int LONGELEMENTS_FIELD_NUMBER = 5;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.LongList longElements_;
+    private akka.protobufv3.internal.Internal.LongList longElements_ =
+        emptyLongList();
     /**
      * <code>repeated sint64 longElements = 5 [packed = true];</code>
      * @return A list containing the longElements.
@@ -2304,7 +2325,8 @@ public final class ReplicatedDataMessages {
 
     public static final int ACTORREFELEMENTS_FIELD_NUMBER = 7;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList actorRefElements_;
+    private akka.protobufv3.internal.LazyStringArrayList actorRefElements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <pre>
      * added in Akka 2.5.14
@@ -2603,11 +2625,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2703,8 +2727,8 @@ public final class ReplicatedDataMessages {
           dotsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
+        stringElements_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         intElements_ = emptyIntList();
         longElements_ = emptyLongList();
         if (otherElementsBuilder_ == null) {
@@ -2714,8 +2738,8 @@ public final class ReplicatedDataMessages {
           otherElementsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000020);
-        actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000040);
+        actorRefElements_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -2758,21 +2782,6 @@ public final class ReplicatedDataMessages {
         } else {
           result.dots_ = dotsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000004) != 0)) {
-          stringElements_ = stringElements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000004);
-        }
-        result.stringElements_ = stringElements_;
-        if (((bitField0_ & 0x00000008) != 0)) {
-          intElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.intElements_ = intElements_;
-        if (((bitField0_ & 0x00000010) != 0)) {
-          longElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.longElements_ = longElements_;
         if (otherElementsBuilder_ == null) {
           if (((bitField0_ & 0x00000020) != 0)) {
             otherElements_ = java.util.Collections.unmodifiableList(otherElements_);
@@ -2782,11 +2791,6 @@ public final class ReplicatedDataMessages {
         } else {
           result.otherElements_ = otherElementsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000040) != 0)) {
-          actorRefElements_ = actorRefElements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000040);
-        }
-        result.actorRefElements_ = actorRefElements_;
       }
 
       private void buildPartial0(akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSet result) {
@@ -2797,6 +2801,22 @@ public final class ReplicatedDataMessages {
               ? vvector_
               : vvectorBuilder_.build();
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          stringElements_.makeImmutable();
+          result.stringElements_ = stringElements_;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          intElements_.makeImmutable();
+          result.intElements_ = intElements_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          longElements_.makeImmutable();
+          result.longElements_ = longElements_;
+        }
+        if (((from_bitField0_ & 0x00000040) != 0)) {
+          actorRefElements_.makeImmutable();
+          result.actorRefElements_ = actorRefElements_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -2877,7 +2897,7 @@ public final class ReplicatedDataMessages {
         if (!other.stringElements_.isEmpty()) {
           if (stringElements_.isEmpty()) {
             stringElements_ = other.stringElements_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            bitField0_ |= 0x00000004;
           } else {
             ensureStringElementsIsMutable();
             stringElements_.addAll(other.stringElements_);
@@ -2887,7 +2907,8 @@ public final class ReplicatedDataMessages {
         if (!other.intElements_.isEmpty()) {
           if (intElements_.isEmpty()) {
             intElements_ = other.intElements_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            intElements_.makeImmutable();
+            bitField0_ |= 0x00000008;
           } else {
             ensureIntElementsIsMutable();
             intElements_.addAll(other.intElements_);
@@ -2897,7 +2918,8 @@ public final class ReplicatedDataMessages {
         if (!other.longElements_.isEmpty()) {
           if (longElements_.isEmpty()) {
             longElements_ = other.longElements_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            longElements_.makeImmutable();
+            bitField0_ |= 0x00000010;
           } else {
             ensureLongElementsIsMutable();
             longElements_.addAll(other.longElements_);
@@ -2933,7 +2955,7 @@ public final class ReplicatedDataMessages {
         if (!other.actorRefElements_.isEmpty()) {
           if (actorRefElements_.isEmpty()) {
             actorRefElements_ = other.actorRefElements_;
-            bitField0_ = (bitField0_ & ~0x00000040);
+            bitField0_ |= 0x00000040;
           } else {
             ensureActorRefElementsIsMutable();
             actorRefElements_.addAll(other.actorRefElements_);
@@ -3142,8 +3164,10 @@ public final class ReplicatedDataMessages {
         } else {
           vvectorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (vvector_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3435,12 +3459,13 @@ public final class ReplicatedDataMessages {
         return dotsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureStringElementsIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
+        if (!stringElements_.isModifiable()) {
           stringElements_ = new akka.protobufv3.internal.LazyStringArrayList(stringElements_);
-          bitField0_ |= 0x00000004;
-         }
+        }
+        bitField0_ |= 0x00000004;
       }
       /**
        * <code>repeated string stringElements = 3;</code>
@@ -3448,7 +3473,8 @@ public final class ReplicatedDataMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getStringElementsList() {
-        return stringElements_.getUnmodifiableView();
+        stringElements_.makeImmutable();
+        return stringElements_;
       }
       /**
        * <code>repeated string stringElements = 3;</code>
@@ -3485,6 +3511,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.set(index, value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -3498,6 +3525,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -3511,6 +3539,7 @@ public final class ReplicatedDataMessages {
         ensureStringElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, stringElements_);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -3519,8 +3548,9 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder clearStringElements() {
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000004);
+        stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000004);;
         onChanged();
         return this;
       }
@@ -3534,16 +3564,17 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
 
       private akka.protobufv3.internal.Internal.IntList intElements_ = emptyIntList();
       private void ensureIntElementsIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
-          intElements_ = mutableCopy(intElements_);
-          bitField0_ |= 0x00000008;
+        if (!intElements_.isModifiable()) {
+          intElements_ = makeMutableCopy(intElements_);
         }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <code>repeated sint32 intElements = 4 [packed = true];</code>
@@ -3551,8 +3582,8 @@ public final class ReplicatedDataMessages {
        */
       public java.util.List<java.lang.Integer>
           getIntElementsList() {
-        return ((bitField0_ & 0x00000008) != 0) ?
-                 java.util.Collections.unmodifiableList(intElements_) : intElements_;
+        intElements_.makeImmutable();
+        return intElements_;
       }
       /**
        * <code>repeated sint32 intElements = 4 [packed = true];</code>
@@ -3577,9 +3608,10 @@ public final class ReplicatedDataMessages {
        */
       public Builder setIntElements(
           int index, int value) {
-        
+
         ensureIntElementsIsMutable();
         intElements_.setInt(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3589,9 +3621,10 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder addIntElements(int value) {
-        
+
         ensureIntElementsIsMutable();
         intElements_.addInt(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3605,6 +3638,7 @@ public final class ReplicatedDataMessages {
         ensureIntElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, intElements_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3621,10 +3655,10 @@ public final class ReplicatedDataMessages {
 
       private akka.protobufv3.internal.Internal.LongList longElements_ = emptyLongList();
       private void ensureLongElementsIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
-          longElements_ = mutableCopy(longElements_);
-          bitField0_ |= 0x00000010;
+        if (!longElements_.isModifiable()) {
+          longElements_ = makeMutableCopy(longElements_);
         }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <code>repeated sint64 longElements = 5 [packed = true];</code>
@@ -3632,8 +3666,8 @@ public final class ReplicatedDataMessages {
        */
       public java.util.List<java.lang.Long>
           getLongElementsList() {
-        return ((bitField0_ & 0x00000010) != 0) ?
-                 java.util.Collections.unmodifiableList(longElements_) : longElements_;
+        longElements_.makeImmutable();
+        return longElements_;
       }
       /**
        * <code>repeated sint64 longElements = 5 [packed = true];</code>
@@ -3658,9 +3692,10 @@ public final class ReplicatedDataMessages {
        */
       public Builder setLongElements(
           int index, long value) {
-        
+
         ensureLongElementsIsMutable();
         longElements_.setLong(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3670,9 +3705,10 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder addLongElements(long value) {
-        
+
         ensureLongElementsIsMutable();
         longElements_.addLong(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3686,6 +3722,7 @@ public final class ReplicatedDataMessages {
         ensureLongElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, longElements_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3940,12 +3977,13 @@ public final class ReplicatedDataMessages {
         return otherElementsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureActorRefElementsIsMutable() {
-        if (!((bitField0_ & 0x00000040) != 0)) {
+        if (!actorRefElements_.isModifiable()) {
           actorRefElements_ = new akka.protobufv3.internal.LazyStringArrayList(actorRefElements_);
-          bitField0_ |= 0x00000040;
-         }
+        }
+        bitField0_ |= 0x00000040;
       }
       /**
        * <pre>
@@ -3957,7 +3995,8 @@ public final class ReplicatedDataMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getActorRefElementsList() {
-        return actorRefElements_.getUnmodifiableView();
+        actorRefElements_.makeImmutable();
+        return actorRefElements_;
       }
       /**
        * <pre>
@@ -4010,6 +4049,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.set(index, value);
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -4027,6 +4067,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.add(value);
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -4044,6 +4085,7 @@ public final class ReplicatedDataMessages {
         ensureActorRefElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, actorRefElements_);
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -4056,8 +4098,9 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder clearActorRefElements() {
-        actorRefElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000040);
+        actorRefElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000040);;
         onChanged();
         return this;
       }
@@ -4075,6 +4118,7 @@ public final class ReplicatedDataMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureActorRefElementsIsMutable();
         actorRefElements_.add(value);
+        bitField0_ |= 0x00000040;
         onChanged();
         return this;
       }
@@ -4193,11 +4237,6 @@ public final class ReplicatedDataMessages {
       return new ORSetDeltaGroup();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_descriptor;
@@ -4264,11 +4303,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORSetDeltaGroup_Entry_descriptor;
@@ -4468,11 +4502,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4836,8 +4872,10 @@ public final class ReplicatedDataMessages {
           } else {
             underlyingBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (underlying_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -5110,11 +5148,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORSetDeltaGroup parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5716,11 +5756,6 @@ public final class ReplicatedDataMessages {
       return new Flag();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_Flag_descriptor;
@@ -5873,11 +5908,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.Flag parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6116,7 +6153,7 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder setEnabled(boolean value) {
-        
+
         enabled_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -6263,11 +6300,6 @@ public final class ReplicatedDataMessages {
       return new LWWRegister();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWRegister_descriptor;
@@ -6520,11 +6552,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWRegister parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6824,7 +6858,7 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -6907,8 +6941,10 @@ public final class ReplicatedDataMessages {
         } else {
           nodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (node_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7026,8 +7062,10 @@ public final class ReplicatedDataMessages {
         } else {
           stateBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (state_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7193,11 +7231,6 @@ public final class ReplicatedDataMessages {
       return new GCounter();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_descriptor;
@@ -7264,11 +7297,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_GCounter_Entry_descriptor;
@@ -7470,11 +7498,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7789,8 +7819,10 @@ public final class ReplicatedDataMessages {
           } else {
             nodeBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000001;
-          onChanged();
+          if (node_ != null) {
+            bitField0_ |= 0x00000001;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -8103,11 +8135,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.GCounter parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8728,11 +8762,6 @@ public final class ReplicatedDataMessages {
       return new PNCounter();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounter_descriptor;
@@ -8945,11 +8974,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounter parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9276,8 +9307,10 @@ public final class ReplicatedDataMessages {
         } else {
           incrementsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (increments_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -9395,8 +9428,10 @@ public final class ReplicatedDataMessages {
         } else {
           decrementsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (decrements_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -9577,11 +9612,6 @@ public final class ReplicatedDataMessages {
       return new ORMap();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_descriptor;
@@ -9691,11 +9721,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMap_Entry_descriptor;
@@ -10041,11 +10066,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10492,8 +10519,10 @@ public final class ReplicatedDataMessages {
           } else {
             valueBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (value_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -10568,7 +10597,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setIntKey(int value) {
-          
+
           intKey_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -10608,7 +10637,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setLongKey(long value) {
-          
+
           longKey_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -10691,8 +10720,10 @@ public final class ReplicatedDataMessages {
           } else {
             otherKeyBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000010;
-          onChanged();
+          if (otherKey_ != null) {
+            bitField0_ |= 0x00000010;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -11016,11 +11047,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMap parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -11384,8 +11417,10 @@ public final class ReplicatedDataMessages {
         } else {
           keysBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (keys_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -11791,11 +11826,6 @@ public final class ReplicatedDataMessages {
       return new ORMapDeltaGroup();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_descriptor;
@@ -11905,11 +11935,6 @@ public final class ReplicatedDataMessages {
         return new MapEntry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_MapEntry_descriptor;
@@ -12253,11 +12278,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.MapEntry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -12703,8 +12730,10 @@ public final class ReplicatedDataMessages {
           } else {
             valueBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (value_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -12779,7 +12808,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setIntKey(int value) {
-          
+
           intKey_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -12819,7 +12848,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setLongKey(long value) {
-          
+
           longKey_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -12902,8 +12931,10 @@ public final class ReplicatedDataMessages {
           } else {
             otherKeyBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000010;
-          onChanged();
+          if (otherKey_ != null) {
+            bitField0_ |= 0x00000010;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -13107,11 +13138,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMapDeltaGroup_Entry_descriptor;
@@ -13410,11 +13436,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13859,8 +13887,10 @@ public final class ReplicatedDataMessages {
           } else {
             underlyingBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (underlying_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -13935,7 +13965,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setZeroTag(int value) {
-          
+
           zeroTag_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -14413,11 +14443,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMapDeltaGroup parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15048,11 +15080,6 @@ public final class ReplicatedDataMessages {
       return new LWWMap();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_descriptor;
@@ -15162,11 +15189,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_LWWMap_Entry_descriptor;
@@ -15512,11 +15534,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15963,8 +15987,10 @@ public final class ReplicatedDataMessages {
           } else {
             valueBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (value_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -16039,7 +16065,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setIntKey(int value) {
-          
+
           intKey_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -16079,7 +16105,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setLongKey(long value) {
-          
+
           longKey_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -16162,8 +16188,10 @@ public final class ReplicatedDataMessages {
           } else {
             otherKeyBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000010;
-          onChanged();
+          if (otherKey_ != null) {
+            bitField0_ |= 0x00000010;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -16487,11 +16515,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.LWWMap parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -16855,8 +16885,10 @@ public final class ReplicatedDataMessages {
         } else {
           keysBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (keys_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -17277,11 +17309,6 @@ public final class ReplicatedDataMessages {
       return new PNCounterMap();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_descriptor;
@@ -17391,11 +17418,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_PNCounterMap_Entry_descriptor;
@@ -17741,11 +17763,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18192,8 +18216,10 @@ public final class ReplicatedDataMessages {
           } else {
             valueBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (value_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -18268,7 +18294,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setIntKey(int value) {
-          
+
           intKey_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -18308,7 +18334,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setLongKey(long value) {
-          
+
           longKey_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -18391,8 +18417,10 @@ public final class ReplicatedDataMessages {
           } else {
             otherKeyBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000010;
-          onChanged();
+          if (otherKey_ != null) {
+            bitField0_ |= 0x00000010;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -18716,11 +18744,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.PNCounterMap parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19084,8 +19114,10 @@ public final class ReplicatedDataMessages {
         } else {
           keysBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (keys_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -19517,11 +19549,6 @@ public final class ReplicatedDataMessages {
       return new ORMultiMap();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_descriptor;
@@ -19631,11 +19658,6 @@ public final class ReplicatedDataMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.internal_static_akka_cluster_ddata_ORMultiMap_Entry_descriptor;
@@ -19981,11 +20003,13 @@ public final class ReplicatedDataMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -20432,8 +20456,10 @@ public final class ReplicatedDataMessages {
           } else {
             valueBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (value_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -20508,7 +20534,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setIntKey(int value) {
-          
+
           intKey_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -20548,7 +20574,7 @@ public final class ReplicatedDataMessages {
          * @return This builder for chaining.
          */
         public Builder setLongKey(long value) {
-          
+
           longKey_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -20631,8 +20657,10 @@ public final class ReplicatedDataMessages {
           } else {
             otherKeyBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000010;
-          onChanged();
+          if (otherKey_ != null) {
+            bitField0_ |= 0x00000010;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -20992,11 +21020,13 @@ public final class ReplicatedDataMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages.ORMultiMap parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -21373,8 +21403,10 @@ public final class ReplicatedDataMessages {
         } else {
           keysBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (keys_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -21689,7 +21721,7 @@ public final class ReplicatedDataMessages {
        * @return This builder for chaining.
        */
       public Builder setWithValueDeltas(boolean value) {
-        
+
         withValueDeltas_ = value;
         bitField0_ |= 0x00000004;
         onChanged();

--- a/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
+++ b/akka-distributed-data/src/main/java/akka/cluster/ddata/protobuf/msg/ReplicatorMessages.java
@@ -118,11 +118,6 @@ public final class ReplicatorMessages {
       return new Get();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Get_descriptor;
@@ -481,11 +476,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Get parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Get parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -869,8 +866,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -945,7 +944,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setConsistency(int value) {
-        
+
         consistency_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -985,7 +984,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setTimeout(int value) {
-        
+
         timeout_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1068,8 +1067,10 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000008;
-        onChanged();
+        if (request_ != null) {
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1144,7 +1145,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setConsistencyMinCap(int value) {
-        
+
         consistencyMinCap_ = value;
         bitField0_ |= 0x00000010;
         onChanged();
@@ -1184,7 +1185,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setConsistencyAdditional(int value) {
-        
+
         consistencyAdditional_ = value;
         bitField0_ |= 0x00000020;
         onChanged();
@@ -1335,11 +1336,6 @@ public final class ReplicatorMessages {
       return new GetSuccess();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetSuccess_descriptor;
@@ -1600,11 +1596,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.GetSuccess parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1958,8 +1956,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2077,8 +2077,10 @@ public final class ReplicatorMessages {
         } else {
           dataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (data_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2196,8 +2198,10 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (request_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2368,11 +2372,6 @@ public final class ReplicatorMessages {
       return new NotFound();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_NotFound_descriptor;
@@ -2583,11 +2582,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.NotFound parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2913,8 +2914,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3032,8 +3035,10 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (request_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3204,11 +3209,6 @@ public final class ReplicatorMessages {
       return new GetFailure();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_GetFailure_descriptor;
@@ -3419,11 +3419,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.GetFailure parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3749,8 +3751,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3868,8 +3872,10 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (request_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4043,11 +4049,6 @@ public final class ReplicatorMessages {
       return new Subscribe();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Subscribe_descriptor;
@@ -4278,11 +4279,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Subscribe parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4599,8 +4602,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4854,11 +4859,6 @@ public final class ReplicatorMessages {
       return new Unsubscribe();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Unsubscribe_descriptor;
@@ -5089,11 +5089,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Unsubscribe parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5410,8 +5412,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5662,11 +5666,6 @@ public final class ReplicatorMessages {
       return new Changed();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Changed_descriptor;
@@ -5879,11 +5878,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Changed parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6210,8 +6211,10 @@ public final class ReplicatorMessages {
         } else {
           keyBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (key_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6329,8 +6332,10 @@ public final class ReplicatorMessages {
         } else {
           dataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (data_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6519,11 +6524,6 @@ public final class ReplicatorMessages {
       return new Write();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Write_descriptor;
@@ -6802,11 +6802,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Write parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Write parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7230,8 +7232,10 @@ public final class ReplicatorMessages {
         } else {
           envelopeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (envelope_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7349,8 +7353,10 @@ public final class ReplicatorMessages {
         } else {
           fromNodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (fromNode_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7491,11 +7497,6 @@ public final class ReplicatorMessages {
       return new Empty();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Empty_descriptor;
@@ -7607,11 +7608,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Empty parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7924,11 +7927,6 @@ public final class ReplicatorMessages {
       return new Read();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Read_descriptor;
@@ -8157,11 +8155,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Read parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Read parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8557,8 +8557,10 @@ public final class ReplicatorMessages {
         } else {
           fromNodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (fromNode_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -8714,11 +8716,6 @@ public final class ReplicatorMessages {
       return new ReadResult();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_ReadResult_descriptor;
@@ -8879,11 +8876,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.ReadResult parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9181,8 +9180,10 @@ public final class ReplicatorMessages {
         } else {
           envelopeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (envelope_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -9378,11 +9379,6 @@ public final class ReplicatorMessages {
       return new DataEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_descriptor;
@@ -9499,11 +9495,6 @@ public final class ReplicatorMessages {
         return new PruningEntry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DataEnvelope_PruningEntry_descriptor;
@@ -9852,11 +9843,13 @@ public final class ReplicatorMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope.PruningEntry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10277,8 +10270,10 @@ public final class ReplicatorMessages {
           } else {
             removedAddressBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000001;
-          onChanged();
+          if (removedAddress_ != null) {
+            bitField0_ |= 0x00000001;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -10396,8 +10391,10 @@ public final class ReplicatorMessages {
           } else {
             ownerAddressBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (ownerAddress_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -10472,7 +10469,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setPerformed(boolean value) {
-          
+
           performed_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -10752,7 +10749,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setObsoleteTime(long value) {
-          
+
           obsoleteTime_ = value;
           bitField0_ |= 0x00000010;
           onChanged();
@@ -11089,11 +11086,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DataEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -11484,8 +11483,10 @@ public final class ReplicatorMessages {
         } else {
           dataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (data_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -11843,8 +11844,10 @@ public final class ReplicatorMessages {
         } else {
           deltaVersionsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (deltaVersions_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -12054,11 +12057,6 @@ public final class ReplicatorMessages {
       return new Status();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_descriptor;
@@ -12139,11 +12137,6 @@ public final class ReplicatorMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Status_Entry_descriptor;
@@ -12399,11 +12392,13 @@ public final class ReplicatorMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Status.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -12793,7 +12788,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setUsedTimestamp(long value) {
-          
+
           usedTimestamp_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -13182,11 +13177,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Status parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Status parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13531,7 +13528,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setChunk(int value) {
-        
+
         chunk_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -13571,7 +13568,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setTotChunks(int value) {
-        
+
         totChunks_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -13851,7 +13848,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setToSystemUid(long value) {
-        
+
         toSystemUid_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -13891,7 +13888,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setFromSystemUid(long value) {
-        
+
         fromSystemUid_ = value;
         bitField0_ |= 0x00000010;
         onChanged();
@@ -14055,11 +14052,6 @@ public final class ReplicatorMessages {
       return new Gossip();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_descriptor;
@@ -14143,11 +14135,6 @@ public final class ReplicatorMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Gossip_Entry_descriptor;
@@ -14414,11 +14401,13 @@ public final class ReplicatorMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -14828,8 +14817,10 @@ public final class ReplicatorMessages {
           } else {
             envelopeBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (envelope_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -14904,7 +14895,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setUsedTimestamp(long value) {
-          
+
           usedTimestamp_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -15255,11 +15246,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Gossip parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15588,7 +15581,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setSendBack(boolean value) {
-        
+
         sendBack_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -15868,7 +15861,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setToSystemUid(long value) {
-        
+
         toSystemUid_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -15908,7 +15901,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setFromSystemUid(long value) {
-        
+
         fromSystemUid_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -16073,11 +16066,6 @@ public final class ReplicatorMessages {
       return new DeltaPropagation();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_descriptor;
@@ -16180,11 +16168,6 @@ public final class ReplicatorMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DeltaPropagation_Entry_descriptor;
@@ -16499,11 +16482,13 @@ public final class ReplicatorMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -16929,8 +16914,10 @@ public final class ReplicatorMessages {
           } else {
             envelopeBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (envelope_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -17005,7 +16992,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setFromSeqNr(long value) {
-          
+
           fromSeqNr_ = value;
           bitField0_ |= 0x00000004;
           onChanged();
@@ -17057,7 +17044,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setToSeqNr(long value) {
-          
+
           toSeqNr_ = value;
           bitField0_ |= 0x00000008;
           onChanged();
@@ -17394,11 +17381,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DeltaPropagation parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -17775,8 +17764,10 @@ public final class ReplicatorMessages {
         } else {
           fromNodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (fromNode_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -18103,7 +18094,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setReply(boolean value) {
-        
+
         reply_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -18258,11 +18249,6 @@ public final class ReplicatorMessages {
       return new UniqueAddress();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_UniqueAddress_descriptor;
@@ -18507,11 +18493,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.UniqueAddress parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18839,8 +18827,10 @@ public final class ReplicatorMessages {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -18915,7 +18905,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setUid(int value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -18967,7 +18957,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setUid2(int value) {
-        
+
         uid2_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -19106,11 +19096,6 @@ public final class ReplicatorMessages {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_Address_descriptor;
@@ -19330,11 +19315,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19671,7 +19658,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -19802,11 +19789,6 @@ public final class ReplicatorMessages {
       return new VersionVector();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_descriptor;
@@ -19872,11 +19854,6 @@ public final class ReplicatorMessages {
         return new Entry();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_VersionVector_Entry_descriptor;
@@ -20079,11 +20056,13 @@ public final class ReplicatorMessages {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector.Entry parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -20398,8 +20377,10 @@ public final class ReplicatorMessages {
           } else {
             nodeBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000001;
-          onChanged();
+          if (node_ != null) {
+            bitField0_ |= 0x00000001;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -20474,7 +20455,7 @@ public final class ReplicatorMessages {
          * @return This builder for chaining.
          */
         public Builder setVersion(long value) {
-          
+
           version_ = value;
           bitField0_ |= 0x00000002;
           onChanged();
@@ -20712,11 +20693,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.VersionVector parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -21342,11 +21325,6 @@ public final class ReplicatorMessages {
       return new OtherMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_OtherMessage_descriptor;
@@ -21572,11 +21550,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.OtherMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -21884,7 +21864,7 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -22046,7 +22026,8 @@ public final class ReplicatorMessages {
       super(builder);
     }
     private StringGSet() {
-      elements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      elements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -22056,11 +22037,6 @@ public final class ReplicatorMessages {
       return new StringGSet();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_StringGSet_descriptor;
@@ -22076,7 +22052,8 @@ public final class ReplicatorMessages {
 
     public static final int ELEMENTS_FIELD_NUMBER = 1;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList elements_;
+    private akka.protobufv3.internal.LazyStringArrayList elements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string elements = 1;</code>
      * @return A list containing the elements.
@@ -22225,11 +22202,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -22305,8 +22284,8 @@ public final class ReplicatorMessages {
       public Builder clear() {
         super.clear();
         bitField0_ = 0;
-        elements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        elements_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -22333,22 +22312,17 @@ public final class ReplicatorMessages {
       @java.lang.Override
       public akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet buildPartial() {
         akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet result = new akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
       }
 
-      private void buildPartialRepeatedFields(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet result) {
-        if (((bitField0_ & 0x00000001) != 0)) {
-          elements_ = elements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        }
-        result.elements_ = elements_;
-      }
-
       private void buildPartial0(akka.cluster.ddata.protobuf.msg.ReplicatorMessages.StringGSet result) {
         int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          elements_.makeImmutable();
+          result.elements_ = elements_;
+        }
       }
 
       @java.lang.Override
@@ -22398,7 +22372,7 @@ public final class ReplicatorMessages {
         if (!other.elements_.isEmpty()) {
           if (elements_.isEmpty()) {
             elements_ = other.elements_;
-            bitField0_ = (bitField0_ & ~0x00000001);
+            bitField0_ |= 0x00000001;
           } else {
             ensureElementsIsMutable();
             elements_.addAll(other.elements_);
@@ -22454,12 +22428,13 @@ public final class ReplicatorMessages {
       }
       private int bitField0_;
 
-      private akka.protobufv3.internal.LazyStringList elements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList elements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureElementsIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
+        if (!elements_.isModifiable()) {
           elements_ = new akka.protobufv3.internal.LazyStringArrayList(elements_);
-          bitField0_ |= 0x00000001;
-         }
+        }
+        bitField0_ |= 0x00000001;
       }
       /**
        * <code>repeated string elements = 1;</code>
@@ -22467,7 +22442,8 @@ public final class ReplicatorMessages {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getElementsList() {
-        return elements_.getUnmodifiableView();
+        elements_.makeImmutable();
+        return elements_;
       }
       /**
        * <code>repeated string elements = 1;</code>
@@ -22504,6 +22480,7 @@ public final class ReplicatorMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureElementsIsMutable();
         elements_.set(index, value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -22517,6 +22494,7 @@ public final class ReplicatorMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureElementsIsMutable();
         elements_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -22530,6 +22508,7 @@ public final class ReplicatorMessages {
         ensureElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, elements_);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -22538,8 +22517,9 @@ public final class ReplicatorMessages {
        * @return This builder for chaining.
        */
       public Builder clearElements() {
-        elements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000001);
+        elements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);;
         onChanged();
         return this;
       }
@@ -22553,6 +22533,7 @@ public final class ReplicatorMessages {
         if (value == null) { throw new NullPointerException(); }
         ensureElementsIsMutable();
         elements_.add(value);
+        bitField0_ |= 0x00000001;
         onChanged();
         return this;
       }
@@ -22686,11 +22667,6 @@ public final class ReplicatorMessages {
       return new DurableDataEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.cluster.ddata.protobuf.msg.ReplicatorMessages.internal_static_akka_cluster_ddata_DurableDataEnvelope_descriptor;
@@ -22913,11 +22889,13 @@ public final class ReplicatorMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.cluster.ddata.protobuf.msg.ReplicatorMessages.DurableDataEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -23281,8 +23259,10 @@ public final class ReplicatorMessages {
         } else {
           dataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (data_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**

--- a/akka-multi-node-testkit/src/main/java/akka/remote/testconductor/TestConductorProtocol.java
+++ b/akka-multi-node-testkit/src/main/java/akka/remote/testconductor/TestConductorProtocol.java
@@ -473,11 +473,6 @@ public final class TestConductorProtocol {
       return new Wrapper();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_Wrapper_descriptor;
@@ -846,11 +841,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Wrapper parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Wrapper parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1244,8 +1241,10 @@ public final class TestConductorProtocol {
         } else {
           helloBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (hello_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1363,8 +1362,10 @@ public final class TestConductorProtocol {
         } else {
           barrierBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (barrier_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1482,8 +1483,10 @@ public final class TestConductorProtocol {
         } else {
           failureBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (failure_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1681,8 +1684,10 @@ public final class TestConductorProtocol {
         } else {
           addrBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (addr_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1856,11 +1861,6 @@ public final class TestConductorProtocol {
       return new Hello();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_Hello_descriptor;
@@ -2091,11 +2091,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Hello parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Hello parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2492,8 +2494,10 @@ public final class TestConductorProtocol {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2675,11 +2679,6 @@ public final class TestConductorProtocol {
       return new EnterBarrier();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_EnterBarrier_descriptor;
@@ -2933,11 +2932,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.EnterBarrier parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.EnterBarrier parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3336,7 +3337,7 @@ public final class TestConductorProtocol {
        * @return This builder for chaining.
        */
       public Builder setTimeout(long value) {
-        
+
         timeout_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -3475,11 +3476,6 @@ public final class TestConductorProtocol {
       return new AddressRequest();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_AddressRequest_descriptor;
@@ -3708,11 +3704,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.AddressRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.AddressRequest parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4108,8 +4106,10 @@ public final class TestConductorProtocol {
         } else {
           addrBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (addr_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4315,11 +4315,6 @@ public final class TestConductorProtocol {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_Address_descriptor;
@@ -4675,11 +4670,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5212,7 +5209,7 @@ public final class TestConductorProtocol {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -5379,11 +5376,6 @@ public final class TestConductorProtocol {
       return new InjectFailure();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.testconductor.TestConductorProtocol.internal_static_InjectFailure_descriptor;
@@ -5686,11 +5678,13 @@ public final class TestConductorProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.InjectFailure parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.testconductor.TestConductorProtocol.InjectFailure parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6141,8 +6135,10 @@ public final class TestConductorProtocol {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6217,7 +6213,7 @@ public final class TestConductorProtocol {
        * @return This builder for chaining.
        */
       public Builder setRateMBit(float value) {
-        
+
         rateMBit_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -6257,7 +6253,7 @@ public final class TestConductorProtocol {
        * @return This builder for chaining.
        */
       public Builder setExitValue(int value) {
-        
+
         exitValue_ = value;
         bitField0_ |= 0x00000010;
         onChanged();

--- a/akka-persistence-query/src/main/java/akka/persistence/query/internal/protobuf/QueryMessages.java
+++ b/akka-persistence-query/src/main/java/akka/persistence/query/internal/protobuf/QueryMessages.java
@@ -251,7 +251,7 @@ public final class QueryMessages {
       offset_ = "";
       offsetManifest_ = "";
       source_ = "";
-      tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      tags_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -259,11 +259,6 @@ public final class QueryMessages {
     protected java.lang.Object newInstance(
         akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
       return new EventEnvelope();
-    }
-
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
     }
 
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -675,7 +670,8 @@ public final class QueryMessages {
     public static final int TAGS_FIELD_NUMBER = 12;
 
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList tags_;
+    private akka.protobufv3.internal.LazyStringArrayList tags_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string tags = 12;</code>
      *
@@ -1147,8 +1143,7 @@ public final class QueryMessages {
         }
         filtered_ = false;
         source_ = "";
-        tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000800);
+        tags_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -1179,21 +1174,11 @@ public final class QueryMessages {
       public akka.persistence.query.internal.protobuf.QueryMessages.EventEnvelope buildPartial() {
         akka.persistence.query.internal.protobuf.QueryMessages.EventEnvelope result =
             new akka.persistence.query.internal.protobuf.QueryMessages.EventEnvelope(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) {
           buildPartial0(result);
         }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(
-          akka.persistence.query.internal.protobuf.QueryMessages.EventEnvelope result) {
-        if (((bitField0_ & 0x00000800) != 0)) {
-          tags_ = tags_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000800);
-        }
-        result.tags_ = tags_;
       }
 
       private void buildPartial0(
@@ -1243,6 +1228,10 @@ public final class QueryMessages {
         if (((from_bitField0_ & 0x00000400) != 0)) {
           result.source_ = source_;
           to_bitField0_ |= 0x00000400;
+        }
+        if (((from_bitField0_ & 0x00000800) != 0)) {
+          tags_.makeImmutable();
+          result.tags_ = tags_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -1344,7 +1333,7 @@ public final class QueryMessages {
         if (!other.tags_.isEmpty()) {
           if (tags_.isEmpty()) {
             tags_ = other.tags_;
-            bitField0_ = (bitField0_ & ~0x00000800);
+            bitField0_ |= 0x00000800;
           } else {
             ensureTagsIsMutable();
             tags_.addAll(other.tags_);
@@ -2038,8 +2027,10 @@ public final class QueryMessages {
         } else {
           eventBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000080;
-        onChanged();
+        if (event_ != null) {
+          bitField0_ |= 0x00000080;
+          onChanged();
+        }
         return this;
       }
       /** <code>optional .Payload event = 8;</code> */
@@ -2153,8 +2144,10 @@ public final class QueryMessages {
         } else {
           metadataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000100;
-        onChanged();
+        if (metadata_ != null) {
+          bitField0_ |= 0x00000100;
+          onChanged();
+        }
         return this;
       }
       /** <code>optional .Payload metadata = 9;</code> */
@@ -2331,14 +2324,14 @@ public final class QueryMessages {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList tags_ =
-          akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList tags_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
 
       private void ensureTagsIsMutable() {
-        if (!((bitField0_ & 0x00000800) != 0)) {
+        if (!tags_.isModifiable()) {
           tags_ = new akka.protobufv3.internal.LazyStringArrayList(tags_);
-          bitField0_ |= 0x00000800;
         }
+        bitField0_ |= 0x00000800;
       }
       /**
        * <code>repeated string tags = 12;</code>
@@ -2346,7 +2339,8 @@ public final class QueryMessages {
        * @return A list containing the tags.
        */
       public akka.protobufv3.internal.ProtocolStringList getTagsList() {
-        return tags_.getUnmodifiableView();
+        tags_.makeImmutable();
+        return tags_;
       }
       /**
        * <code>repeated string tags = 12;</code>
@@ -2387,6 +2381,7 @@ public final class QueryMessages {
         }
         ensureTagsIsMutable();
         tags_.set(index, value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -2402,6 +2397,7 @@ public final class QueryMessages {
         }
         ensureTagsIsMutable();
         tags_.add(value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -2414,6 +2410,7 @@ public final class QueryMessages {
       public Builder addAllTags(java.lang.Iterable<java.lang.String> values) {
         ensureTagsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, tags_);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -2423,8 +2420,9 @@ public final class QueryMessages {
        * @return This builder for chaining.
        */
       public Builder clearTags() {
-        tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+        tags_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
         bitField0_ = (bitField0_ & ~0x00000800);
+        ;
         onChanged();
         return this;
       }
@@ -2440,6 +2438,7 @@ public final class QueryMessages {
         }
         ensureTagsIsMutable();
         tags_.add(value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }

--- a/akka-persistence-typed/src/main/java/akka/persistence/typed/serialization/ReplicatedEventSourcing.java
+++ b/akka-persistence-typed/src/main/java/akka/persistence/typed/serialization/ReplicatedEventSourcing.java
@@ -150,11 +150,6 @@ public final class ReplicatedEventSourcing {
       return new Counter();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.persistence.typed.serialization.ReplicatedEventSourcing
           .internal_static_Counter_descriptor;
@@ -709,11 +704,6 @@ public final class ReplicatedEventSourcing {
     protected java.lang.Object newInstance(
         akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
       return new CounterUpdate();
-    }
-
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
     }
 
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -1394,7 +1384,7 @@ public final class ReplicatedEventSourcing {
     private ORSet() {
       originDc_ = "";
       dots_ = java.util.Collections.emptyList();
-      stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      stringElements_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
       intElements_ = emptyIntList();
       longElements_ = emptyLongList();
       otherElements_ = java.util.Collections.emptyList();
@@ -1405,11 +1395,6 @@ public final class ReplicatedEventSourcing {
     protected java.lang.Object newInstance(
         akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
       return new ORSet();
-    }
-
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
     }
 
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -1553,7 +1538,8 @@ public final class ReplicatedEventSourcing {
     public static final int STRINGELEMENTS_FIELD_NUMBER = 4;
 
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList stringElements_;
+    private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string stringElements = 4;</code>
      *
@@ -1592,7 +1578,7 @@ public final class ReplicatedEventSourcing {
     public static final int INTELEMENTS_FIELD_NUMBER = 5;
 
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList intElements_;
+    private akka.protobufv3.internal.Internal.IntList intElements_ = emptyIntList();
     /**
      * <code>repeated sint32 intElements = 5 [packed = true];</code>
      *
@@ -1625,7 +1611,7 @@ public final class ReplicatedEventSourcing {
     public static final int LONGELEMENTS_FIELD_NUMBER = 6;
 
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.LongList longElements_;
+    private akka.protobufv3.internal.Internal.LongList longElements_ = emptyLongList();
     /**
      * <code>repeated sint64 longElements = 6 [packed = true];</code>
      *
@@ -2044,8 +2030,7 @@ public final class ReplicatedEventSourcing {
           dotsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000004);
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
         intElements_ = emptyIntList();
         longElements_ = emptyLongList();
         if (otherElementsBuilder_ == null) {
@@ -2103,21 +2088,6 @@ public final class ReplicatedEventSourcing {
         } else {
           result.dots_ = dotsBuilder_.build();
         }
-        if (((bitField0_ & 0x00000008) != 0)) {
-          stringElements_ = stringElements_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.stringElements_ = stringElements_;
-        if (((bitField0_ & 0x00000010) != 0)) {
-          intElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.intElements_ = intElements_;
-        if (((bitField0_ & 0x00000020) != 0)) {
-          longElements_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000020);
-        }
-        result.longElements_ = longElements_;
         if (otherElementsBuilder_ == null) {
           if (((bitField0_ & 0x00000040) != 0)) {
             otherElements_ = java.util.Collections.unmodifiableList(otherElements_);
@@ -2140,6 +2110,18 @@ public final class ReplicatedEventSourcing {
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.vvector_ = vvectorBuilder_ == null ? vvector_ : vvectorBuilder_.build();
           to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          stringElements_.makeImmutable();
+          result.stringElements_ = stringElements_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          intElements_.makeImmutable();
+          result.intElements_ = intElements_;
+        }
+        if (((from_bitField0_ & 0x00000020) != 0)) {
+          longElements_.makeImmutable();
+          result.longElements_ = longElements_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -2233,7 +2215,7 @@ public final class ReplicatedEventSourcing {
         if (!other.stringElements_.isEmpty()) {
           if (stringElements_.isEmpty()) {
             stringElements_ = other.stringElements_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ |= 0x00000008;
           } else {
             ensureStringElementsIsMutable();
             stringElements_.addAll(other.stringElements_);
@@ -2243,7 +2225,8 @@ public final class ReplicatedEventSourcing {
         if (!other.intElements_.isEmpty()) {
           if (intElements_.isEmpty()) {
             intElements_ = other.intElements_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            intElements_.makeImmutable();
+            bitField0_ |= 0x00000010;
           } else {
             ensureIntElementsIsMutable();
             intElements_.addAll(other.intElements_);
@@ -2253,7 +2236,8 @@ public final class ReplicatedEventSourcing {
         if (!other.longElements_.isEmpty()) {
           if (longElements_.isEmpty()) {
             longElements_ = other.longElements_;
-            bitField0_ = (bitField0_ & ~0x00000020);
+            longElements_.makeImmutable();
+            bitField0_ |= 0x00000020;
           } else {
             ensureLongElementsIsMutable();
             longElements_.addAll(other.longElements_);
@@ -2593,8 +2577,10 @@ public final class ReplicatedEventSourcing {
         } else {
           vvectorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (vvector_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /** <code>required .VersionVector vvector = 2;</code> */
@@ -2887,14 +2873,14 @@ public final class ReplicatedEventSourcing {
         return dotsBuilder_;
       }
 
-      private akka.protobufv3.internal.LazyStringList stringElements_ =
-          akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList stringElements_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
 
       private void ensureStringElementsIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
+        if (!stringElements_.isModifiable()) {
           stringElements_ = new akka.protobufv3.internal.LazyStringArrayList(stringElements_);
-          bitField0_ |= 0x00000008;
         }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <code>repeated string stringElements = 4;</code>
@@ -2902,7 +2888,8 @@ public final class ReplicatedEventSourcing {
        * @return A list containing the stringElements.
        */
       public akka.protobufv3.internal.ProtocolStringList getStringElementsList() {
-        return stringElements_.getUnmodifiableView();
+        stringElements_.makeImmutable();
+        return stringElements_;
       }
       /**
        * <code>repeated string stringElements = 4;</code>
@@ -2943,6 +2930,7 @@ public final class ReplicatedEventSourcing {
         }
         ensureStringElementsIsMutable();
         stringElements_.set(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2958,6 +2946,7 @@ public final class ReplicatedEventSourcing {
         }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2970,6 +2959,7 @@ public final class ReplicatedEventSourcing {
       public Builder addAllStringElements(java.lang.Iterable<java.lang.String> values) {
         ensureStringElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, stringElements_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -2979,8 +2969,9 @@ public final class ReplicatedEventSourcing {
        * @return This builder for chaining.
        */
       public Builder clearStringElements() {
-        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+        stringElements_ = akka.protobufv3.internal.LazyStringArrayList.emptyList();
         bitField0_ = (bitField0_ & ~0x00000008);
+        ;
         onChanged();
         return this;
       }
@@ -2996,6 +2987,7 @@ public final class ReplicatedEventSourcing {
         }
         ensureStringElementsIsMutable();
         stringElements_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3003,10 +2995,10 @@ public final class ReplicatedEventSourcing {
       private akka.protobufv3.internal.Internal.IntList intElements_ = emptyIntList();
 
       private void ensureIntElementsIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
-          intElements_ = mutableCopy(intElements_);
-          bitField0_ |= 0x00000010;
+        if (!intElements_.isModifiable()) {
+          intElements_ = makeMutableCopy(intElements_);
         }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <code>repeated sint32 intElements = 5 [packed = true];</code>
@@ -3014,9 +3006,8 @@ public final class ReplicatedEventSourcing {
        * @return A list containing the intElements.
        */
       public java.util.List<java.lang.Integer> getIntElementsList() {
-        return ((bitField0_ & 0x00000010) != 0)
-            ? java.util.Collections.unmodifiableList(intElements_)
-            : intElements_;
+        intElements_.makeImmutable();
+        return intElements_;
       }
       /**
        * <code>repeated sint32 intElements = 5 [packed = true];</code>
@@ -3046,6 +3037,7 @@ public final class ReplicatedEventSourcing {
 
         ensureIntElementsIsMutable();
         intElements_.setInt(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3059,6 +3051,7 @@ public final class ReplicatedEventSourcing {
 
         ensureIntElementsIsMutable();
         intElements_.addInt(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3071,6 +3064,7 @@ public final class ReplicatedEventSourcing {
       public Builder addAllIntElements(java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureIntElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, intElements_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3089,10 +3083,10 @@ public final class ReplicatedEventSourcing {
       private akka.protobufv3.internal.Internal.LongList longElements_ = emptyLongList();
 
       private void ensureLongElementsIsMutable() {
-        if (!((bitField0_ & 0x00000020) != 0)) {
-          longElements_ = mutableCopy(longElements_);
-          bitField0_ |= 0x00000020;
+        if (!longElements_.isModifiable()) {
+          longElements_ = makeMutableCopy(longElements_);
         }
+        bitField0_ |= 0x00000020;
       }
       /**
        * <code>repeated sint64 longElements = 6 [packed = true];</code>
@@ -3100,9 +3094,8 @@ public final class ReplicatedEventSourcing {
        * @return A list containing the longElements.
        */
       public java.util.List<java.lang.Long> getLongElementsList() {
-        return ((bitField0_ & 0x00000020) != 0)
-            ? java.util.Collections.unmodifiableList(longElements_)
-            : longElements_;
+        longElements_.makeImmutable();
+        return longElements_;
       }
       /**
        * <code>repeated sint64 longElements = 6 [packed = true];</code>
@@ -3132,6 +3125,7 @@ public final class ReplicatedEventSourcing {
 
         ensureLongElementsIsMutable();
         longElements_.setLong(index, value);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -3145,6 +3139,7 @@ public final class ReplicatedEventSourcing {
 
         ensureLongElementsIsMutable();
         longElements_.addLong(value);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -3157,6 +3152,7 @@ public final class ReplicatedEventSourcing {
       public Builder addAllLongElements(java.lang.Iterable<? extends java.lang.Long> values) {
         ensureLongElementsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, longElements_);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -3496,11 +3492,6 @@ public final class ReplicatedEventSourcing {
       return new ORSetDeltaGroup();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.persistence.typed.serialization.ReplicatedEventSourcing
           .internal_static_ORSetDeltaGroup_descriptor;
@@ -3571,11 +3562,6 @@ public final class ReplicatedEventSourcing {
       protected java.lang.Object newInstance(
           akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
         return new Entry();
-      }
-
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-        return this.unknownFields;
       }
 
       public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -4246,8 +4232,10 @@ public final class ReplicatedEventSourcing {
           } else {
             underlyingBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000002;
-          onChanged();
+          if (underlying_ != null) {
+            bitField0_ |= 0x00000002;
+            onChanged();
+          }
           return this;
         }
         /** <code>required .ORSet underlying = 2;</code> */
@@ -5207,11 +5195,6 @@ public final class ReplicatedEventSourcing {
       return new VersionVector();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.persistence.typed.serialization.ReplicatedEventSourcing
           .internal_static_VersionVector_descriptor;
@@ -5285,11 +5268,6 @@ public final class ReplicatedEventSourcing {
       protected java.lang.Object newInstance(
           akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
         return new Entry();
-      }
-
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-        return this.unknownFields;
       }
 
       public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -6876,11 +6854,6 @@ public final class ReplicatedEventSourcing {
       return new ReplicatedEventMetadata();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.persistence.typed.serialization.ReplicatedEventSourcing
           .internal_static_ReplicatedEventMetadata_descriptor;
@@ -7758,8 +7731,10 @@ public final class ReplicatedEventSourcing {
         } else {
           versionVectorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (versionVector_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /** <code>required .VersionVector versionVector = 3;</code> */
@@ -7994,11 +7969,6 @@ public final class ReplicatedEventSourcing {
       return new ReplicatedSnapshotMetadata();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.persistence.typed.serialization.ReplicatedEventSourcing
           .internal_static_ReplicatedSnapshotMetadata_descriptor;
@@ -8073,11 +8043,6 @@ public final class ReplicatedEventSourcing {
       protected java.lang.Object newInstance(
           akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
         return new Seen();
-      }
-
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-        return this.unknownFields;
       }
 
       public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -9487,8 +9452,10 @@ public final class ReplicatedEventSourcing {
         } else {
           versionBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (version_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /** <code>required .VersionVector version = 1;</code> */
@@ -9943,11 +9910,6 @@ public final class ReplicatedEventSourcing {
     protected java.lang.Object newInstance(
         akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
       return new ReplicatedPublishedEventMetaData();
-    }
-
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
     }
 
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -10674,8 +10636,10 @@ public final class ReplicatedEventSourcing {
         } else {
           versionVectorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (versionVector_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /** <code>optional .VersionVector versionVector = 2;</code> */
@@ -10924,11 +10888,6 @@ public final class ReplicatedEventSourcing {
     protected java.lang.Object newInstance(
         akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
       return new PublishedEvent();
-    }
-
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
     }
 
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
@@ -11906,8 +11865,10 @@ public final class ReplicatedEventSourcing {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /** <code>optional .Payload payload = 3;</code> */
@@ -12084,8 +12045,10 @@ public final class ReplicatedEventSourcing {
         } else {
           metadataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (metadata_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /** <code>optional .ReplicatedPublishedEventMetaData metadata = 5;</code> */

--- a/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
+++ b/akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java
@@ -211,11 +211,6 @@ public final class MessageFormats {
       return new PersistentMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_PersistentMessage_descriptor;
@@ -820,11 +815,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1248,8 +1245,10 @@ public final class MessageFormats {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1324,7 +1323,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setSequenceNr(long value) {
-        
+
         sequenceNr_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -1456,7 +1455,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setDeleted(boolean value) {
-        
+
         deleted_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -1788,7 +1787,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setTimestamp(long value) {
-        
+
         timestamp_ = value;
         bitField0_ |= 0x00000080;
         onChanged();
@@ -1871,8 +1870,10 @@ public final class MessageFormats {
         } else {
           metadataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000100;
-        onChanged();
+        if (metadata_ != null) {
+          bitField0_ |= 0x00000100;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2048,11 +2049,6 @@ public final class MessageFormats {
       return new PersistentPayload();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_PersistentPayload_descriptor;
@@ -2278,11 +2274,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentPayload parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentPayload parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2550,7 +2548,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -2761,11 +2759,6 @@ public final class MessageFormats {
       return new AtomicWrite();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_AtomicWrite_descriptor;
@@ -2937,11 +2930,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.AtomicWrite parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.AtomicWrite parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3568,11 +3563,6 @@ public final class MessageFormats {
       return new AtLeastOnceDeliverySnapshot();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_descriptor;
@@ -3656,11 +3646,6 @@ public final class MessageFormats {
         return new UnconfirmedDelivery();
       }
 
-      @java.lang.Override
-      public final akka.protobufv3.internal.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
       public static final akka.protobufv3.internal.Descriptors.Descriptor
           getDescriptor() {
         return akka.persistence.serialization.MessageFormats.internal_static_AtLeastOnceDeliverySnapshot_UnconfirmedDelivery_descriptor;
@@ -3931,11 +3916,13 @@ public final class MessageFormats {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
+
       public static akka.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return akka.protobufv3.internal.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
+
       public static akka.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot.UnconfirmedDelivery parseDelimitedFrom(
           java.io.InputStream input,
           akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4225,7 +4212,7 @@ public final class MessageFormats {
          * @return This builder for chaining.
          */
         public Builder setDeliveryId(long value) {
-          
+
           deliveryId_ = value;
           bitField0_ |= 0x00000001;
           onChanged();
@@ -4388,8 +4375,10 @@ public final class MessageFormats {
           } else {
             payloadBuilder_.mergeFrom(value);
           }
-          bitField0_ |= 0x00000004;
-          onChanged();
+          if (payload_ != null) {
+            bitField0_ |= 0x00000004;
+            onChanged();
+          }
           return this;
         }
         /**
@@ -4703,11 +4692,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.AtLeastOnceDeliverySnapshot parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5010,7 +5001,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setCurrentDeliveryId(long value) {
-        
+
         currentDeliveryId_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -5419,11 +5410,6 @@ public final class MessageFormats {
       return new PersistentStateChangeEvent();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_PersistentStateChangeEvent_descriptor;
@@ -5716,11 +5702,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentStateChangeEvent parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6177,7 +6165,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setTimeoutNanos(long value) {
-        
+
         timeoutNanos_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -6327,11 +6315,6 @@ public final class MessageFormats {
       return new PersistentFSMSnapshot();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.persistence.serialization.MessageFormats.internal_static_PersistentFSMSnapshot_descriptor;
@@ -6598,11 +6581,13 @@ public final class MessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.persistence.serialization.MessageFormats.PersistentFSMSnapshot parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7012,8 +6997,10 @@ public final class MessageFormats {
         } else {
           dataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (data_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7088,7 +7075,7 @@ public final class MessageFormats {
        * @return This builder for chaining.
        */
       public Builder setTimeoutNanos(long value) {
-        
+
         timeoutNanos_ = value;
         bitField0_ |= 0x00000004;
         onChanged();

--- a/akka-remote-tests/src/test/java/akka/remote/artery/protobuf/TestMessages.java
+++ b/akka-remote-tests/src/test/java/akka/remote/artery/protobuf/TestMessages.java
@@ -139,11 +139,6 @@ public final class TestMessages {
       return new TestMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.artery.protobuf.TestMessages.internal_static_TestMessage_descriptor;
@@ -563,11 +558,13 @@ public final class TestMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.artery.protobuf.TestMessages.TestMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.artery.protobuf.TestMessages.TestMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -932,7 +929,7 @@ public final class TestMessages {
        * @return This builder for chaining.
        */
       public Builder setId(long value) {
-        
+
         id_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -1052,7 +1049,7 @@ public final class TestMessages {
        * @return This builder for chaining.
        */
       public Builder setStatus(boolean value) {
-        
+
         status_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -1547,11 +1544,6 @@ public final class TestMessages {
       return new Item();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.artery.protobuf.TestMessages.internal_static_Item_descriptor;
@@ -1772,11 +1764,13 @@ public final class TestMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.artery.protobuf.TestMessages.Item parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.artery.protobuf.TestMessages.Item parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2033,7 +2027,7 @@ public final class TestMessages {
        * @return This builder for chaining.
        */
       public Builder setId(long value) {
-        
+
         id_ = value;
         bitField0_ |= 0x00000001;
         onChanged();

--- a/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
+++ b/akka-remote/src/main/java/akka/remote/ArteryControlFormats.java
@@ -74,11 +74,6 @@ public final class ArteryControlFormats {
       return new Quarantined();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_Quarantined_descriptor;
@@ -291,11 +286,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.Quarantined parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.Quarantined parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -622,8 +619,10 @@ public final class ArteryControlFormats {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -741,8 +740,10 @@ public final class ArteryControlFormats {
         } else {
           toBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (to_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -906,11 +907,6 @@ public final class ArteryControlFormats {
       return new MessageWithAddress();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_MessageWithAddress_descriptor;
@@ -1073,11 +1069,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.MessageWithAddress parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.MessageWithAddress parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1384,8 +1382,10 @@ public final class ArteryControlFormats {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1556,11 +1556,6 @@ public final class ArteryControlFormats {
       return new HandshakeReq();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_HandshakeReq_descriptor;
@@ -1773,11 +1768,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.HandshakeReq parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.HandshakeReq parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2104,8 +2101,10 @@ public final class ArteryControlFormats {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2223,8 +2222,10 @@ public final class ArteryControlFormats {
         } else {
           toBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (to_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2464,7 +2465,8 @@ public final class ArteryControlFormats {
       super(builder);
     }
     private CompressionTableAdvertisement() {
-      keys_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      keys_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       values_ = emptyIntList();
     }
 
@@ -2475,11 +2477,6 @@ public final class ArteryControlFormats {
       return new CompressionTableAdvertisement();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_CompressionTableAdvertisement_descriptor;
@@ -2560,7 +2557,8 @@ public final class ArteryControlFormats {
 
     public static final int KEYS_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList keys_;
+    private akka.protobufv3.internal.LazyStringArrayList keys_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <pre>
      * actual Map is represented by separate sequences of keys and values,
@@ -2620,7 +2618,8 @@ public final class ArteryControlFormats {
 
     public static final int VALUES_FIELD_NUMBER = 5;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList values_;
+    private akka.protobufv3.internal.Internal.IntList values_ =
+        emptyIntList();
     /**
      * <code>repeated uint32 values = 5;</code>
      * @return A list containing the values.
@@ -2844,11 +2843,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.CompressionTableAdvertisement parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.CompressionTableAdvertisement parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2942,8 +2943,8 @@ public final class ArteryControlFormats {
         }
         originUid_ = 0L;
         tableVersion_ = 0;
-        keys_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        keys_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         values_ = emptyIntList();
         return this;
       }
@@ -2971,23 +2972,9 @@ public final class ArteryControlFormats {
       @java.lang.Override
       public akka.remote.ArteryControlFormats.CompressionTableAdvertisement buildPartial() {
         akka.remote.ArteryControlFormats.CompressionTableAdvertisement result = new akka.remote.ArteryControlFormats.CompressionTableAdvertisement(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.remote.ArteryControlFormats.CompressionTableAdvertisement result) {
-        if (((bitField0_ & 0x00000008) != 0)) {
-          keys_ = keys_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.keys_ = keys_;
-        if (((bitField0_ & 0x00000010) != 0)) {
-          values_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.values_ = values_;
       }
 
       private void buildPartial0(akka.remote.ArteryControlFormats.CompressionTableAdvertisement result) {
@@ -3006,6 +2993,14 @@ public final class ArteryControlFormats {
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.tableVersion_ = tableVersion_;
           to_bitField0_ |= 0x00000004;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          keys_.makeImmutable();
+          result.keys_ = keys_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          values_.makeImmutable();
+          result.values_ = values_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -3066,7 +3061,7 @@ public final class ArteryControlFormats {
         if (!other.keys_.isEmpty()) {
           if (keys_.isEmpty()) {
             keys_ = other.keys_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ |= 0x00000008;
           } else {
             ensureKeysIsMutable();
             keys_.addAll(other.keys_);
@@ -3076,7 +3071,8 @@ public final class ArteryControlFormats {
         if (!other.values_.isEmpty()) {
           if (values_.isEmpty()) {
             values_ = other.values_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            values_.makeImmutable();
+            bitField0_ |= 0x00000010;
           } else {
             ensureValuesIsMutable();
             values_.addAll(other.values_);
@@ -3243,8 +3239,10 @@ public final class ArteryControlFormats {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3319,7 +3317,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setOriginUid(long value) {
-        
+
         originUid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -3359,7 +3357,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setTableVersion(int value) {
-        
+
         tableVersion_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -3376,12 +3374,13 @@ public final class ArteryControlFormats {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList keys_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList keys_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureKeysIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
+        if (!keys_.isModifiable()) {
           keys_ = new akka.protobufv3.internal.LazyStringArrayList(keys_);
-          bitField0_ |= 0x00000008;
-         }
+        }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <pre>
@@ -3395,7 +3394,8 @@ public final class ArteryControlFormats {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getKeysList() {
-        return keys_.getUnmodifiableView();
+        keys_.makeImmutable();
+        return keys_;
       }
       /**
        * <pre>
@@ -3456,6 +3456,7 @@ public final class ArteryControlFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureKeysIsMutable();
         keys_.set(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3475,6 +3476,7 @@ public final class ArteryControlFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureKeysIsMutable();
         keys_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3494,6 +3496,7 @@ public final class ArteryControlFormats {
         ensureKeysIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, keys_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -3508,8 +3511,9 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder clearKeys() {
-        keys_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        keys_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000008);;
         onChanged();
         return this;
       }
@@ -3529,16 +3533,17 @@ public final class ArteryControlFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureKeysIsMutable();
         keys_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
 
       private akka.protobufv3.internal.Internal.IntList values_ = emptyIntList();
       private void ensureValuesIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
-          values_ = mutableCopy(values_);
-          bitField0_ |= 0x00000010;
+        if (!values_.isModifiable()) {
+          values_ = makeMutableCopy(values_);
         }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <code>repeated uint32 values = 5;</code>
@@ -3546,8 +3551,8 @@ public final class ArteryControlFormats {
        */
       public java.util.List<java.lang.Integer>
           getValuesList() {
-        return ((bitField0_ & 0x00000010) != 0) ?
-                 java.util.Collections.unmodifiableList(values_) : values_;
+        values_.makeImmutable();
+        return values_;
       }
       /**
        * <code>repeated uint32 values = 5;</code>
@@ -3572,9 +3577,10 @@ public final class ArteryControlFormats {
        */
       public Builder setValues(
           int index, int value) {
-        
+
         ensureValuesIsMutable();
         values_.setInt(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3584,9 +3590,10 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder addValues(int value) {
-        
+
         ensureValuesIsMutable();
         values_.addInt(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3600,6 +3607,7 @@ public final class ArteryControlFormats {
         ensureValuesIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, values_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -3734,11 +3742,6 @@ public final class ArteryControlFormats {
       return new CompressionTableAdvertisementAck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_CompressionTableAdvertisementAck_descriptor;
@@ -3940,11 +3943,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.CompressionTableAdvertisementAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.CompressionTableAdvertisementAck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4264,8 +4269,10 @@ public final class ArteryControlFormats {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4340,7 +4347,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setVersion(int value) {
-        
+
         version_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -4511,11 +4518,6 @@ public final class ArteryControlFormats {
       return new SystemMessageEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_SystemMessageEnvelope_descriptor;
@@ -4831,11 +4833,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.SystemMessageEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.SystemMessageEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5196,7 +5200,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -5276,7 +5280,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setSeqNo(long value) {
-        
+
         seqNo_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -5359,8 +5363,10 @@ public final class ArteryControlFormats {
         } else {
           ackReplyToBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (ackReplyTo_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5532,11 +5538,6 @@ public final class ArteryControlFormats {
       return new SystemMessageDeliveryAck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_SystemMessageDeliveryAck_descriptor;
@@ -5739,11 +5740,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.SystemMessageDeliveryAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.SystemMessageDeliveryAck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6020,7 +6023,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setSeqNo(long value) {
-        
+
         seqNo_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -6103,8 +6106,10 @@ public final class ArteryControlFormats {
         } else {
           fromBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (from_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6315,11 +6320,6 @@ public final class ArteryControlFormats {
       return new Address();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_Address_descriptor;
@@ -6675,11 +6675,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.Address parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.Address parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7217,7 +7219,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -7354,11 +7356,6 @@ public final class ArteryControlFormats {
       return new UniqueAddress();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_UniqueAddress_descriptor;
@@ -7561,11 +7558,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.UniqueAddress parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.UniqueAddress parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7885,8 +7884,10 @@ public final class ArteryControlFormats {
         } else {
           addressBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (address_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7961,7 +7962,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setUid(long value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -8083,11 +8084,6 @@ public final class ArteryControlFormats {
       return new ArteryHeartbeatRsp();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_ArteryHeartbeatRsp_descriptor;
@@ -8240,11 +8236,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.ArteryHeartbeatRsp parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.ArteryHeartbeatRsp parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8488,7 +8486,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setUid(long value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -8605,11 +8603,6 @@ public final class ArteryControlFormats {
       return new FlushAck();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ArteryControlFormats.internal_static_FlushAck_descriptor;
@@ -8757,11 +8750,13 @@ public final class ArteryControlFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ArteryControlFormats.FlushAck parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ArteryControlFormats.FlushAck parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8997,7 +8992,7 @@ public final class ArteryControlFormats {
        * @return This builder for chaining.
        */
       public Builder setExpectedAcks(int value) {
-        
+
         expectedAcks_ = value;
         bitField0_ |= 0x00000001;
         onChanged();

--- a/akka-remote/src/main/java/akka/remote/ContainerFormats.java
+++ b/akka-remote/src/main/java/akka/remote/ContainerFormats.java
@@ -228,11 +228,6 @@ public final class ContainerFormats {
       return new SelectionEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_SelectionEnvelope_descriptor;
@@ -562,11 +557,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.SelectionEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.SelectionEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -951,7 +948,7 @@ public final class ContainerFormats {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -1283,7 +1280,7 @@ public final class ContainerFormats {
        * @return This builder for chaining.
        */
       public Builder setWildcardFanOut(boolean value) {
-        
+
         wildcardFanOut_ = value;
         bitField0_ |= 0x00000010;
         onChanged();
@@ -1423,11 +1420,6 @@ public final class ContainerFormats {
       return new Selection();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_Selection_descriptor;
@@ -1641,11 +1633,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.Selection parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.Selection parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2109,11 +2103,6 @@ public final class ContainerFormats {
       return new Identify();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_Identify_descriptor;
@@ -2276,11 +2265,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.Identify parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.Identify parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2579,8 +2570,10 @@ public final class ContainerFormats {
         } else {
           messageIdBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (messageId_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2751,11 +2744,6 @@ public final class ContainerFormats {
       return new ActorIdentity();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_ActorIdentity_descriptor;
@@ -2966,11 +2954,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.ActorIdentity parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.ActorIdentity parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3296,8 +3286,10 @@ public final class ContainerFormats {
         } else {
           correlationIdBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (correlationId_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3415,8 +3407,10 @@ public final class ContainerFormats {
         } else {
           refBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (ref_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3575,11 +3569,6 @@ public final class ContainerFormats {
       return new ActorRef();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_ActorRef_descriptor;
@@ -3760,11 +3749,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.ActorRef parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.ActorRef parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4166,11 +4157,6 @@ public final class ContainerFormats {
       return new Option();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_Option_descriptor;
@@ -4331,11 +4317,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.Option parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.Option parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4633,8 +4621,10 @@ public final class ContainerFormats {
         } else {
           valueBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (value_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4810,11 +4800,6 @@ public final class ContainerFormats {
       return new Payload();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_Payload_descriptor;
@@ -5040,11 +5025,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.Payload parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.Payload parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5352,7 +5339,7 @@ public final class ContainerFormats {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -5509,11 +5496,6 @@ public final class ContainerFormats {
       return new WatcherHeartbeatResponse();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_WatcherHeartbeatResponse_descriptor;
@@ -5666,11 +5648,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.WatcherHeartbeatResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.WatcherHeartbeatResponse parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5909,7 +5893,7 @@ public final class ContainerFormats {
        * @return This builder for chaining.
        */
       public Builder setUid(long value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -6091,11 +6075,6 @@ public final class ContainerFormats {
       return new Throwable();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_Throwable_descriptor;
@@ -6448,11 +6427,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.Throwable parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.Throwable parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -7008,8 +6989,10 @@ public final class ContainerFormats {
         } else {
           causeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (cause_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -7444,11 +7427,6 @@ public final class ContainerFormats {
       return new ThrowableNotSerializable();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_ThrowableNotSerializable_descriptor;
@@ -7765,11 +7743,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.ThrowableNotSerializable parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.ThrowableNotSerializable parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8400,11 +8380,6 @@ public final class ContainerFormats {
       return new ActorInitializationException();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_ActorInitializationException_descriptor;
@@ -8683,11 +8658,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.ActorInitializationException parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.ActorInitializationException parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -9031,8 +9008,10 @@ public final class ContainerFormats {
         } else {
           actorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (actor_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -9230,8 +9209,10 @@ public final class ContainerFormats {
         } else {
           causeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (cause_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -9437,11 +9418,6 @@ public final class ContainerFormats {
       return new StackTraceElement();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_StackTraceElement_descriptor;
@@ -9797,11 +9773,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.StackTraceElement parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.StackTraceElement parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10334,7 +10312,7 @@ public final class ContainerFormats {
        * @return This builder for chaining.
        */
       public Builder setLineNumber(int value) {
-        
+
         lineNumber_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -10462,11 +10440,6 @@ public final class ContainerFormats {
       return new StatusReplyErrorMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ContainerFormats.internal_static_StatusReplyErrorMessage_descriptor;
@@ -10647,11 +10620,13 @@ public final class ContainerFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ContainerFormats.StatusReplyErrorMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ContainerFormats.StatusReplyErrorMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)

--- a/akka-remote/src/main/java/akka/remote/SystemMessageFormats.java
+++ b/akka-remote/src/main/java/akka/remote/SystemMessageFormats.java
@@ -131,11 +131,6 @@ public final class SystemMessageFormats {
       return new SystemMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.SystemMessageFormats.internal_static_SystemMessage_descriptor;
@@ -693,11 +688,13 @@ public final class SystemMessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.SystemMessageFormats.SystemMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.SystemMessageFormats.SystemMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1168,8 +1165,10 @@ public final class SystemMessageFormats {
         } else {
           watchDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (watchData_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1287,8 +1286,10 @@ public final class SystemMessageFormats {
         } else {
           causeDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (causeData_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1406,8 +1407,10 @@ public final class SystemMessageFormats {
         } else {
           superviseDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000008;
-        onChanged();
+        if (superviseData_ != null) {
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1525,8 +1528,10 @@ public final class SystemMessageFormats {
         } else {
           failedDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000010;
-        onChanged();
+        if (failedData_ != null) {
+          bitField0_ |= 0x00000010;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1644,8 +1649,10 @@ public final class SystemMessageFormats {
         } else {
           dwNotificationDataBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000020;
-        onChanged();
+        if (dwNotificationData_ != null) {
+          bitField0_ |= 0x00000020;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1816,11 +1823,6 @@ public final class SystemMessageFormats {
       return new WatchData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.SystemMessageFormats.internal_static_WatchData_descriptor;
@@ -2033,11 +2035,13 @@ public final class SystemMessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.SystemMessageFormats.WatchData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.SystemMessageFormats.WatchData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2364,8 +2368,10 @@ public final class SystemMessageFormats {
         } else {
           watcheeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (watchee_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2483,8 +2489,10 @@ public final class SystemMessageFormats {
         } else {
           watcherBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (watcher_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2651,11 +2659,6 @@ public final class SystemMessageFormats {
       return new SuperviseData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.SystemMessageFormats.internal_static_SuperviseData_descriptor;
@@ -2858,11 +2861,13 @@ public final class SystemMessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.SystemMessageFormats.SuperviseData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.SystemMessageFormats.SuperviseData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3177,8 +3182,10 @@ public final class SystemMessageFormats {
         } else {
           childBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (child_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3253,7 +3260,7 @@ public final class SystemMessageFormats {
        * @return This builder for chaining.
        */
       public Builder setAsync(boolean value) {
-        
+
         async_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -3385,11 +3392,6 @@ public final class SystemMessageFormats {
       return new FailedData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.SystemMessageFormats.internal_static_FailedData_descriptor;
@@ -3592,11 +3594,13 @@ public final class SystemMessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.SystemMessageFormats.FailedData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.SystemMessageFormats.FailedData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3911,8 +3915,10 @@ public final class SystemMessageFormats {
         } else {
           childBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (child_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3987,7 +3993,7 @@ public final class SystemMessageFormats {
        * @return This builder for chaining.
        */
       public Builder setUid(long value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -4130,11 +4136,6 @@ public final class SystemMessageFormats {
       return new DeathWatchNotificationData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.SystemMessageFormats.internal_static_DeathWatchNotificationData_descriptor;
@@ -4377,11 +4378,13 @@ public final class SystemMessageFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.SystemMessageFormats.DeathWatchNotificationData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.SystemMessageFormats.DeathWatchNotificationData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4712,8 +4715,10 @@ public final class SystemMessageFormats {
         } else {
           actorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (actor_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4788,7 +4793,7 @@ public final class SystemMessageFormats {
        * @return This builder for chaining.
        */
       public Builder setExistenceConfirmed(boolean value) {
-        
+
         existenceConfirmed_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -4828,7 +4833,7 @@ public final class SystemMessageFormats {
        * @return This builder for chaining.
        */
       public Builder setAddressTerminated(boolean value) {
-        
+
         addressTerminated_ = value;
         bitField0_ |= 0x00000004;
         onChanged();

--- a/akka-remote/src/main/java/akka/remote/WireFormats.java
+++ b/akka-remote/src/main/java/akka/remote/WireFormats.java
@@ -364,11 +364,6 @@ public final class WireFormats {
       return new AckAndEnvelopeContainer();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AckAndEnvelopeContainer_descriptor;
@@ -577,11 +572,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AckAndEnvelopeContainer parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AckAndEnvelopeContainer parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -906,8 +903,10 @@ public final class WireFormats {
         } else {
           ackBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (ack_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1025,8 +1024,10 @@ public final class WireFormats {
         } else {
           envelopeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (envelope_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1228,11 +1229,6 @@ public final class WireFormats {
       return new RemoteEnvelope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_RemoteEnvelope_descriptor;
@@ -1529,11 +1525,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.RemoteEnvelope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.RemoteEnvelope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1905,8 +1903,10 @@ public final class WireFormats {
         } else {
           recipientBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (recipient_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2024,8 +2024,10 @@ public final class WireFormats {
         } else {
           messageBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (message_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2143,8 +2145,10 @@ public final class WireFormats {
         } else {
           senderBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (sender_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -2219,7 +2223,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setSeq(long value) {
-        
+
         seq_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -2354,11 +2358,6 @@ public final class WireFormats {
       return new AcknowledgementInfo();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AcknowledgementInfo_descriptor;
@@ -2394,7 +2393,8 @@ public final class WireFormats {
 
     public static final int NACKS_FIELD_NUMBER = 2;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.LongList nacks_;
+    private akka.protobufv3.internal.Internal.LongList nacks_ =
+        emptyLongList();
     /**
      * <code>repeated fixed64 nacks = 2;</code>
      * @return A list containing the nacks.
@@ -2554,11 +2554,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AcknowledgementInfo parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AcknowledgementInfo parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2662,18 +2664,9 @@ public final class WireFormats {
       @java.lang.Override
       public akka.remote.WireFormats.AcknowledgementInfo buildPartial() {
         akka.remote.WireFormats.AcknowledgementInfo result = new akka.remote.WireFormats.AcknowledgementInfo(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.remote.WireFormats.AcknowledgementInfo result) {
-        if (((bitField0_ & 0x00000002) != 0)) {
-          nacks_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
-        result.nacks_ = nacks_;
       }
 
       private void buildPartial0(akka.remote.WireFormats.AcknowledgementInfo result) {
@@ -2682,6 +2675,10 @@ public final class WireFormats {
         if (((from_bitField0_ & 0x00000001) != 0)) {
           result.cumulativeAck_ = cumulativeAck_;
           to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          nacks_.makeImmutable();
+          result.nacks_ = nacks_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -2736,7 +2733,8 @@ public final class WireFormats {
         if (!other.nacks_.isEmpty()) {
           if (nacks_.isEmpty()) {
             nacks_ = other.nacks_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            nacks_.makeImmutable();
+            bitField0_ |= 0x00000002;
           } else {
             ensureNacksIsMutable();
             nacks_.addAll(other.nacks_);
@@ -2786,7 +2784,8 @@ public final class WireFormats {
               case 18: {
                 int length = input.readRawVarint32();
                 int limit = input.pushLimit(length);
-                ensureNacksIsMutable();
+                int alloc = length > 4096 ? 4096 : length;
+                ensureNacksIsMutable(alloc / 8);
                 while (input.getBytesUntilLimit() > 0) {
                   nacks_.addLong(input.readFixed64());
                 }
@@ -2833,7 +2832,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setCumulativeAck(long value) {
-        
+
         cumulativeAck_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -2852,10 +2851,16 @@ public final class WireFormats {
 
       private akka.protobufv3.internal.Internal.LongList nacks_ = emptyLongList();
       private void ensureNacksIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
-          nacks_ = mutableCopy(nacks_);
-          bitField0_ |= 0x00000002;
+        if (!nacks_.isModifiable()) {
+          nacks_ = makeMutableCopy(nacks_);
         }
+        bitField0_ |= 0x00000002;
+      }
+      private void ensureNacksIsMutable(int capacity) {
+        if (!nacks_.isModifiable()) {
+          nacks_ = makeMutableCopy(nacks_, capacity);
+        }
+        bitField0_ |= 0x00000002;
       }
       /**
        * <code>repeated fixed64 nacks = 2;</code>
@@ -2863,8 +2868,8 @@ public final class WireFormats {
        */
       public java.util.List<java.lang.Long>
           getNacksList() {
-        return ((bitField0_ & 0x00000002) != 0) ?
-                 java.util.Collections.unmodifiableList(nacks_) : nacks_;
+        nacks_.makeImmutable();
+        return nacks_;
       }
       /**
        * <code>repeated fixed64 nacks = 2;</code>
@@ -2889,9 +2894,10 @@ public final class WireFormats {
        */
       public Builder setNacks(
           int index, long value) {
-        
+
         ensureNacksIsMutable();
         nacks_.setLong(index, value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2901,9 +2907,10 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder addNacks(long value) {
-        
+
         ensureNacksIsMutable();
         nacks_.addLong(value);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -2917,6 +2924,7 @@ public final class WireFormats {
         ensureNacksIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, nacks_);
+        bitField0_ |= 0x00000002;
         onChanged();
         return this;
       }
@@ -3044,11 +3052,6 @@ public final class WireFormats {
       return new ActorRefData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_ActorRefData_descriptor;
@@ -3229,11 +3232,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.ActorRefData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.ActorRefData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3666,11 +3671,6 @@ public final class WireFormats {
       return new SerializedMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_SerializedMessage_descriptor;
@@ -3896,11 +3896,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.SerializedMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.SerializedMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4213,7 +4215,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -4427,11 +4429,6 @@ public final class WireFormats {
       return new DaemonMsgCreateData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_DaemonMsgCreateData_descriptor;
@@ -4762,11 +4759,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.DaemonMsgCreateData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.DaemonMsgCreateData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5144,8 +5143,10 @@ public final class WireFormats {
         } else {
           propsBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (props_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5263,8 +5264,10 @@ public final class WireFormats {
         } else {
           deployBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (deploy_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5462,8 +5465,10 @@ public final class WireFormats {
         } else {
           supervisorBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000008;
-        onChanged();
+        if (supervisor_ != null) {
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -5760,8 +5765,9 @@ public final class WireFormats {
     }
     private PropsData() {
       clazz_ = "";
-      args_ = java.util.Collections.emptyList();
-      manifests_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      args_ = emptyList(akka.protobufv3.internal.ByteString.class);
+      manifests_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       serializerIds_ = emptyIntList();
       hasManifest_ = emptyBooleanList();
     }
@@ -5773,11 +5779,6 @@ public final class WireFormats {
       return new PropsData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_PropsData_descriptor;
@@ -5869,7 +5870,8 @@ public final class WireFormats {
 
     public static final int ARGS_FIELD_NUMBER = 4;
     @SuppressWarnings("serial")
-    private java.util.List<akka.protobufv3.internal.ByteString> args_;
+    private akka.protobufv3.internal.Internal.ProtobufList<akka.protobufv3.internal.ByteString> args_ =
+        emptyList(akka.protobufv3.internal.ByteString.class);
     /**
      * <code>repeated bytes args = 4;</code>
      * @return A list containing the args.
@@ -5897,7 +5899,8 @@ public final class WireFormats {
 
     public static final int MANIFESTS_FIELD_NUMBER = 5;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList manifests_;
+    private akka.protobufv3.internal.LazyStringArrayList manifests_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <pre>
      * serialized props parameters
@@ -5957,7 +5960,8 @@ public final class WireFormats {
 
     public static final int SERIALIZERIDS_FIELD_NUMBER = 6;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.IntList serializerIds_;
+    private akka.protobufv3.internal.Internal.IntList serializerIds_ =
+        emptyIntList();
     /**
      * <pre>
      * newer wire protocol: serializer id for each arg
@@ -5997,7 +6001,8 @@ public final class WireFormats {
 
     public static final int HASMANIFEST_FIELD_NUMBER = 7;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.Internal.BooleanList hasManifest_;
+    private akka.protobufv3.internal.Internal.BooleanList hasManifest_ =
+        emptyBooleanList();
     /**
      * <pre>
      * additionally a flag per position to indicate if it was
@@ -6247,11 +6252,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.PropsData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.PropsData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -6344,9 +6351,9 @@ public final class WireFormats {
           deployBuilder_ = null;
         }
         clazz_ = "";
-        args_ = java.util.Collections.emptyList();
-        manifests_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        args_ = emptyList(akka.protobufv3.internal.ByteString.class);
+        manifests_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         serializerIds_ = emptyIntList();
         hasManifest_ = emptyBooleanList();
         return this;
@@ -6375,33 +6382,9 @@ public final class WireFormats {
       @java.lang.Override
       public akka.remote.WireFormats.PropsData buildPartial() {
         akka.remote.WireFormats.PropsData result = new akka.remote.WireFormats.PropsData(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.remote.WireFormats.PropsData result) {
-        if (((bitField0_ & 0x00000004) != 0)) {
-          args_ = java.util.Collections.unmodifiableList(args_);
-          bitField0_ = (bitField0_ & ~0x00000004);
-        }
-        result.args_ = args_;
-        if (((bitField0_ & 0x00000008) != 0)) {
-          manifests_ = manifests_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000008);
-        }
-        result.manifests_ = manifests_;
-        if (((bitField0_ & 0x00000010) != 0)) {
-          serializerIds_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        }
-        result.serializerIds_ = serializerIds_;
-        if (((bitField0_ & 0x00000020) != 0)) {
-          hasManifest_.makeImmutable();
-          bitField0_ = (bitField0_ & ~0x00000020);
-        }
-        result.hasManifest_ = hasManifest_;
       }
 
       private void buildPartial0(akka.remote.WireFormats.PropsData result) {
@@ -6416,6 +6399,22 @@ public final class WireFormats {
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.clazz_ = clazz_;
           to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          args_.makeImmutable();
+          result.args_ = args_;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          manifests_.makeImmutable();
+          result.manifests_ = manifests_;
+        }
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          serializerIds_.makeImmutable();
+          result.serializerIds_ = serializerIds_;
+        }
+        if (((from_bitField0_ & 0x00000020) != 0)) {
+          hasManifest_.makeImmutable();
+          result.hasManifest_ = hasManifest_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -6475,7 +6474,8 @@ public final class WireFormats {
         if (!other.args_.isEmpty()) {
           if (args_.isEmpty()) {
             args_ = other.args_;
-            bitField0_ = (bitField0_ & ~0x00000004);
+            args_.makeImmutable();
+            bitField0_ |= 0x00000004;
           } else {
             ensureArgsIsMutable();
             args_.addAll(other.args_);
@@ -6485,7 +6485,7 @@ public final class WireFormats {
         if (!other.manifests_.isEmpty()) {
           if (manifests_.isEmpty()) {
             manifests_ = other.manifests_;
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ |= 0x00000008;
           } else {
             ensureManifestsIsMutable();
             manifests_.addAll(other.manifests_);
@@ -6495,7 +6495,8 @@ public final class WireFormats {
         if (!other.serializerIds_.isEmpty()) {
           if (serializerIds_.isEmpty()) {
             serializerIds_ = other.serializerIds_;
-            bitField0_ = (bitField0_ & ~0x00000010);
+            serializerIds_.makeImmutable();
+            bitField0_ |= 0x00000010;
           } else {
             ensureSerializerIdsIsMutable();
             serializerIds_.addAll(other.serializerIds_);
@@ -6505,7 +6506,8 @@ public final class WireFormats {
         if (!other.hasManifest_.isEmpty()) {
           if (hasManifest_.isEmpty()) {
             hasManifest_ = other.hasManifest_;
-            bitField0_ = (bitField0_ & ~0x00000020);
+            hasManifest_.makeImmutable();
+            bitField0_ |= 0x00000020;
           } else {
             ensureHasManifestIsMutable();
             hasManifest_.addAll(other.hasManifest_);
@@ -6596,7 +6598,8 @@ public final class WireFormats {
               case 58: {
                 int length = input.readRawVarint32();
                 int limit = input.pushLimit(length);
-                ensureHasManifestIsMutable();
+                int alloc = length > 4096 ? 4096 : length;
+                ensureHasManifestIsMutable(alloc / 1);
                 while (input.getBytesUntilLimit() > 0) {
                   hasManifest_.addBoolean(input.readBool());
                 }
@@ -6686,8 +6689,10 @@ public final class WireFormats {
         } else {
           deployBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (deploy_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -6819,12 +6824,12 @@ public final class WireFormats {
         return this;
       }
 
-      private java.util.List<akka.protobufv3.internal.ByteString> args_ = java.util.Collections.emptyList();
+      private akka.protobufv3.internal.Internal.ProtobufList<akka.protobufv3.internal.ByteString> args_ = emptyList(akka.protobufv3.internal.ByteString.class);
       private void ensureArgsIsMutable() {
-        if (!((bitField0_ & 0x00000004) != 0)) {
-          args_ = new java.util.ArrayList<akka.protobufv3.internal.ByteString>(args_);
-          bitField0_ |= 0x00000004;
+        if (!args_.isModifiable()) {
+          args_ = makeMutableCopy(args_);
         }
+        bitField0_ |= 0x00000004;
       }
       /**
        * <code>repeated bytes args = 4;</code>
@@ -6832,8 +6837,8 @@ public final class WireFormats {
        */
       public java.util.List<akka.protobufv3.internal.ByteString>
           getArgsList() {
-        return ((bitField0_ & 0x00000004) != 0) ?
-                 java.util.Collections.unmodifiableList(args_) : args_;
+        args_.makeImmutable();
+        return args_;
       }
       /**
        * <code>repeated bytes args = 4;</code>
@@ -6861,6 +6866,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureArgsIsMutable();
         args_.set(index, value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6873,6 +6879,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureArgsIsMutable();
         args_.add(value);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6886,6 +6893,7 @@ public final class WireFormats {
         ensureArgsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, args_);
+        bitField0_ |= 0x00000004;
         onChanged();
         return this;
       }
@@ -6894,18 +6902,19 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder clearArgs() {
-        args_ = java.util.Collections.emptyList();
+        args_ = emptyList(akka.protobufv3.internal.ByteString.class);
         bitField0_ = (bitField0_ & ~0x00000004);
         onChanged();
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList manifests_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList manifests_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureManifestsIsMutable() {
-        if (!((bitField0_ & 0x00000008) != 0)) {
+        if (!manifests_.isModifiable()) {
           manifests_ = new akka.protobufv3.internal.LazyStringArrayList(manifests_);
-          bitField0_ |= 0x00000008;
-         }
+        }
+        bitField0_ |= 0x00000008;
       }
       /**
        * <pre>
@@ -6919,7 +6928,8 @@ public final class WireFormats {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getManifestsList() {
-        return manifests_.getUnmodifiableView();
+        manifests_.makeImmutable();
+        return manifests_;
       }
       /**
        * <pre>
@@ -6980,6 +6990,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureManifestsIsMutable();
         manifests_.set(index, value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -6999,6 +7010,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureManifestsIsMutable();
         manifests_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -7018,6 +7030,7 @@ public final class WireFormats {
         ensureManifestsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, manifests_);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
@@ -7032,8 +7045,9 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder clearManifests() {
-        manifests_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000008);
+        manifests_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000008);;
         onChanged();
         return this;
       }
@@ -7053,16 +7067,17 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureManifestsIsMutable();
         manifests_.add(value);
+        bitField0_ |= 0x00000008;
         onChanged();
         return this;
       }
 
       private akka.protobufv3.internal.Internal.IntList serializerIds_ = emptyIntList();
       private void ensureSerializerIdsIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
-          serializerIds_ = mutableCopy(serializerIds_);
-          bitField0_ |= 0x00000010;
+        if (!serializerIds_.isModifiable()) {
+          serializerIds_ = makeMutableCopy(serializerIds_);
         }
+        bitField0_ |= 0x00000010;
       }
       /**
        * <pre>
@@ -7074,8 +7089,8 @@ public final class WireFormats {
        */
       public java.util.List<java.lang.Integer>
           getSerializerIdsList() {
-        return ((bitField0_ & 0x00000010) != 0) ?
-                 java.util.Collections.unmodifiableList(serializerIds_) : serializerIds_;
+        serializerIds_.makeImmutable();
+        return serializerIds_;
       }
       /**
        * <pre>
@@ -7112,9 +7127,10 @@ public final class WireFormats {
        */
       public Builder setSerializerIds(
           int index, int value) {
-        
+
         ensureSerializerIdsIsMutable();
         serializerIds_.setInt(index, value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -7128,9 +7144,10 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder addSerializerIds(int value) {
-        
+
         ensureSerializerIdsIsMutable();
         serializerIds_.addInt(value);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -7148,6 +7165,7 @@ public final class WireFormats {
         ensureSerializerIdsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, serializerIds_);
+        bitField0_ |= 0x00000010;
         onChanged();
         return this;
       }
@@ -7168,10 +7186,16 @@ public final class WireFormats {
 
       private akka.protobufv3.internal.Internal.BooleanList hasManifest_ = emptyBooleanList();
       private void ensureHasManifestIsMutable() {
-        if (!((bitField0_ & 0x00000020) != 0)) {
-          hasManifest_ = mutableCopy(hasManifest_);
-          bitField0_ |= 0x00000020;
+        if (!hasManifest_.isModifiable()) {
+          hasManifest_ = makeMutableCopy(hasManifest_);
         }
+        bitField0_ |= 0x00000020;
+      }
+      private void ensureHasManifestIsMutable(int capacity) {
+        if (!hasManifest_.isModifiable()) {
+          hasManifest_ = makeMutableCopy(hasManifest_, capacity);
+        }
+        bitField0_ |= 0x00000020;
       }
       /**
        * <pre>
@@ -7184,8 +7208,8 @@ public final class WireFormats {
        */
       public java.util.List<java.lang.Boolean>
           getHasManifestList() {
-        return ((bitField0_ & 0x00000020) != 0) ?
-                 java.util.Collections.unmodifiableList(hasManifest_) : hasManifest_;
+        hasManifest_.makeImmutable();
+        return hasManifest_;
       }
       /**
        * <pre>
@@ -7225,9 +7249,10 @@ public final class WireFormats {
        */
       public Builder setHasManifest(
           int index, boolean value) {
-        
+
         ensureHasManifestIsMutable();
         hasManifest_.setBoolean(index, value);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -7242,9 +7267,10 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder addHasManifest(boolean value) {
-        
+
         ensureHasManifestIsMutable();
         hasManifest_.addBoolean(value);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -7263,6 +7289,7 @@ public final class WireFormats {
         ensureHasManifestIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, hasManifest_);
+        bitField0_ |= 0x00000020;
         onChanged();
         return this;
       }
@@ -7561,7 +7588,8 @@ public final class WireFormats {
       scopeManifest_ = "";
       configManifest_ = "";
       routerConfigManifest_ = "";
-      tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      tags_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
     }
 
     @java.lang.Override
@@ -7571,11 +7599,6 @@ public final class WireFormats {
       return new DeployData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_DeployData_descriptor;
@@ -7961,7 +7984,8 @@ public final class WireFormats {
 
     public static final int TAGS_FIELD_NUMBER = 12;
     @SuppressWarnings("serial")
-    private akka.protobufv3.internal.LazyStringList tags_;
+    private akka.protobufv3.internal.LazyStringArrayList tags_ =
+        akka.protobufv3.internal.LazyStringArrayList.emptyList();
     /**
      * <code>repeated string tags = 12;</code>
      * @return A list containing the tags.
@@ -8285,11 +8309,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.DeployData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.DeployData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -8381,8 +8407,8 @@ public final class WireFormats {
         configManifest_ = "";
         routerConfigSerializerId_ = 0;
         routerConfigManifest_ = "";
-        tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000800);
+        tags_ =
+            akka.protobufv3.internal.LazyStringArrayList.emptyList();
         return this;
       }
 
@@ -8409,18 +8435,9 @@ public final class WireFormats {
       @java.lang.Override
       public akka.remote.WireFormats.DeployData buildPartial() {
         akka.remote.WireFormats.DeployData result = new akka.remote.WireFormats.DeployData(this);
-        buildPartialRepeatedFields(result);
         if (bitField0_ != 0) { buildPartial0(result); }
         onBuilt();
         return result;
-      }
-
-      private void buildPartialRepeatedFields(akka.remote.WireFormats.DeployData result) {
-        if (((bitField0_ & 0x00000800) != 0)) {
-          tags_ = tags_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000800);
-        }
-        result.tags_ = tags_;
       }
 
       private void buildPartial0(akka.remote.WireFormats.DeployData result) {
@@ -8469,6 +8486,10 @@ public final class WireFormats {
         if (((from_bitField0_ & 0x00000400) != 0)) {
           result.routerConfigManifest_ = routerConfigManifest_;
           to_bitField0_ |= 0x00000400;
+        }
+        if (((from_bitField0_ & 0x00000800) != 0)) {
+          tags_.makeImmutable();
+          result.tags_ = tags_;
         }
         result.bitField0_ |= to_bitField0_;
       }
@@ -8563,7 +8584,7 @@ public final class WireFormats {
         if (!other.tags_.isEmpty()) {
           if (tags_.isEmpty()) {
             tags_ = other.tags_;
-            bitField0_ = (bitField0_ & ~0x00000800);
+            bitField0_ |= 0x00000800;
           } else {
             ensureTagsIsMutable();
             tags_.addAll(other.tags_);
@@ -8995,7 +9016,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setScopeSerializerId(int value) {
-        
+
         scopeSerializerId_ = value;
         bitField0_ |= 0x00000020;
         onChanged();
@@ -9120,7 +9141,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setConfigSerializerId(int value) {
-        
+
         configSerializerId_ = value;
         bitField0_ |= 0x00000080;
         onChanged();
@@ -9240,7 +9261,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setRouterConfigSerializerId(int value) {
-        
+
         routerConfigSerializerId_ = value;
         bitField0_ |= 0x00000200;
         onChanged();
@@ -9337,12 +9358,13 @@ public final class WireFormats {
         return this;
       }
 
-      private akka.protobufv3.internal.LazyStringList tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
+      private akka.protobufv3.internal.LazyStringArrayList tags_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
       private void ensureTagsIsMutable() {
-        if (!((bitField0_ & 0x00000800) != 0)) {
+        if (!tags_.isModifiable()) {
           tags_ = new akka.protobufv3.internal.LazyStringArrayList(tags_);
-          bitField0_ |= 0x00000800;
-         }
+        }
+        bitField0_ |= 0x00000800;
       }
       /**
        * <code>repeated string tags = 12;</code>
@@ -9350,7 +9372,8 @@ public final class WireFormats {
        */
       public akka.protobufv3.internal.ProtocolStringList
           getTagsList() {
-        return tags_.getUnmodifiableView();
+        tags_.makeImmutable();
+        return tags_;
       }
       /**
        * <code>repeated string tags = 12;</code>
@@ -9387,6 +9410,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureTagsIsMutable();
         tags_.set(index, value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -9400,6 +9424,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureTagsIsMutable();
         tags_.add(value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -9413,6 +9438,7 @@ public final class WireFormats {
         ensureTagsIsMutable();
         akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(
             values, tags_);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -9421,8 +9447,9 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder clearTags() {
-        tags_ = akka.protobufv3.internal.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000800);
+        tags_ =
+          akka.protobufv3.internal.LazyStringArrayList.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000800);;
         onChanged();
         return this;
       }
@@ -9436,6 +9463,7 @@ public final class WireFormats {
         if (value == null) { throw new NullPointerException(); }
         ensureTagsIsMutable();
         tags_.add(value);
+        bitField0_ |= 0x00000800;
         onChanged();
         return this;
       }
@@ -9562,11 +9590,6 @@ public final class WireFormats {
       return new AkkaProtocolMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AkkaProtocolMessage_descriptor;
@@ -9762,11 +9785,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AkkaProtocolMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AkkaProtocolMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10123,8 +10148,10 @@ public final class WireFormats {
         } else {
           instructionBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (instruction_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -10297,11 +10324,6 @@ public final class WireFormats {
       return new AkkaControlMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AkkaControlMessage_descriptor;
@@ -10499,11 +10521,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AkkaControlMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AkkaControlMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -10871,8 +10895,10 @@ public final class WireFormats {
         } else {
           handshakeInfoBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (handshakeInfo_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -11057,11 +11083,6 @@ public final class WireFormats {
       return new AkkaHandshakeInfo();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AkkaHandshakeInfo_descriptor;
@@ -11328,11 +11349,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AkkaHandshakeInfo parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AkkaHandshakeInfo parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -11662,8 +11685,10 @@ public final class WireFormats {
         } else {
           originBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (origin_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -11738,7 +11763,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setUid(long value) {
-        
+
         uid_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -11947,11 +11972,6 @@ public final class WireFormats {
       return new FiniteDuration();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_FiniteDuration_descriptor;
@@ -12141,11 +12161,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.FiniteDuration parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.FiniteDuration parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -12407,7 +12429,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setValue(long value) {
-        
+
         value_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -12570,11 +12592,6 @@ public final class WireFormats {
       return new RemoteScope();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_RemoteScope_descriptor;
@@ -12737,11 +12754,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.RemoteScope parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.RemoteScope parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13040,8 +13059,10 @@ public final class WireFormats {
         } else {
           nodeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (node_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -13259,11 +13280,6 @@ public final class WireFormats {
       return new DefaultResizer();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_DefaultResizer_descriptor;
@@ -13655,11 +13671,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.DefaultResizer parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.DefaultResizer parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -13994,7 +14012,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setLowerBound(int value) {
-        
+
         lowerBound_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -14034,7 +14052,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setUpperBound(int value) {
-        
+
         upperBound_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -14074,7 +14092,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setPressureThreshold(int value) {
-        
+
         pressureThreshold_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -14114,7 +14132,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setRampupRate(double value) {
-        
+
         rampupRate_ = value;
         bitField0_ |= 0x00000008;
         onChanged();
@@ -14154,7 +14172,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setBackoffThreshold(double value) {
-        
+
         backoffThreshold_ = value;
         bitField0_ |= 0x00000010;
         onChanged();
@@ -14194,7 +14212,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setBackoffRate(double value) {
-        
+
         backoffRate_ = value;
         bitField0_ |= 0x00000020;
         onChanged();
@@ -14234,7 +14252,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setMessagesPerResize(int value) {
-        
+
         messagesPerResize_ = value;
         bitField0_ |= 0x00000040;
         onChanged();
@@ -14373,11 +14391,6 @@ public final class WireFormats {
       return new FromConfig();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_FromConfig_descriptor;
@@ -14602,11 +14615,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.FromConfig parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.FromConfig parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -14919,8 +14934,10 @@ public final class WireFormats {
         } else {
           resizerBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (resizer_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -15196,11 +15213,6 @@ public final class WireFormats {
       return new GenericRoutingPool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_GenericRoutingPool_descriptor;
@@ -15504,11 +15516,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.GenericRoutingPool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.GenericRoutingPool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -15810,7 +15824,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setNrOfInstances(int value) {
-        
+
         nrOfInstances_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -15930,7 +15944,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setUsePoolDispatcher(boolean value) {
-        
+
         usePoolDispatcher_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -16013,8 +16027,10 @@ public final class WireFormats {
         } else {
           resizerBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000008;
-        onChanged();
+        if (resizer_ != null) {
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -16185,11 +16201,6 @@ public final class WireFormats {
       return new ScatterGatherPool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_ScatterGatherPool_descriptor;
@@ -16402,11 +16413,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.ScatterGatherPool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.ScatterGatherPool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -16733,8 +16746,10 @@ public final class WireFormats {
         } else {
           genericBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (generic_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -16852,8 +16867,10 @@ public final class WireFormats {
         } else {
           withinBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (within_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -17039,11 +17056,6 @@ public final class WireFormats {
       return new TailChoppingPool();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_TailChoppingPool_descriptor;
@@ -17306,11 +17318,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.TailChoppingPool parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.TailChoppingPool parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -17665,8 +17679,10 @@ public final class WireFormats {
         } else {
           genericBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (generic_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -17784,8 +17800,10 @@ public final class WireFormats {
         } else {
           withinBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (within_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -17903,8 +17921,10 @@ public final class WireFormats {
         } else {
           intervalBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
-        onChanged();
+        if (interval_ != null) {
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -18115,11 +18135,6 @@ public final class WireFormats {
       return new AddressData();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_AddressData_descriptor;
@@ -18471,11 +18486,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.AddressData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.AddressData parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -18930,7 +18947,7 @@ public final class WireFormats {
        * @return This builder for chaining.
        */
       public Builder setPort(int value) {
-        
+
         port_ = value;
         bitField0_ |= 0x00000004;
         onChanged();
@@ -19156,11 +19173,6 @@ public final class WireFormats {
       return new RemoteRouterConfig();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.WireFormats.internal_static_RemoteRouterConfig_descriptor;
@@ -19383,11 +19395,13 @@ public final class WireFormats {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.WireFormats.RemoteRouterConfig parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.WireFormats.RemoteRouterConfig parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -19751,8 +19765,10 @@ public final class WireFormats {
         } else {
           localBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (local_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**

--- a/akka-remote/src/test/java/akka/remote/ProtobufProtocol.java
+++ b/akka-remote/src/test/java/akka/remote/ProtobufProtocol.java
@@ -84,11 +84,6 @@ public final class ProtobufProtocol {
       return new MyMessage();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.remote.ProtobufProtocol.internal_static_MyMessage_descriptor;
@@ -349,11 +344,13 @@ public final class ProtobufProtocol {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.remote.ProtobufProtocol.MyMessage parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.remote.ProtobufProtocol.MyMessage parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -626,7 +623,7 @@ public final class ProtobufProtocol {
        * @return This builder for chaining.
        */
       public Builder setId(long value) {
-        
+
         id_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -746,7 +743,7 @@ public final class ProtobufProtocol {
        * @return This builder for chaining.
        */
       public Builder setStatus(boolean value) {
-        
+
         status_ = value;
         bitField0_ |= 0x00000004;
         onChanged();

--- a/akka-remote/src/test/java/akka/remote/protobuf/v3/ProtobufProtocolV3.java
+++ b/akka-remote/src/test/java/akka/remote/protobuf/v3/ProtobufProtocolV3.java
@@ -71,11 +71,6 @@ public final class ProtobufProtocolV3 {
       return new MyMessageV3();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
-      return this.unknownFields;
-    }
-
     public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return akka.remote.protobuf.v3.ProtobufProtocolV3.internal_static_MyMessageV3_descriptor;
     }

--- a/akka-stream/src/main/java/akka/stream/StreamRefMessages.java
+++ b/akka-stream/src/main/java/akka/stream/StreamRefMessages.java
@@ -59,11 +59,6 @@ public final class StreamRefMessages {
       return new SinkRef();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_SinkRef_descriptor;
@@ -226,11 +221,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.SinkRef parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.SinkRef parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -529,8 +526,10 @@ public final class StreamRefMessages {
         } else {
           targetRefBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (targetRef_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -686,11 +685,6 @@ public final class StreamRefMessages {
       return new SourceRef();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_SourceRef_descriptor;
@@ -853,11 +847,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.SourceRef parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.SourceRef parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1156,8 +1152,10 @@ public final class StreamRefMessages {
         } else {
           originRefBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (originRef_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1316,11 +1314,6 @@ public final class StreamRefMessages {
       return new ActorRef();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_ActorRef_descriptor;
@@ -1501,11 +1494,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.ActorRef parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.ActorRef parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -1927,11 +1922,6 @@ public final class StreamRefMessages {
       return new Payload();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_Payload_descriptor;
@@ -2157,11 +2147,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.Payload parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.Payload parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -2469,7 +2461,7 @@ public final class StreamRefMessages {
        * @return This builder for chaining.
        */
       public Builder setSerializerId(int value) {
-        
+
         serializerId_ = value;
         bitField0_ |= 0x00000002;
         onChanged();
@@ -2630,11 +2622,6 @@ public final class StreamRefMessages {
       return new OnSubscribeHandshake();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_OnSubscribeHandshake_descriptor;
@@ -2797,11 +2784,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.OnSubscribeHandshake parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.OnSubscribeHandshake parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3100,8 +3089,10 @@ public final class StreamRefMessages {
         } else {
           targetRefBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (targetRef_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -3253,11 +3244,6 @@ public final class StreamRefMessages {
       return new CumulativeDemand();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_CumulativeDemand_descriptor;
@@ -3410,11 +3396,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.CumulativeDemand parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.CumulativeDemand parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -3653,7 +3641,7 @@ public final class StreamRefMessages {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -3785,11 +3773,6 @@ public final class StreamRefMessages {
       return new SequencedOnNext();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_SequencedOnNext_descriptor;
@@ -3992,11 +3975,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.SequencedOnNext parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.SequencedOnNext parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -4268,7 +4253,7 @@ public final class StreamRefMessages {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();
@@ -4351,8 +4336,10 @@ public final class StreamRefMessages {
         } else {
           payloadBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000002;
-        onChanged();
+        if (payload_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -4505,11 +4492,6 @@ public final class StreamRefMessages {
       return new RemoteStreamFailure();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_RemoteStreamFailure_descriptor;
@@ -4657,11 +4639,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.RemoteStreamFailure parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.RemoteStreamFailure parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5014,11 +4998,6 @@ public final class StreamRefMessages {
       return new RemoteStreamCompleted();
     }
 
-    @java.lang.Override
-    public final akka.protobufv3.internal.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
     public static final akka.protobufv3.internal.Descriptors.Descriptor
         getDescriptor() {
       return akka.stream.StreamRefMessages.internal_static_RemoteStreamCompleted_descriptor;
@@ -5171,11 +5150,13 @@ public final class StreamRefMessages {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
+
     public static akka.stream.StreamRefMessages.RemoteStreamCompleted parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return akka.protobufv3.internal.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
+
     public static akka.stream.StreamRefMessages.RemoteStreamCompleted parseDelimitedFrom(
         java.io.InputStream input,
         akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
@@ -5414,7 +5395,7 @@ public final class StreamRefMessages {
        * @return This builder for chaining.
        */
       public Builder setSeqNr(long value) {
-        
+
         seqNr_ = value;
         bitField0_ |= 0x00000001;
         onChanged();

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.19.2"
   val nettyVersion = "4.1.100.Final"
-  val protobufJavaVersion = "3.21.12" // also sync with protocVersion in Protobuf.scala
+  val protobufJavaVersion = "3.24.0" // also sync with protocVersion in Protobuf.scala
   val logbackVersion = "1.2.12"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -33,7 +33,7 @@ object Protobuf {
     // this keeps intellij happy for files that use the shaded protobuf
     Compile / unmanagedJars += (LocalProject("akka-protobuf-v3") / assembly).value,
     protoc := "protoc",
-    protocVersion := "3.21.12", // also sync with protobufJavaVersion in Dependencies.scala
+    protocVersion := "24.0", // 3.24.0, also sync with protobufJavaVersion in Dependencies.scala
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value


### PR DESCRIPTION
To align with the grpc bump https://github.com/akka/akka-grpc
Not important to use the same, but since we are anyway bumping.

Previous non-released bump was in #32149 

Merge, not squash, to keep commit attribution to nobody for the regenerate.
