### PR TITLE
Provide monadic conversions for StatusReply

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
+++ b/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
@@ -47,6 +47,21 @@ final class StatusReply[+T] private (private val status: Try[T]) {
   def isError: Boolean = status.isFailure
   def isSuccess: Boolean = status.isSuccess
 
+  /**
+   * Return this StatusReply as a Try.
+   */
+  def toTry: Try[T] = status
+
+  /**
+   * Return this StatusReply as an Either.
+   */
+  def toEither: Either[Throwable, T] = status.toEither
+
+  /**
+   * Return this StatusReply as an Option, returning None and discarding the error if it's an Error.
+   */
+  def toOption: Option[T] = status.toOption
+
   override def equals(other: Any): Boolean = other match {
     case that: StatusReply[_] => status == that.status
     case _                    => false


### PR DESCRIPTION
Sometimes you want to work with a StatusReply in the context of monadic processing with Try, Either or Option, rather than always pattern matching on it. This provides convenience methods to do that.