### PR TITLE
chore: Temporary disable RemoteConnectionSpec for Aeron, #32182

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
@@ -12,6 +12,7 @@ import akka.remote.RARP
 import akka.remote.artery.Association.UidCollisionException
 import akka.remote.artery.AssociationState.UidKnown
 import akka.remote.artery.AssociationState.UidUnknown
+import akka.remote.artery.aeron.ArteryAeronUdpTransport
 import akka.testkit.{ EventFilter, ImplicitSender, TestActors, TestEvent, TestProbe }
 
 class RemoteConnectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
@@ -27,6 +28,10 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
   "Remoting between systems" should {
 
     "handle uid collision when connection TO two systems with same uid" in {
+      // FIXME temporary disabled check until #32182 is fixed
+      if (!RARP(localSystem).provider.transport.isInstanceOf[ArteryAeronUdpTransport])
+        pending
+
       val localProbe = new TestProbe(localSystem)
       val localPort = RARP(localSystem).provider.getDefaultAddress.getPort().get
 
@@ -109,6 +114,10 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
     }
 
     "handle uid collision when connection FROM two systems with same uid" in {
+      // FIXME temporary disabled check until #32182 is fixed
+      if (!RARP(localSystem).provider.transport.isInstanceOf[ArteryAeronUdpTransport])
+        pending
+
       // same kind of test as above, but connection is first established from the other remote systems
       val localProbe = new TestProbe(localSystem)
       val localPort = RARP(localSystem).provider.getDefaultAddress.getPort().get


### PR DESCRIPTION
It's on my todo list to look closer at the test failure in #32182 but more important things pop up all the time. Disable for now so that not nightlies are failing all the time.