### PR TITLE
feat: ChangeEvent from Durable State

### DIFF
--- a/akka-docs/src/main/java/docs/persistence/state/MyChangeEventJavaStateStore.java
+++ b/akka-docs/src/main/java/docs/persistence/state/MyChangeEventJavaStateStore.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.persistence.state;
+
+// #plugin-imports
+
+import akka.Done;
+import akka.actor.ExtendedActorSystem;
+import akka.persistence.state.javadsl.DurableStateUpdateWithChangeEventStore;
+import akka.persistence.state.javadsl.GetObjectResult;
+import com.typesafe.config.Config;
+import java.util.concurrent.CompletionStage;
+
+// #plugin-imports
+
+// #state-store-plugin-api
+class MyChangeEventJavaStateStore<A> implements DurableStateUpdateWithChangeEventStore<A> {
+
+  private ExtendedActorSystem system;
+  private Config config;
+  private String cfgPath;
+
+  public MyChangeEventJavaStateStore(ExtendedActorSystem system, Config config, String cfgPath) {
+    this.system = system;
+    this.config = config;
+    this.cfgPath = cfgPath;
+  }
+
+  /**
+   * Will delete the state by setting it to the empty state and the revision number will be
+   * incremented by 1.
+   */
+  @Override
+  public CompletionStage<Done> deleteObject(String persistenceId, long revision) {
+    // implement deleteObject here
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Done> deleteObject(
+      String persistenceId, long revision, Object changeEvent) {
+    // implement deleteObject here
+    return null;
+  }
+
+  /** Returns the current state for the given persistence id. */
+  @Override
+  public CompletionStage<GetObjectResult<A>> getObject(String persistenceId) {
+    // implement getObject here
+    return null;
+  }
+
+  /**
+   * Will persist the latest state. If it’s a new persistence id, the record will be inserted.
+   *
+   * <p>In case of an existing persistence id, the record will be updated only if the revision
+   * number of the incoming record is 1 more than the already existing record. Otherwise persist
+   * will fail.
+   */
+  @Override
+  public CompletionStage<Done> upsertObject(
+      String persistenceId, long revision, Object value, String tag) {
+    // implement upsertObject here
+    return null;
+  }
+
+  /** Deprecated. Use the deleteObject overload with revision instead. */
+  @Override
+  public CompletionStage<Done> deleteObject(String persistenceId) {
+    return deleteObject(persistenceId, 0);
+  }
+
+  @Override
+  public CompletionStage<Done> upsertObject(
+      String persistenceId, long revision, A value, String tag, Object changeEvent) {
+    // implement deleteObject here
+    return null;
+  }
+}
+// #state-store-plugin-api

--- a/akka-docs/src/main/paradox/durable-state/state-store-plugin.md
+++ b/akka-docs/src/main/paradox/durable-state/state-store-plugin.md
@@ -24,6 +24,16 @@ Scala
 Java
 :  @@snip [MyJavaStateStore.java](/akka-docs/src/main/java/docs/persistence/state/MyJavaStateStore.java) { #state-store-plugin-api }
 
+A durable state store plugin may also extend `DurableStateUpdateWithChangeEventStore` to store additional change event.
+
+`DurableStateUpdateWithChangeEventStore` is an interface and the methods to be implemented are:
+
+Scala
+:  @@snip [MyStateStore.scala](/akka-docs/src/main/scala/docs/persistence/state/MyStateStore.scala) { //#plugin-api-change-event }
+
+Java
+:  @@snip [MyChangeEventJavaStateStore.java](/akka-docs/src/main/java/docs/persistence/state/MyChangeEventJavaStateStore.java) { #state-store-plugin-api }
+
 ## State Store provider
 
 A `DurableStateStoreProvider` needs to be implemented to be able to create the plugin itself:

--- a/akka-docs/src/main/scala/docs/persistence/state/MyStateStore.scala
+++ b/akka-docs/src/main/scala/docs/persistence/state/MyStateStore.scala
@@ -9,8 +9,11 @@ import akka.actor.ExtendedActorSystem
 import akka.persistence.state.{ DurableStateStoreProvider, DurableStateStoreRegistry }
 import akka.persistence.state.scaladsl.{ DurableStateStore, DurableStateUpdateStore, GetObjectResult }
 import com.typesafe.config.Config
+
 import akka.persistence.state.javadsl.{ DurableStateStore => JDurableStateStore }
 import scala.concurrent.Future
+
+import akka.persistence.state.scaladsl.DurableStateUpdateWithChangeEventStore
 
 //#plugin-provider
 class MyStateStoreProvider(system: ExtendedActorSystem, config: Config, cfgPath: String)
@@ -57,3 +60,48 @@ class MyStateStore[A](system: ExtendedActorSystem, config: Config, cfgPath: Stri
   override def getObject(persistenceId: String): Future[GetObjectResult[A]] = ???
 }
 //#plugin-api
+
+//#plugin-api-change-event
+class MyChangeEventStateStore[A](system: ExtendedActorSystem, config: Config, cfgPath: String)
+    extends DurableStateUpdateWithChangeEventStore[A] {
+
+  /**
+   * The `changeEvent` is written to the event journal.
+   * Same `persistenceId` is used in the journal and the `revision` is used as `sequenceNr`.
+   *
+   * @param revision sequence number for optimistic locking. starts at 1.
+   */
+  override def upsertObject(
+      persistenceId: String,
+      revision: Long,
+      value: A,
+      tag: String,
+      changeEvent: Any): Future[Done] = ???
+
+  override def deleteObject(persistenceId: String, revision: Long, changeEvent: Any): Future[Done] = ???
+
+  /**
+   * Will persist the latest state. If it’s a new persistence id, the record will be inserted.
+   *
+   * In case of an existing persistence id, the record will be updated only if the revision
+   * number of the incoming record is 1 more than the already existing record. Otherwise persist will fail.
+   */
+  override def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): Future[Done] = ???
+
+  /**
+   * Deprecated. Use the deleteObject overload with revision instead.
+   */
+  override def deleteObject(persistenceId: String): Future[Done] = deleteObject(persistenceId, 0)
+
+  /**
+   * Will delete the state by setting it to the empty state and the revision number will be incremented by 1.
+   */
+  override def deleteObject(persistenceId: String, revision: Long): Future[Done] = ???
+
+  /**
+   * Returns the current state for the given persistence id.
+   */
+  override def getObject(persistenceId: String): Future[GetObjectResult[A]] = ???
+
+}
+//#plugin-api-change-event

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -15,8 +15,11 @@ import akka.japi.Pair
 import akka.persistence.query.DurableStateChange
 import akka.persistence.query.Offset
 import akka.persistence.query.javadsl.{ DurableStateStorePagedPersistenceIdsQuery, DurableStateStoreQuery }
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.query.typed.javadsl.CurrentEventsBySliceQuery
 import akka.persistence.query.typed.javadsl.DurableStateStoreBySliceQuery
-import akka.persistence.state.javadsl.DurableStateUpdateStore
+import akka.persistence.query.typed.javadsl.EventsBySliceQuery
+import akka.persistence.state.javadsl.DurableStateUpdateWithChangeEventStore
 import akka.persistence.state.javadsl.GetObjectResult
 import akka.persistence.testkit.state.scaladsl.{ PersistenceTestKitDurableStateStore => SStore }
 import akka.stream.javadsl.Source
@@ -26,10 +29,12 @@ object PersistenceTestKitDurableStateStore {
 }
 
 class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
-    extends DurableStateUpdateStore[A]
+    extends DurableStateUpdateWithChangeEventStore[A]
     with DurableStateStoreQuery[A]
     with DurableStateStoreBySliceQuery[A]
-    with DurableStateStorePagedPersistenceIdsQuery[A] {
+    with DurableStateStorePagedPersistenceIdsQuery[A]
+    with CurrentEventsBySliceQuery
+    with EventsBySliceQuery {
 
   def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =
     stateStore.getObject(persistenceId).map(_.toJava)(stateStore.system.dispatcher).toJava
@@ -37,10 +42,16 @@ class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
   def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): CompletionStage[Done] =
     stateStore.upsertObject(persistenceId, seqNr, value, tag).toJava
 
+  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String, changeEvent: Any): CompletionStage[Done] =
+    stateStore.upsertObject(persistenceId, seqNr, value, tag, changeEvent).toJava
+
   def deleteObject(persistenceId: String): CompletionStage[Done] = CompletableFuture.completedFuture(Done)
 
   def deleteObject(persistenceId: String, revision: Long): CompletionStage[Done] =
     stateStore.deleteObject(persistenceId, revision).toJava
+
+  def deleteObject(persistenceId: String, revision: Long, changeEvent: Any): CompletionStage[Done] =
+    stateStore.deleteObject(persistenceId, revision, changeEvent).toJava
 
   def changes(tag: String, offset: Offset): Source[DurableStateChange[A], akka.NotUsed] = {
     stateStore.changes(tag, offset).asJava
@@ -77,4 +88,23 @@ class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
   override def currentPersistenceIds(afterId: Optional[String], limit: Long): Source[String, NotUsed] =
     stateStore.currentPersistenceIds(afterId.asScala, limit).asJava
 
+  /**
+   * For change events.
+   */
+  override def currentEventsBySlices[Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset): Source[EventEnvelope[Event], NotUsed] =
+    stateStore.currentEventsBySlices(entityType, minSlice, maxSlice, offset).asJava
+
+  /**
+   * For change events.
+   */
+  override def eventsBySlices[Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset): Source[EventEnvelope[Event], NotUsed] =
+    stateStore.eventsBySlices(entityType, minSlice, maxSlice, offset).asJava
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/ChangeEventSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/ChangeEventSpec.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.persistence.query.Offset
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.query.typed.scaladsl.CurrentEventsBySliceQuery
+import akka.persistence.query.typed.scaladsl.EventsBySliceQuery
+import akka.persistence.state.DurableStateStoreRegistry
+import akka.persistence.testkit.PersistenceTestKitDurableStateStorePlugin
+import akka.persistence.typed.PersistenceId
+import akka.stream.scaladsl.Sink
+import akka.stream.testkit.scaladsl.TestSink
+
+object ChangeEventSpec {
+
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
+    akka.loglevel = INFO
+    """))
+
+  sealed trait Command
+  final case class Update(value: String, replyTo: ActorRef[Done]) extends Command
+  final case class Delete(replyTo: ActorRef[Done]) extends Command
+
+  def behaviorWithChangeEvent(persistenceId: PersistenceId, probe: ActorRef[String]): Behavior[Command] = {
+    val changeEventHandler = ChangeEventHandler[String, String](updateHandler = { (previousState, newState) =>
+      val chgEvent = newState.replace(previousState, "")
+      probe ! s"update: $previousState, $newState => $chgEvent"
+      chgEvent
+    }, deleteHandler = { previousState =>
+      val chgEvent = "DEL"
+      probe ! s"delete: $previousState => $chgEvent"
+      chgEvent
+    })
+
+    DurableStateBehavior[Command, String](
+      persistenceId,
+      emptyState = "",
+      commandHandler = (state, command) => {
+        command match {
+          case Update(value, replyTo) =>
+            Effect.persist(state + value).thenReply(replyTo)(_ => Done)
+          case Delete(replyTo) =>
+            Effect.delete().thenReply(replyTo)((_: String) => Done)
+
+        }
+      }).withChangeEventHandler(changeEventHandler)
+  }
+}
+
+class ChangeEventSpec extends ScalaTestWithActorTestKit(ChangeEventSpec.conf) with AnyWordSpecLike with LogCapturing {
+  import ChangeEventSpec._
+
+  "DurableStateBehavior with change event" must {
+    "call the change event handler" in {
+      val changeHandlerProbe = TestProbe[String]()
+      val b = behaviorWithChangeEvent(PersistenceId("Test", "p1"), changeHandlerProbe.ref)
+      val ref = spawn(b)
+      ref ! Update("a", system.ignoreRef)
+      changeHandlerProbe.expectMessage("update: , a => a")
+      ref ! Update("b", system.ignoreRef)
+      changeHandlerProbe.expectMessage("update: a, ab => b")
+      ref ! Update("c", system.ignoreRef)
+      changeHandlerProbe.expectMessage("update: ab, abc => c")
+    }
+
+    "call the delete change event handler" in {
+      val probe = TestProbe[String]()
+      val b = behaviorWithChangeEvent(PersistenceId("Test", "p2"), probe.ref)
+      val ref = spawn(b)
+      ref ! Update("a", system.ignoreRef)
+      probe.expectMessage("update: , a => a")
+      ref ! Update("b", system.ignoreRef)
+      probe.expectMessage("update: a, ab => b")
+      ref ! Delete(system.ignoreRef)
+      probe.expectMessage("delete: ab => DEL")
+    }
+
+    "persist change event and retrieve with currentEventsBySlices" in {
+      val replyProbe = TestProbe[Done]()
+      val probe = TestProbe[String]()
+      val pid = PersistenceId("Test", "p3")
+
+      val b = behaviorWithChangeEvent(pid, probe.ref)
+      val ref = spawn(b)
+      ref ! Update("a", system.ignoreRef)
+      ref ! Update("b", system.ignoreRef)
+      ref ! Update("c", system.ignoreRef)
+      ref ! Delete(replyProbe.ref)
+      replyProbe.expectMessage(Done)
+
+      val query = DurableStateStoreRegistry(system)
+        .durableStateStoreFor(PersistenceTestKitDurableStateStorePlugin.PluginId)
+        .asInstanceOf[CurrentEventsBySliceQuery]
+      val sliceRange = query.sliceRanges(1).head
+      val currentEventsBySlices =
+        query
+          .currentEventsBySlices[String](pid.entityTypeHint, sliceRange.min, sliceRange.max, Offset.noOffset)
+          .filter(_.persistenceId == pid.id)
+          .runWith(Sink.seq)
+          .futureValue
+
+      currentEventsBySlices.map(_.event) shouldBe Vector("a", "b", "c", "DEL")
+    }
+
+    "persist change event and retrieve with eventsBySlices" in {
+      val replyProbe = TestProbe[Done]()
+      val probe = TestProbe[String]()
+      val pid = PersistenceId("Test", "p4")
+
+      val query = DurableStateStoreRegistry(system)
+        .durableStateStoreFor(PersistenceTestKitDurableStateStorePlugin.PluginId)
+        .asInstanceOf[EventsBySliceQuery]
+      val sliceRange = query.sliceRanges(1).head
+      val eventsBySlices =
+        query
+          .eventsBySlices[String](pid.entityTypeHint, sliceRange.min, sliceRange.max, Offset.noOffset)
+          .filter(_.persistenceId == pid.id)
+          .runWith(TestSink[EventEnvelope[String]]())
+      eventsBySlices.request(100)
+
+      val b = behaviorWithChangeEvent(pid, probe.ref)
+      val ref = spawn(b)
+      ref ! Update("a", system.ignoreRef)
+      ref ! Update("b", system.ignoreRef)
+      ref ! Update("c", replyProbe.ref)
+      replyProbe.expectMessage(Done)
+
+      eventsBySlices.expectNext().event shouldBe "a"
+      eventsBySlices.expectNext().event shouldBe "b"
+      eventsBySlices.expectNext().event shouldBe "c"
+
+      ref ! Update("d", system.ignoreRef)
+      ref ! Delete(replyProbe.ref)
+      eventsBySlices.expectNext().event shouldBe "d"
+      eventsBySlices.expectNext().event shouldBe "DEL"
+    }
+  }
+}

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/ChangeEventSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/ChangeEventSpec.scala
@@ -34,11 +34,12 @@ object ChangeEventSpec {
   final case class Delete(replyTo: ActorRef[Done]) extends Command
 
   def behaviorWithChangeEvent(persistenceId: PersistenceId, probe: ActorRef[String]): Behavior[Command] = {
-    val changeEventHandler = ChangeEventHandler[String, String](updateHandler = { (previousState, newState) =>
-      val chgEvent = newState.replace(previousState, "")
-      probe ! s"update: $previousState, $newState => $chgEvent"
-      chgEvent
-    }, deleteHandler = { previousState =>
+    val changeEventHandler = ChangeEventHandler[Command, String, String](updateHandler = {
+      (previousState, newState, _) =>
+        val chgEvent = newState.replace(previousState, "")
+        probe ! s"update: $previousState, $newState => $chgEvent"
+        chgEvent
+    }, deleteHandler = { (previousState, _) =>
       val chgEvent = "DEL"
       probe ! s"delete: $previousState => $chgEvent"
       chgEvent

--- a/akka-persistence-typed/src/main/mima-filters/2.9.0.backwards.excludes/ChangeEventHandler.excludes
+++ b/akka-persistence-typed/src/main/mima-filters/2.9.0.backwards.excludes/ChangeEventHandler.excludes
@@ -1,0 +1,2 @@
+# addition to @DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.persistence.typed.state.scaladsl.DurableStateBehavior.withChangeEventHandler")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -1008,7 +1008,7 @@ private[akka] object Running {
         unstashAll()
         behavior
 
-      case callback: Callback[_] =>
+      case callback: Callback[Any] @unchecked =>
         callback.sideEffect(state.state)
         behavior
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -1011,6 +1011,11 @@ private[akka] object Running {
       case callback: Callback[Any] @unchecked =>
         callback.sideEffect(state.state)
         behavior
+
+      case _ =>
+        // case _: Callback[S] should be covered by above case, but needed needed to silence Scala 3 exhaustive match
+        throw new IllegalStateException(
+          s"Unexpected effect [${effect.getClass.getName}]. This is a bug, please report https://github.com/akka/akka/issues")
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
@@ -17,9 +17,11 @@ import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.state.DurableStateStoreRegistry
 import akka.persistence.state.scaladsl.DurableStateUpdateStore
+import akka.persistence.state.scaladsl.DurableStateUpdateWithChangeEventStore
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.SnapshotAdapter
 import akka.persistence.typed.state.internal.InternalProtocol.RecoveryTimeout
+import akka.persistence.typed.state.scaladsl.ChangeEventHandler
 import akka.persistence.typed.state.scaladsl.DurableStateBehavior
 import akka.util.OptionVal
 
@@ -38,16 +40,23 @@ private[akka] final class BehaviorSetup[C, S](
     var holdingRecoveryPermit: Boolean,
     val settings: DurableStateSettings,
     val stashState: StashState,
-    private val internalLoggerFactory: () => Logger) {
+    private val internalLoggerFactory: () => Logger,
+    val changeEventHandler: Option[ChangeEventHandler[S, Any]]) {
 
   import akka.actor.typed.scaladsl.adapter._
 
-  val persistence: Persistence = Persistence(context.system.toClassic)
+  val persistence: Persistence = Persistence(context.system)
 
   // Any instead S because adapter may change the type
   val durableStateStore: DurableStateUpdateStore[Any] =
-    DurableStateStoreRegistry(context.system.toClassic)
+    DurableStateStoreRegistry(context.system)
       .durableStateStoreFor[DurableStateUpdateStore[Any]](settings.durableStateStorePluginId)
+
+  // fail early if state store doesn't implement change events
+  if (changeEventHandler.isDefined && !durableStateStore.isInstanceOf[DurableStateUpdateWithChangeEventStore[_]])
+    new IllegalArgumentException(
+      "Change event handler was defined but the DurableStateStore " +
+      s"[${durableStateStore.getClass.getName}] doesn't implement [DurableStateUpdateWithChangeEventStore]")
 
   def selfClassic: ClassicActorRef = context.self.toClassic
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
@@ -41,7 +41,7 @@ private[akka] final class BehaviorSetup[C, S](
     val settings: DurableStateSettings,
     val stashState: StashState,
     private val internalLoggerFactory: () => Logger,
-    val changeEventHandler: Option[ChangeEventHandler[S, Any]]) {
+    val changeEventHandler: Option[ChangeEventHandler[Any, S, Any]]) {
 
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -53,7 +53,7 @@ private[akka] final case class DurableStateBehaviorImpl[Command, State](
     supervisionStrategy: SupervisorStrategy = SupervisorStrategy.stop,
     override val signalHandler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty,
     customStashCapacity: Option[Int] = None,
-    changeEventHandler: Option[ChangeEventHandler[State, Any]] = None)
+    changeEventHandler: Option[ChangeEventHandler[Any, State, Any]] = None)
     extends DurableStateBehavior[Command, State] {
 
   if (persistenceId eq null)
@@ -172,8 +172,9 @@ private[akka] final case class DurableStateBehaviorImpl[Command, State](
   override def withStashCapacity(size: Int): DurableStateBehavior[Command, State] =
     copy(customStashCapacity = Some(size))
 
-  override def withChangeEventHandler[C](handler: ChangeEventHandler[State, C]): DurableStateBehavior[Command, State] =
-    copy(changeEventHandler = Option(handler.asInstanceOf[ChangeEventHandler[State, Any]]))
+  override def withChangeEventHandler[ChangeEvent](
+      handler: ChangeEventHandler[Command, State, ChangeEvent]): DurableStateBehavior[Command, State] =
+    copy(changeEventHandler = Option(handler.asInstanceOf[ChangeEventHandler[Any, State, Any]]))
 
 }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
@@ -123,7 +123,7 @@ private[akka] object Running {
 
       val changeEvent = setup.changeEventHandler match {
         case None          => OptionVal.None
-        case Some(handler) => OptionVal.Some(handler.updateHandler(state.state, stateAfterApply.state))
+        case Some(handler) => OptionVal.Some(handler.updateHandler(state.state, stateAfterApply.state, cmd))
       }
 
       val newState2 =
@@ -139,7 +139,7 @@ private[akka] object Running {
 
       val changeEvent = setup.changeEventHandler match {
         case None          => OptionVal.None
-        case Some(handler) => OptionVal.Some(handler.deleteHandler(state.state))
+        case Some(handler) => OptionVal.Some(handler.deleteHandler(state.state, cmd))
       }
 
       val nextState = internalDelete(setup.context, cmd, state, changeEvent)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
@@ -387,6 +387,11 @@ private[akka] object Running {
       case callback: Callback[Any] @unchecked =>
         callback.sideEffect(state.state)
         behavior
+
+      case _ =>
+        // case _: Callback[S] should be covered by above case, but needed needed to silence Scala 3 exhaustive match
+        throw new IllegalStateException(
+          s"Unexpected effect [${effect.getClass.getName}]. This is a bug, please report https://github.com/akka/akka/issues")
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -13,7 +13,7 @@ import akka.annotation.InternalApi
  *
  * The `updateHandler` and `deleteHandler` are invoked after the ordinary command handler. Be aware of that
  * if the state is mutable and modified by the command handler the previous state parameter of the `updateHandler`
- * will also include the modification, since it's the same instance. If that is problem you need to use
+ * will also include the modification, since it's the same instance. If that is a problem you need to use
  * immutable state and create a new state instance when modifying it in the command handler.
  */
 @ApiMayChange

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -8,7 +8,7 @@ package akka.persistence.typed.state.javadsl
  * Implement this interface in the [[DurableStateBehavior]] to store additional change event when
  * the state is updated. The event can be used in Projections.
  */
-trait ChangeEventHandler[State, ChangeEvent] {
+trait ChangeEventHandler[Command, State, ChangeEvent] {
 
   /**
    * Store additional change event when the state is updated. The event can be used in Projections.
@@ -17,7 +17,7 @@ trait ChangeEventHandler[State, ChangeEvent] {
    * @param newState      New state after the update.
    * @return The change event to be stored.
    */
-  def changeEvent(previousState: State, newState: State): ChangeEvent
+  def changeEvent(previousState: State, newState: State, command: Command): ChangeEvent
 
   /**
    * Store additional change event when the state is updated. The event can be used in Projections.
@@ -25,6 +25,6 @@ trait ChangeEventHandler[State, ChangeEvent] {
    * @param previousState Previous state before the delete.
    * @return The change event to be stored.
    */
-  def deleteChangeEvent(previousState: State): ChangeEvent
+  def deleteChangeEvent(previousState: State, command: Command): ChangeEvent
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -4,9 +4,11 @@
 
 package akka.persistence.typed.state.javadsl
 
+import akka.annotation.InternalApi
+
 /**
- * Implement this interface in the [[DurableStateBehavior]] to store additional change event when
- * the state is updated. The event can be used in Projections.
+ * Implement this interface and use it in [[DurableStateBehavior#withChangeEventHandler]]
+ * to store additional change event when the state is updated. The event can be used in Projections.
  */
 trait ChangeEventHandler[Command, State, ChangeEvent] {
 
@@ -26,5 +28,19 @@ trait ChangeEventHandler[Command, State, ChangeEvent] {
    * @return The change event to be stored.
    */
   def deleteChangeEvent(previousState: State, command: Command): ChangeEvent
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object ChangeEventHandler {
+  val Undefined: ChangeEventHandler[Any, Any, Any] = new ChangeEventHandler[Any, Any, Any] {
+    override def changeEvent(previousState: Any, newState: Any, command: Any): Any = null
+    override def deleteChangeEvent(previousState: Any, command: Any): Any = null
+  }
+
+  def undefined[Command, State, ChangeEvent]: ChangeEventHandler[Command, State, ChangeEvent] =
+    Undefined.asInstanceOf[ChangeEventHandler[Command, State, ChangeEvent]]
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -10,6 +10,11 @@ import akka.annotation.InternalApi
 /**
  * API May Change: Implement this interface and use it in [[DurableStateBehavior#withChangeEventHandler]]
  * to store additional change event when the state is updated. The event can be used in Projections.
+ *
+ * The `updateHandler` and `deleteHandler` are invoked after the ordinary command handler. Be aware of that
+ * if the state is mutable and modified by the command handler the previous state parameter of the `updateHandler`
+ * will also include the modification, since it's the same instance. If that is problem you need to use
+ * immutable state and create a new state instance when modifying it in the command handler.
  */
 @ApiMayChange
 trait ChangeEventHandler[Command, State, ChangeEvent] {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -4,12 +4,14 @@
 
 package akka.persistence.typed.state.javadsl
 
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 
 /**
- * Implement this interface and use it in [[DurableStateBehavior#withChangeEventHandler]]
+ * API May Change: Implement this interface and use it in [[DurableStateBehavior#withChangeEventHandler]]
  * to store additional change event when the state is updated. The event can be used in Projections.
  */
+@ApiMayChange
 trait ChangeEventHandler[Command, State, ChangeEvent] {
 
   /**

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -26,7 +26,7 @@ trait ChangeEventHandler[Command, State, ChangeEvent] {
    * @param newState      New state after the update.
    * @return The change event to be stored.
    */
-  def changeEvent(previousState: State, newState: State, command: Command): ChangeEvent
+  def updateHandler(previousState: State, newState: State, command: Command): ChangeEvent
 
   /**
    * Store additional change event when the state is updated. The event can be used in Projections.
@@ -34,7 +34,7 @@ trait ChangeEventHandler[Command, State, ChangeEvent] {
    * @param previousState Previous state before the delete.
    * @return The change event to be stored.
    */
-  def deleteChangeEvent(previousState: State, command: Command): ChangeEvent
+  def deleteHandler(previousState: State, command: Command): ChangeEvent
 
 }
 
@@ -43,8 +43,8 @@ trait ChangeEventHandler[Command, State, ChangeEvent] {
  */
 @InternalApi private[akka] object ChangeEventHandler {
   val Undefined: ChangeEventHandler[Any, Any, Any] = new ChangeEventHandler[Any, Any, Any] {
-    override def changeEvent(previousState: Any, newState: Any, command: Any): Any = null
-    override def deleteChangeEvent(previousState: Any, command: Any): Any = null
+    override def updateHandler(previousState: Any, newState: Any, command: Any): Any = null
+    override def deleteHandler(previousState: Any, command: Any): Any = null
   }
 
   def undefined[Command, State, ChangeEvent]: ChangeEventHandler[Command, State, ChangeEvent] =

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/ChangeEventHandler.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+/**
+ * Implement this interface in the [[DurableStateBehavior]] to store additional change event when
+ * the state is updated. The event can be used in Projections.
+ */
+trait ChangeEventHandler[State, ChangeEvent] {
+
+  /**
+   * Store additional change event when the state is updated. The event can be used in Projections.
+   *
+   * @param previousState Previous state before the update.
+   * @param newState      New state after the update.
+   * @return The change event to be stored.
+   */
+  def changeEvent(previousState: State, newState: State): ChangeEvent
+
+  /**
+   * Store additional change event when the state is updated. The event can be used in Projections.
+   *
+   * @param previousState Previous state before the delete.
+   * @return The change event to be stored.
+   */
+  def deleteChangeEvent(previousState: State): ChangeEvent
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -99,9 +99,10 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
   }
 
   /**
-   * Override this and implement the [[ChangeEventHandler]] to store additional change event
+   * API May Change: Override this and implement the [[ChangeEventHandler]] to store additional change event
    * when the state is updated or deleted. The event can be used in Projections.
    */
+  @ApiMayChange
   protected def changeEventHandler(): ChangeEventHandler[Command, State, _] =
     ChangeEventHandler.undefined[Command, State, Any]
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -143,11 +143,11 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
         behaviorWithSignalHandler
 
     val withChangeEventHandler = this match {
-      case handler: ChangeEventHandler[State, _] @unchecked =>
+      case handler: ChangeEventHandler[Command, State, _] @unchecked =>
         withSignalHandler.withChangeEventHandler(
           scaladsl.ChangeEventHandler(
-            updateHandler = (previousState, newState) => handler.changeEvent(previousState, newState),
-            deleteHandler = previousState => handler.deleteChangeEvent(previousState)))
+            updateHandler = (previousState, newState, command) => handler.changeEvent(previousState, newState, command),
+            deleteHandler = (previousState, command) => handler.deleteChangeEvent(previousState, command)))
       case _ =>
         withSignalHandler
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -155,8 +155,9 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
       case handler: ChangeEventHandler[Command, State, _] @unchecked =>
         withSignalHandler.withChangeEventHandler(
           scaladsl.ChangeEventHandler(
-            updateHandler = (previousState, newState, command) => handler.changeEvent(previousState, newState, command),
-            deleteHandler = (previousState, command) => handler.deleteChangeEvent(previousState, command)))
+            updateHandler = (previousState, newState, command) =>
+              handler.updateHandler(previousState, newState, command),
+            deleteHandler = (previousState, command) => handler.deleteHandler(previousState, command)))
     }
 
     if (stashCapacity.isPresent) {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -99,6 +99,13 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
   }
 
   /**
+   * Override this and implement the [[ChangeEventHandler]] to store additional change event
+   * when the state is updated or deleted. The event can be used in Projections.
+   */
+  protected def changeEventHandler(): ChangeEventHandler[Command, State, _] =
+    ChangeEventHandler.undefined[Command, State, Any]
+
+  /**
    * Override and define the `DurableStateStore` plugin id that this actor should use instead of the default.
    */
   def durableStateStorePluginId: String = ""
@@ -142,14 +149,13 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
       else
         behaviorWithSignalHandler
 
-    val withChangeEventHandler = this match {
+    val withChangeEventHandler = changeEventHandler() match {
+      case handler if handler eq ChangeEventHandler.Undefined => withSignalHandler
       case handler: ChangeEventHandler[Command, State, _] @unchecked =>
         withSignalHandler.withChangeEventHandler(
           scaladsl.ChangeEventHandler(
             updateHandler = (previousState, newState, command) => handler.changeEvent(previousState, newState, command),
             deleteHandler = (previousState, command) => handler.deleteChangeEvent(previousState, command)))
-      case _ =>
-        withSignalHandler
     }
 
     if (stashCapacity.isPresent) {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
@@ -4,6 +4,12 @@
 
 package akka.persistence.typed.state.scaladsl
 
+import akka.annotation.ApiMayChange
+
+/**
+ * API May Change
+ */
+@ApiMayChange
 object ChangeEventHandler {
 
   /**
@@ -22,9 +28,10 @@ object ChangeEventHandler {
 }
 
 /**
- * Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store additional change event when
- * the state is updated. The event can be used in Projections.
+ * API May Change: Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store
+ * additional change event when the state is updated. The event can be used in Projections.
  */
+@ApiMayChange
 final class ChangeEventHandler[Command, State, ChangeEvent] private (
     val updateHandler: (State, State, Command) => ChangeEvent,
     val deleteHandler: (State, Command) => ChangeEvent)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
@@ -16,6 +16,11 @@ object ChangeEventHandler {
    * Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store additional change event when
    * the state is updated. The event can be used in Projections.
    *
+   * The `updateHandler` and `deleteHandler` are invoked after the ordinary command handler. Be aware of that
+   * if the state is mutable and modified by the command handler the previous state parameter of the `updateHandler`
+   * will also include the modification, since it's the same instance. If that is problem you need to use
+   * immutable state and create a new state instance when modifying it in the command handler.
+   *
    * @param updateHandler Function that given the previous and new state creates the change event to be stored
    *                      when the DurableState is updated.
    * @param deleteHandler Function that given the previous state creates the change event to be stored

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
@@ -18,7 +18,7 @@ object ChangeEventHandler {
    *
    * The `updateHandler` and `deleteHandler` are invoked after the ordinary command handler. Be aware of that
    * if the state is mutable and modified by the command handler the previous state parameter of the `updateHandler`
-   * will also include the modification, since it's the same instance. If that is problem you need to use
+   * will also include the modification, since it's the same instance. If that is a problem you need to use
    * immutable state and create a new state instance when modifying it in the command handler.
    *
    * @param updateHandler Function that given the previous and new state creates the change event to be stored

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
@@ -15,9 +15,9 @@ object ChangeEventHandler {
    * @param deleteHandler Function that given the previous state creates the change event to be stored
    *                      when the DurableState is deleted.
    */
-  def apply[State, ChangeEvent](
-      updateHandler: (State, State) => ChangeEvent,
-      deleteHandler: State => ChangeEvent): ChangeEventHandler[State, ChangeEvent] =
+  def apply[Command, State, ChangeEvent](
+      updateHandler: (State, State, Command) => ChangeEvent,
+      deleteHandler: (State, Command) => ChangeEvent): ChangeEventHandler[Command, State, ChangeEvent] =
     new ChangeEventHandler(updateHandler, deleteHandler)
 }
 
@@ -25,6 +25,6 @@ object ChangeEventHandler {
  * Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store additional change event when
  * the state is updated. The event can be used in Projections.
  */
-final class ChangeEventHandler[State, ChangeEvent] private (
-    val updateHandler: (State, State) => ChangeEvent,
-    val deleteHandler: State => ChangeEvent)
+final class ChangeEventHandler[Command, State, ChangeEvent] private (
+    val updateHandler: (State, State, Command) => ChangeEvent,
+    val deleteHandler: (State, Command) => ChangeEvent)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/ChangeEventHandler.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+object ChangeEventHandler {
+
+  /**
+   * Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store additional change event when
+   * the state is updated. The event can be used in Projections.
+   *
+   * @param updateHandler Function that given the previous and new state creates the change event to be stored
+   *                      when the DurableState is updated.
+   * @param deleteHandler Function that given the previous state creates the change event to be stored
+   *                      when the DurableState is deleted.
+   */
+  def apply[State, ChangeEvent](
+      updateHandler: (State, State) => ChangeEvent,
+      deleteHandler: State => ChangeEvent): ChangeEventHandler[State, ChangeEvent] =
+    new ChangeEventHandler(updateHandler, deleteHandler)
+}
+
+/**
+ * Define these handlers in the [[DurableStateBehavior#withChangeEventHandler]] to store additional change event when
+ * the state is updated. The event can be used in Projections.
+ */
+final class ChangeEventHandler[State, ChangeEvent] private (
+    val updateHandler: (State, State) => ChangeEvent,
+    val deleteHandler: State => ChangeEvent)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -169,6 +169,7 @@ object DurableStateBehavior {
   /**
    * Store additional change event when the state is updated or deleted. The event can be used in Projections.
    */
-  def withChangeEventHandler[C](handler: ChangeEventHandler[State, C]): DurableStateBehavior[Command, State]
+  def withChangeEventHandler[ChangeEvent](
+      handler: ChangeEventHandler[Command, State, ChangeEvent]): DurableStateBehavior[Command, State]
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -165,4 +165,10 @@ object DurableStateBehavior {
    * If not defined, the default `akka.persistence.typed.stash-capacity` will be used.
    */
   def withStashCapacity(size: Int): DurableStateBehavior[Command, State]
+
+  /**
+   * Store additional change event when the state is updated or deleted. The event can be used in Projections.
+   */
+  def withChangeEventHandler[C](handler: ChangeEventHandler[State, C]): DurableStateBehavior[Command, State]
+
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -167,8 +167,10 @@ object DurableStateBehavior {
   def withStashCapacity(size: Int): DurableStateBehavior[Command, State]
 
   /**
-   * Store additional change event when the state is updated or deleted. The event can be used in Projections.
+   * API May Change: Store additional change event when the state is updated or deleted.
+   * The event can be used in Projections.
    */
+  @ApiMayChange
   def withChangeEventHandler[ChangeEvent](
       handler: ChangeEventHandler[Command, State, ChangeEvent]): DurableStateBehavior[Command, State]
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
@@ -372,7 +372,7 @@ public class DurableStatePersistentBehaviorTest {
     // #changeHandler
     public class MyPersistentBehavior
       extends DurableStateBehavior<MyPersistentBehavior.Command, MyPersistentBehavior.State>
-    implements ChangeEventHandler<MyPersistentBehavior.State, MyPersistentBehavior.ChangeEvent>{
+    implements ChangeEventHandler<MyPersistentBehavior.Command, MyPersistentBehavior.State, MyPersistentBehavior.ChangeEvent>{
 
       // #changeHandler
 
@@ -433,7 +433,7 @@ public class DurableStatePersistentBehaviorTest {
 
 
       @Override
-      public ChangeEvent changeEvent(State previousState, State newState) {
+      public ChangeEvent changeEvent(State previousState, State newState, MyPersistentBehavior.Command command) {
         Set<String> addedItems = new HashSet<>(newState.getItems());
         addedItems.removeAll(previousState.getItems());
         Set<String> removedItems = new HashSet<>(previousState.getItems());
@@ -443,7 +443,7 @@ public class DurableStatePersistentBehaviorTest {
       }
 
       @Override
-      public ChangeEvent deleteChangeEvent(State previousState) {
+      public ChangeEvent deleteChangeEvent(State previousState, MyPersistentBehavior.Command command) {
         return new ItemsChanged(Collections.emptySet(), previousState.getItems());
       }
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
@@ -435,7 +435,7 @@ public class DurableStatePersistentBehaviorTest {
       public ChangeEventHandler<Command, State, ChangeEvent> changeEventHandler() {
         return new ChangeEventHandler<>() {
           @Override
-          public ChangeEvent changeEvent(State previousState, State newState, Command command) {
+          public ChangeEvent updateHandler(State previousState, State newState, Command command) {
             Set<String> addedItems = new HashSet<>(newState.getItems());
             addedItems.removeAll(previousState.getItems());
             Set<String> removedItems = new HashSet<>(previousState.getItems());
@@ -445,7 +445,7 @@ public class DurableStatePersistentBehaviorTest {
           }
 
           @Override
-          public ChangeEvent deleteChangeEvent(State previousState, Command command) {
+          public ChangeEvent deleteHandler(State previousState, Command command) {
             return new ItemsChanged(Collections.emptySet(), previousState.getItems());
           }
         };

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
@@ -371,8 +371,7 @@ public class DurableStatePersistentBehaviorTest {
 
     // #changeHandler
     public class MyPersistentBehavior
-      extends DurableStateBehavior<MyPersistentBehavior.Command, MyPersistentBehavior.State>
-    implements ChangeEventHandler<MyPersistentBehavior.Command, MyPersistentBehavior.State, MyPersistentBehavior.ChangeEvent>{
+      extends DurableStateBehavior<MyPersistentBehavior.Command, MyPersistentBehavior.State> {
 
       // #changeHandler
 
@@ -433,18 +432,23 @@ public class DurableStatePersistentBehaviorTest {
 
 
       @Override
-      public ChangeEvent changeEvent(State previousState, State newState, MyPersistentBehavior.Command command) {
-        Set<String> addedItems = new HashSet<>(newState.getItems());
-        addedItems.removeAll(previousState.getItems());
-        Set<String> removedItems = new HashSet<>(previousState.getItems());
-        removedItems.removeAll(newState.getItems());
+      public ChangeEventHandler<Command, State, ChangeEvent> changeEventHandler() {
+        return new ChangeEventHandler<>() {
+          @Override
+          public ChangeEvent changeEvent(State previousState, State newState, Command command) {
+            Set<String> addedItems = new HashSet<>(newState.getItems());
+            addedItems.removeAll(previousState.getItems());
+            Set<String> removedItems = new HashSet<>(previousState.getItems());
+            removedItems.removeAll(newState.getItems());
 
-        return new ItemsChanged(addedItems, removedItems);
-      }
+            return new ItemsChanged(addedItems, removedItems);
+          }
 
-      @Override
-      public ChangeEvent deleteChangeEvent(State previousState, MyPersistentBehavior.Command command) {
-        return new ItemsChanged(Collections.emptySet(), previousState.getItems());
+          @Override
+          public ChangeEvent deleteChangeEvent(State previousState, Command command) {
+            return new ItemsChanged(Collections.emptySet(), previousState.getItems());
+          }
+        };
       }
 
       // #changeHandler

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
@@ -16,7 +16,7 @@ import akka.Done
 trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
 
   /**
-   * @param seqNr sequence number for optimistic locking. starts at 1.
+   * @param revision sequence number for optimistic locking. starts at 1.
    */
   def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): CompletionStage[Done]
 

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
@@ -12,6 +12,8 @@ import akka.Done
  * API for updating durable state objects.
  *
  * For Scala API see [[akka.persistence.state.scaladsl.DurableStateUpdateStore]].
+ *
+ * See also [[DurableStateUpdateWithChangeEventStore]]
  */
 trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
 

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateWithChangeEventStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateWithChangeEventStore.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+
+/**
+ * API for updating durable state objects and storing additional change event.
+ *
+ * For Scala API see [[akka.persistence.state.scaladsl.DurableStateUpdateWithChangeEventStore]].
+ */
+trait DurableStateUpdateWithChangeEventStore[A] extends DurableStateUpdateStore[A] {
+
+  /**
+   * The `changeEvent` is written to the event journal.
+   * Same `persistenceId` is used in the journal and the `revision` is used as `sequenceNr`.
+   *
+   * @param revision sequence number for optimistic locking. starts at 1.
+   */
+  def upsertObject(
+      persistenceId: String,
+      revision: Long,
+      value: A,
+      tag: String,
+      changeEvent: Any): CompletionStage[Done]
+
+  def deleteObject(persistenceId: String, revision: Long, changeEvent: Any): CompletionStage[Done]
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateWithChangeEventStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateWithChangeEventStore.scala
@@ -7,12 +7,14 @@ package akka.persistence.state.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.Done
+import akka.annotation.ApiMayChange
 
 /**
- * API for updating durable state objects and storing additional change event.
+ * API May Change: API for updating durable state objects and storing additional change event.
  *
  * For Scala API see [[akka.persistence.state.scaladsl.DurableStateUpdateWithChangeEventStore]].
  */
+@ApiMayChange
 trait DurableStateUpdateWithChangeEventStore[A] extends DurableStateUpdateStore[A] {
 
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
@@ -12,8 +12,9 @@ import akka.Done
  * API for updating durable state objects.
  *
  * For Java API see [[akka.persistence.state.javadsl.DurableStateUpdateStore]].
+ *
+ * See also [[DurableStateUpdateWithChangeEventStore]]
  */
-//#plugin-api
 trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
 
   /**
@@ -26,4 +27,3 @@ trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
 
   def deleteObject(persistenceId: String, revision: Long): Future[Done]
 }
-//#plugin-api

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateWithChangeEventStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateWithChangeEventStore.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.scaladsl
+
+import scala.concurrent.Future
+
+import akka.Done
+
+/**
+ * API for updating durable state objects and storing additional change event.
+ *
+ * For Java API see [[akka.persistence.state.javadsl.DurableStateUpdateWithChangeEventStore]].
+ */
+//#plugin-api
+trait DurableStateUpdateWithChangeEventStore[A] extends DurableStateUpdateStore[A] {
+
+  /**
+   * The `changeEvent` is written to the event journal.
+   * Same `persistenceId` is used in the journal and the `revision` is used as `sequenceNr`.
+   *
+   * @param revision sequence number for optimistic locking. starts at 1.
+   */
+  def upsertObject(persistenceId: String, revision: Long, value: A, tag: String, changeEvent: Any): Future[Done]
+
+  def deleteObject(persistenceId: String, revision: Long, changeEvent: Any): Future[Done]
+}
+//#plugin-api

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateWithChangeEventStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateWithChangeEventStore.scala
@@ -7,13 +7,14 @@ package akka.persistence.state.scaladsl
 import scala.concurrent.Future
 
 import akka.Done
+import akka.annotation.ApiMayChange
 
 /**
- * API for updating durable state objects and storing additional change event.
+ * API May Change: API for updating durable state objects and storing additional change event.
  *
  * For Java API see [[akka.persistence.state.javadsl.DurableStateUpdateWithChangeEventStore]].
  */
-//#plugin-api
+@ApiMayChange
 trait DurableStateUpdateWithChangeEventStore[A] extends DurableStateUpdateStore[A] {
 
   /**
@@ -26,4 +27,3 @@ trait DurableStateUpdateWithChangeEventStore[A] extends DurableStateUpdateStore[
 
   def deleteObject(persistenceId: String, revision: Long, changeEvent: Any): Future[Done]
 }
-//#plugin-api

--- a/build.sbt
+++ b/build.sbt
@@ -295,6 +295,7 @@ lazy val persistenceTypedTests = akkaModule("akka-persistence-typed-tests")
     persistenceTyped,
     persistenceTestkit % "test",
     actorTestkitTyped % "test",
+    streamTestkit % "test",
     persistence % "test->test", // for SteppingInMemJournal
     jackson % "test->test")
   .settings(AkkaBuild.mayChangeSettings)


### PR DESCRIPTION
* by storing additional change events when Durable State is updated and deleted we make it possible to use all nice event sourced Projection capabilities with Durable State, including Projections over gRPC
* otherwise we would have to duplicate many many things to use the existing DurableStateChange and the queries based on that
* we might even deprecate the existing DurableStateChange if this works out, but that can be a later decision

TODO:
- [x] docs