### PR TITLE
Remove unnecessary todo from TraversalBuilder

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -626,7 +626,6 @@ import akka.util.unused
  */
 @InternalApi private[akka] object LinearTraversalBuilder {
 
-  // TODO: Remove
   private val cachedEmptyLinear =
     LinearTraversalBuilder(OptionVal.None, OptionVal.None, 0, 0, PushNotUsed, OptionVal.None, Attributes.none)
 


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

This is [an old todo](https://github.com/akka/akka/commit/ba63c7af8dab0292f07082c63749d4fef11e6380#diff-b883c24816652f3ab9c42e10b1820d8367228d48a016fa2fa1595cdae3bbea6bR462). 

Is it better to remove it or add some explanation?
