### PR TITLE
Remove unnecessary todo from akka-cluster script

### DIFF
--- a/akka-cluster/jmx-client/akka-cluster
+++ b/akka-cluster/jmx-client/akka-cluster
@@ -12,7 +12,7 @@
 #      ...
 # ==============================================================
 
-# FIXME support authentication? if so add: -Dcom.sun.management.jmxremote.password.file=<path to file> AND tweak this script to support it (arg need 'user:passwd' instead of '-')
+# support authentication? if so add: -Dcom.sun.management.jmxremote.password.file=<path to file> AND tweak this script to support it (arg need 'user:passwd' instead of '-')
 
 
 


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found this.

It [was added long time ago](https://github.com/akka/akka/commit/a400b90d873a8886a8785a27a9c65ce67ba3a63d#diff-9166e2b798d9d6ddbb8d031a44f70b110475fd2476046524fe3d946e32bab2f7).

I think it's better to leave only a comment. Todo items should indicate the problems, but in this case, it's just a note.