### PR TITLE
Remove unnecessary todo from PhasedFusingActorMaterializer

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -686,7 +686,7 @@ private final case class SavedIslandData(
     islandName: String,
     subflowFuser: OptionVal[GraphInterpreterShell => ActorRef])
     extends PhaseIsland[GraphStageLogic] {
-  // TODO: remove these
+
   private val logicArrayType = Array.empty[GraphStageLogic]
   private[this] val logics = new util.ArrayList[GraphStageLogic](16)
 


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

This is [an old todo](https://github.com/akka/akka/commit/ba63c7af8dab0292f07082c63749d4fef11e6380).

I think it's about size optimization. Is it better to remove it or add some explanation? 

