### PR TITLE
Remove unnecessary todo from SnapshotFailureRobustnessSpec

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotFailureRobustnessSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotFailureRobustnessSpec.scala
@@ -39,7 +39,6 @@ object SnapshotFailureRobustnessSpec {
 
   class DeleteSnapshotTestPersistentActor(name: String, probe: ActorRef) extends NamedPersistentActor(name) {
 
-    // TODO do we call it "snapshot store" or "snapshot plugin", small inconsistency here
     override def snapshotPluginId: String =
       "akka.persistence.snapshot-store.local-delete-fail"
 


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

The method `snapshotPluginId` and the setting `akka.persistence.snapshot-store` are public API and shouldn't be changed (maybe In a major release ).

It was done many [years ago](https://github.com/akka/akka/commit/63baaf1b2b3d0fc6c1971307fd1e66d74106c968#diff-bced7afff776a8dac97599d2e1b09a9ff7f3a5526c373f3e9eeb8e1c0c2c3807)

Is it better to remove this todo?