### PR TITLE
Remove unnecessary todo from DurableDataSpec

### DIFF
--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -272,8 +272,6 @@ abstract class DurableDataSpec(multiNodeConfig: DurableDataSpecConfig)
     val r = newReplicator()
 
     runOn(first) {
-      // FIXME
-      log.debug("sending message with sender: {}", implicitly[ActorRef])
       r ! Update(KeyC, ORSet.empty[String], WriteLocal)(_ :+ myself.name)
       expectMsg(UpdateSuccess(KeyC, None))
     }


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

It [was added long time ago](https://github.com/akka/akka/commit/6c13949aecd52d94936118fbbd909cc2e3d6653e#diff-6503f04231ea4645372d1c9f9c87f30f2a4510f1264cef0a4874945b76e0729bR212).

It's hard to understand the meaning. Should it be deleted or should be added some additional information?