### PR TITLE
fix: Topics with the same name but different message types

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -99,7 +99,8 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
 
     case MessagePublished(msg) =>
       context.log.trace("Message of type [{}] published", msg.getClass)
-      localSubscribers.foreach(_ ! msg)
+      if (classTag.runtimeClass.isAssignableFrom(msg.getClass))
+        localSubscribers.foreach(_ ! msg)
       this
 
     case Subscribe(subscriber) =>


### PR DESCRIPTION
Should not publish messages of the wrong type to subscribers

