### PR TITLE
chore: Add a note about fifos not being supported in FileIO.fromPath

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -149,6 +149,9 @@ object FileIO {
    * and a possible exception if IO operation was not completed successfully. Note that bytes having been read by the source does
    * not give any guarantee that the bytes were seen by downstream stages.
    *
+   * It is not possible to read FIFOs, also known as named pipes, with `fromPath`, trying to do so will potentially first block
+   * and then fail the stream.
+   *
    * @param f         the file path to read from
    */
   def fromPath(f: Path): javadsl.Source[ByteString, CompletionStage[IOResult]] = fromPath(f, 8192)
@@ -183,6 +186,9 @@ object FileIO {
    * It materializes a [[java.util.concurrent.CompletionStage]] of [[IOResult]] containing the number of bytes read from the source file upon completion,
    * and a possible exception if IO operation was not completed successfully. Note that bytes having been read by the source does
    * not give any guarantee that the bytes were seen by downstream stages.
+   *
+   * It is not possible to read FIFOs, also known as named pipes, with `fromPath`, trying to do so will potentially first block
+   * and then fail the stream.
    *
    * @param f         the file path to read from
    * @param chunkSize the size of each read operation

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
@@ -51,6 +51,9 @@ object FileIO {
    * and a possible exception if IO operation was not completed successfully. Note that bytes having been read by the source does
    * not give any guarantee that the bytes were seen by downstream stages.
    *
+   * It is not possible to read FIFOs, also known as named pipes, with `fromPath`, trying to do so will potentially first block
+   * and then fail the stream.
+   *
    * @param f         the file path to read from
    * @param chunkSize the size of each read operation, defaults to 8192
    */
@@ -68,6 +71,9 @@ object FileIO {
    * It materializes a [[Future]] of [[IOResult]] containing the number of bytes read from the source file upon completion,
    * and a possible exception if IO operation was not completed successfully. Note that bytes having been read by the source does
    * not give any guarantee that the bytes were seen by downstream stages.
+   *
+   * It is not possible to read FIFOs, also known as named pipes, with `fromPath`, trying to do so will potentially first block
+   * and then fail the stream.
    *
    * @param f         the file path to read from
    * @param chunkSize the size of each read operation, defaults to 8192


### PR DESCRIPTION
Refs #32134

Wanted to fail fast with a better error message but could not find a definitive way to know a path is a fifo from Java, the closest is that `Files.isRegularFile` returns false, or that the posix file attributes contains `isOther` but those would probably also cover devices and other things that may be fine to read with fromPath