### PR TITLE
feat: Allow indirect replication

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventPublishingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventPublishingSpec.scala
@@ -205,7 +205,7 @@ class ReplicatedEventPublishingSpec
       probe.expectMessage(Set("one", "two", "three"))
     }
 
-    "ignore a published event from an unknown replica" in {
+    "accept a published event from an unknown replica" in {
       val id = nextEntityId()
       val actor = spawn(MyReplicatedBehavior(id, DCA, Set(DCA, DCB)))
       val probe = createTestProbe[Any]()
@@ -224,7 +224,7 @@ class ReplicatedEventPublishingSpec
       probe.expectMessage(Done)
 
       actor ! MyReplicatedBehavior.Get(probe.ref)
-      probe.expectMessage(Set("one", "three"))
+      probe.expectMessage(Set("one", "two", "three"))
     }
 
     "ignore an already seen event from a replica" in {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReplicaId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReplicaId.scala
@@ -7,4 +7,6 @@ package akka.persistence.typed
 /**
  * Identifies a replica in Replicated Event Sourcing, could be a datacenter name or a logical identifier.
  */
-final case class ReplicaId(id: String)
+final case class ReplicaId(id: String) {
+  override def toString: String = id
+}


### PR DESCRIPTION
* it was only using events from the origin replica
* this allows indirect replication, e.g. A writes e1, replicates to B, and C receives e1 from B
* will be needed for some edge topologies
* also remove the check that replica of received event is included in allReplicas
* there will be a corresponding change in Projection gRPC

See https://github.com/akka/akka-projection/issues/1069