### PR TITLE
build: Harden flaky Aeron tests in CI

### DIFF
--- a/.github/workflows/multi-node-aeron.yml
+++ b/.github/workflows/multi-node-aeron.yml
@@ -1,8 +1,8 @@
-name: Multi node test
+name: Multi node test with Aeron
 
 on:
   schedule:
-    - cron: '0 2 * * 1,3,5'
+    - cron: '0 4 * * 1,3'
   workflow_dispatch:
 
 permissions:
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-multi-node-tests:
-    name: Multi Node Test
+  run-multi-node-aeron-tests:
+    name: Multi Node Test with Artery Aeron UDP transport
     runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
@@ -32,7 +32,6 @@ jobs:
       - name: Install Kubectl
         run: |
           sudo snap install kubectl --classic
-
       # https://github.com/google-github-actions/auth/releases
       # v1.0.0
       - name: Authenticate to Google Cloud
@@ -53,12 +52,12 @@ jobs:
           gcloud components install gke-gcloud-auth-plugin
           gcloud config set compute/region us-central1
           gcloud config set compute/zone us-central1-c
-          ./kubernetes/create-cluster-gke.sh "akka-multi-node-${GITHUB_RUN_ID}"
+          ./kubernetes/create-cluster-gke.sh "akka-artery-aeron-cluster-${GITHUB_RUN_ID}"
 
       - name: Setup Pods
         run: |
           # Start 10 pods. At most 10 MultiJvmNode (akka.cluster.StressSpec is currently disabled).
-          ./kubernetes/setup.sh 10 multi-node-test.hosts tcp
+          ./kubernetes/setup.sh 10 multi-node-test.hosts udp
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
@@ -68,16 +67,17 @@ jobs:
         with:
           jvm: temurin:1.17
 
-      - name: Multi node test
+      - name: Multi node test with Artery Aeron UDP
         run: |
           cat multi-node-test.hosts
           cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
-            -Dakka.test.tags.exclude=gh-exclude,timing \
             -Dakka.cluster.assert=on \
+            -Dakka.remote.artery.transport=aeron-udp \
             -Dsbt.override.build.repos=false \
+            -Dakka.test.tags.exclude=gh-exclude,gh-exclude-aeron,timing \
             -Dakka.test.multi-node=true \
             -Dakka.test.multi-node.targetDirName=${PWD}/target/${{ github.run_id }} \
             -Dakka.test.multi-node.java=${JAVA_HOME}/bin/java \
@@ -108,4 +108,4 @@ jobs:
         if: ${{ always() }}
         shell: bash {0}
         run: |
-          gcloud container clusters delete "akka-multi-node-${GITHUB_RUN_ID}" --quiet
+          gcloud container clusters delete "akka-artery-aeron-cluster-${GITHUB_RUN_ID}" --quiet

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -87,9 +87,6 @@ jobs:
             -Dmultinode.Xlog:gc \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
             -Daeron.dir=/opt/volumes/media-driver \
-            -Dmultinode.Daeron.dir=/opt/volumes/media-driver \
-            -Daeron.term.buffer.length=33554432 \
-            -Dmultinode.Daeron.term.buffer.length=33554432 \
             multiNodeTest
 
       - name: Email on failure
@@ -107,7 +104,7 @@ jobs:
           body: |
             Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
             https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      
+
       - name: Cleanup the environment
         if: ${{ always() }}
         shell: bash {0}
@@ -181,10 +178,6 @@ jobs:
             -Dmultinode.Xmx512M \
             -Dmultinode.Xlog:gc \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
-            -Daeron.dir=/opt/volumes/media-driver \
-            -Dmultinode.Daeron.dir=/opt/volumes/media-driver \
-            -Daeron.term.buffer.length=33554432 \
-            -Dmultinode.Daeron.term.buffer.length=33554432 \
             multiNodeTest
 
       - name: Email on failure
@@ -202,7 +195,7 @@ jobs:
           body: |
             Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
             https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-      
+
       - name: Cleanup the environment
         if: ${{ always() }}
         shell: bash {0}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -215,8 +215,6 @@ jobs:
           -Dakka.test.tags.exclude=gh-exclude,gh-exclude-aeron,timing \
           -Dakka.test.multi-in-test=false \
           -Dakka.cluster.assert=on \
-          -Daeron.dir=/opt/volumes/media-driver \
-          -Daeron.term.buffer.length=33554432 \
           clean ${{ matrix.command }}
 
       - name: Email on failure

--- a/kubernetes/test-node-base.yaml
+++ b/kubernetes/test-node-base.yaml
@@ -31,10 +31,10 @@ spec:
         command: ["sleep", "infinity"]
         resources:
           requests:
-            memory: "3Gi"
+            memory: "10Gi"
             cpu: "3500m"
           limits:
-            memory: "3Gi"
+            memory: "10Gi"
         lifecycle:
           postStart:
             exec:
@@ -74,7 +74,7 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
-            sizeLimit: 1Gi
+            sizeLimit: 8Gi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/test-node-base.yaml
+++ b/kubernetes/test-node-base.yaml
@@ -32,7 +32,7 @@ spec:
         resources:
           requests:
             memory: "3Gi"
-            cpu: "2800m"
+            cpu: "3500m"
           limits:
             memory: "3Gi"
         lifecycle:
@@ -45,8 +45,8 @@ spec:
         imagePullPolicy: Always
         name: multi-test-nodeX
         volumeMounts:
-          - mountPath: /opt/volumes/media-driver
-            name: media-driver
+          - mountPath: /dev/shm
+            name: dshm
         ports:
         - name: web
           containerPort: 80
@@ -70,9 +70,11 @@ spec:
           containerPort: 4711
           protocol: TCP
       volumes:
-        # Needed for Aeron tests: https://github.com/real-logic/aeron/blob/master/README.md#troubleshooting
-        - name: media-driver
-          emptyDir: {}
+        # Needed for Aeron tests, increase /dev/shm
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
* increase /dev/shm and use that (by default)
* use default term buffer size
* increase cpu requests, shouldn't matter but corresponds to what we want to use, 2 pods per node

This looks very promising. I have tried in a gke cluster. Verified with `df -h`. It was 64 MB and now 1G.

No more "Scheduled sending of heartbeat was delayed".

This wasn't possible when we tried last time https://github.com/akka/akka/issues/30601