### PR TITLE
Remove unnecessary todo from DurableStateStoreRegistry

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreRegistry.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreRegistry.scala
@@ -85,9 +85,7 @@ class DurableStateStoreRegistry(system: ExtendedActorSystem)
    * Java API: Returns the [[akka.persistence.state.javadsl.DurableStateStore]] specified by the given
    * configuration entry.
    */
-  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[_]](
-      @unused clazz: Class[T], // FIXME generic Class could be problematic in Java
-      pluginId: String): T = {
+  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[_]](@unused clazz: Class[T], pluginId: String): T = {
     pluginFor(pluginIdOrDefault(pluginId), pluginConfig(pluginId)).javadslPlugin.asInstanceOf[T]
   }
 


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

This code was created in [this PR](https://github.com/akka/akka/pull/30280/files#diff-7789a59ee91f4575ea65c0fa3af6884ddb09dea7c41209a577bcf20040d09117). This PR is related to #30277 . This issue was released 2 years ago.

Should this todo be removed?