### PR TITLE
docs: clarify example code of reliable delivery

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/docs/delivery/WorkPullingDocExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/delivery/WorkPullingDocExample.scala
@@ -130,10 +130,12 @@ object WorkPullingDocExample {
 
   }
 
+  //#ask
+
   final class ImageWorkManager(
       context: ActorContext[ImageWorkManager.Command],
       stashBuffer: StashBuffer[ImageWorkManager.Command]) {
-
+    //#ask
     import ImageWorkManager._
 
     private def waitForNext(): Behavior[Command] = {
@@ -227,7 +229,9 @@ object WorkPullingDocExample {
       //#ask
     }
     //#producer
+    //#ask
   }
+  //#ask
   //#producer
 
 }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

## Motivation

In the original "ask" case, there was some ambiguity about where the `stashBuffer` was obtained from. This PR makes the code in that case more complete, and the code of `Work pulling` case will not any changes.

## Before

<img width="463" alt="截屏2023-10-23 14 30 01" src="https://github.com/akka/akka/assets/26020358/b6a1f631-9671-4e6d-acb8-532501c34032">


## After

<img width="849" alt="截屏2023-10-23 14 29 21" src="https://github.com/akka/akka/assets/26020358/5ab51b4d-ed6c-4796-aa09-2c2d8ff33e4a">
