### PR TITLE
Remove unnecessary todo from MetrciKeyDSL

### DIFF
--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricKeyDSL.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricKeyDSL.scala
@@ -18,7 +18,6 @@ trait MetricKeyDSL {
   object MetricKey {
     def fromString(root: String) = MetricKey(sanitizeMetricKeyPart(root))
 
-    // todo not sure what else needs replacing, while keeping key as readable as can be
     private def sanitizeMetricKeyPart(keyPart: String) =
       keyPart
         .replaceAll("""\.\.\.""", "\u2026") // ... => …


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

This code was created in [this commit](https://github.com/akka/akka/commit/684c0279ec2e7e1b9dc669b22f076e6ab3b1e00b)  many years ago.

Should this todo be removed?

