### PR TITLE
Remove sigar-loader from "test" config dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -148,8 +148,7 @@ object Dependencies {
     }
 
     object Provided {
-      // TODO remove from "test" config
-      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
+      val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided" // ApacheV2
 
       val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided;test"
 


### PR DESCRIPTION
I found this todo. 

My personal fork is green with these changes. 
