### PR TITLE
chore: Use JDK 17 in multi-node tests

### DIFF
--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: temurin:1.11.0.17
+          jvm: temurin:1.17
 
       - name: Multi node test
         run: |
@@ -157,10 +157,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: temurin:1.11.0.17
+          jvm: temurin:1.17
 
       - name: Multi node test with Artery Aeron UDP
         run: |

--- a/kubernetes/setup.sh
+++ b/kubernetes/setup.sh
@@ -16,7 +16,7 @@ for i in `seq 1 "${NUM_OF_NODES}"`;
 do
   cat ./kubernetes/test-node-base.yaml | sed "s/test-nodeX/test-node${i}/" > ".tmp/test-node${i}.yml"
   echo $i
-  echo "test-node${i}:/usr/local/openjdk-11/bin/java -Dmultinode.protocol=$PROTOCOL -Dmultinode.port=5000 -Dmultinode.udp.port=6000" >> ${DEST_HOST_FILE}
+  echo "test-node${i}:/opt/java/openjdk/bin/java -Dmultinode.protocol=$PROTOCOL -Dmultinode.port=5000 -Dmultinode.udp.port=6000" >> ${DEST_HOST_FILE}
 done
 
 kubectl apply -f ${TMP_DIR}

--- a/kubernetes/test-node-base.yaml
+++ b/kubernetes/test-node-base.yaml
@@ -27,7 +27,7 @@ spec:
                         - multi-node-test
                 topologyKey: kubernetes.io/hostname
       containers:
-      - image: openjdk:11
+      - image: docker.io/library/eclipse-temurin:17.0.8.1_1-jre
         command: ["sleep", "infinity"]
         resources:
           requests:


### PR DESCRIPTION
Multi-node tests with Aeron UDP is constantly failing, different tests failing. Maybe far fetched, but first switching to JDK 17. In logs we can see many "Scheduled sending of heartbeat was delayed", which is not good sign. Then our other timing assumptions may be completely off. That is only seen when running with Aeron.