### PR TITLE
Remove unnecessary todo from ReplicatedAuctionExampleSpec

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedAuctionExampleSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedAuctionExampleSpec.scala
@@ -199,7 +199,6 @@ object ReplicatedAuctionExampleSpec {
             case Close =>
               context.log.info("Close")
               require(shouldClose(state))
-              // TODO send email (before or after persisting)
               Effect.persist(WinnerDecided(replicationContext.replicaId, state.highestBid, state.highestCounterOffer))
             case _: OfferBid =>
               // auction finished, no more bids accepted


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

I think it's better to leave only a comment. Todo items should indicate the problems, but in this case, it's just a note.