### PR TITLE
chore: fix logging for optional snapshots when deleting events

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -81,7 +81,7 @@ private[akka] final class BehaviorSetup[C, E, S](
         case _                                              => false
       })) {
     throw new IllegalArgumentException(
-      "Retention criteria with delete events can't be used together with snapshot-is-optional=false. " +
+      "Retention criteria with delete events can't be used together with snapshot-is-optional=true. " +
       "That can result in wrong recovered state if snapshot load fails.")
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -161,7 +161,7 @@ private[akka] trait JournalInteractions[C, E, S] {
   protected def internalDeleteEvents(lastSequenceNr: Long, toSequenceNr: Long): Unit = {
     if (setup.isSnapshotOptional) {
       setup.internalLogger.warn(
-        "Delete events shouldn't be used together with snapshot-is-optional=false. " +
+        "Delete events shouldn't be used together with snapshot-is-optional=true. " +
         "That can result in wrong recovered state if snapshot load fails.")
     }
     if (toSequenceNr > 0) {


### PR DESCRIPTION
Here, optional refers to fact if loading a snapshot is allowed to fail. 

It may even be that this logging is currently not triggered based on this condition: https://github.com/akka/akka/blob/main/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala#L79-L86