### PR TITLE
feat: Cache piercing for discovery and async-dns

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/SimpleDnsCacheSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/SimpleDnsCacheSpec.scala
@@ -62,6 +62,28 @@ class SimpleDnsCacheSpec extends AnyWordSpec with Matchers {
       cache.cached(DnsProtocol.Resolve("test.local")) should ===(None)
     }
 
+    "drop a specific key" in {
+      val localClock = new AtomicLong(0)
+      val cache: SimpleDnsCache = new SimpleDnsCache() {
+        override protected def clock() = localClock.get
+      }
+      val ttl = Ttl.fromPositive(5000.millis)
+      val cacheEntry1 =
+        DnsProtocol.Resolved(
+          "test.local",
+          immutable.Seq(ARecord("test.local", ttl, InetAddress.getByName("127.0.0.1"))))
+      cache.put(("test.local", Ip()), cacheEntry1, ttl)
+      val cacheEntry2 =
+        DnsProtocol.Resolved(
+          "example.com",
+          immutable.Seq(ARecord("example.com", ttl, InetAddress.getByName("127.0.0.1"))))
+      cache.put(("example.com", Ip()), cacheEntry2, ttl)
+      cache.drop(("example.com", Ip()))
+      cache.cached(DnsProtocol.Resolve("example.com")) should ===(None)
+      cache.cached(DnsProtocol.Resolve("test.local")) should ===(Some(cacheEntry1))
+
+    }
+
   }
 
   // TODO test that the old protocol is converted correctly

--- a/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
@@ -73,6 +73,10 @@ class SimpleDnsCache extends Dns with PeriodicCacheCleanup with NoSerializationV
     cacheRef.get().get(key)
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   @tailrec
   private[akka] final def put(key: (String, RequestType), records: Resolved, ttl: CachePolicy): Unit = {
     val c = cacheRef.get()
@@ -80,6 +84,10 @@ class SimpleDnsCache extends Dns with PeriodicCacheCleanup with NoSerializationV
       put(key, records, ttl)
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private[akka] final def drop(key: (String, RequestType)): Unit = {
     val c = cacheRef.get()
     if (!cacheRef.compareAndSet(c, c.drop(key)))

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -31,7 +31,6 @@ private[akka] object AsyncDnsManager {
   private case object CacheCleanup
 
   case object GetCache
-  case class DropFromCache()
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -31,6 +31,7 @@ private[akka] object AsyncDnsManager {
   private case object CacheCleanup
 
   case object GetCache
+  case class DropFromCache()
 }
 
 /**

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -134,9 +134,18 @@ object ServiceDiscovery {
  * Akka remoting ports and HTTP ports.
  *
  * @param serviceName must not be 'null' or an empty String
+ * @param discardCache Ask the discovery implementation to drop any cached result and do a new resolution.
+ *                     Optionally supported by implementations.
  */
-final class Lookup(val serviceName: String, val portName: Option[String], val protocol: Option[String])
+final class Lookup(
+    val serviceName: String,
+    val portName: Option[String],
+    val protocol: Option[String],
+    val discardCache: Boolean)
     extends NoSerializationVerificationNeeded {
+
+  def this(serviceName: String, portName: Option[String], protocol: Option[String]) =
+    this(serviceName, portName, protocol, discardCache = false)
 
   require(serviceName != null, "'serviceName' cannot be null")
   require(serviceName.trim.nonEmpty, "'serviceName' cannot be empty")
@@ -154,6 +163,12 @@ final class Lookup(val serviceName: String, val portName: Option[String], val pr
   def withProtocol(value: String): Lookup = copy(protocol = Some(value))
 
   /**
+   * Ask the discovery implementation to drop any cached result and do a new resolution.
+   * Optionally supported by implementations.
+   */
+  def withDiscardCache: Lookup = copy(discardCache = true)
+
+  /**
    * Java API
    */
   def getPortName: Optional[String] =
@@ -168,7 +183,8 @@ final class Lookup(val serviceName: String, val portName: Option[String], val pr
   private def copy(
       serviceName: String = serviceName,
       portName: Option[String] = portName,
-      protocol: Option[String] = protocol): Lookup =
+      protocol: Option[String] = protocol,
+      discardCache: Boolean = discardCache): Lookup =
     new Lookup(serviceName, portName, protocol)
 
   override def toString: String = s"Lookup($serviceName,$portName,$protocol)"

--- a/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
@@ -115,11 +115,9 @@ private[akka] class DnsServiceDiscovery(system: ExtendedActorSystem) extends Ser
     log.debug("Lookup [{}] translated to SRV query [{}] as contains portName and protocol", lookup, srvRequest)
     val mode = Srv
 
-    val query = DnsProtocol.Resolve(srvRequest, mode)
-
     def askResolve(): Future[Resolved] = {
       dns
-        .ask(query)(resolveTimeout)
+        .ask(DnsProtocol.Resolve(srvRequest, mode))(resolveTimeout)
         .map {
           case resolved: DnsProtocol.Resolved =>
             log.debug("{} lookup result: {}", mode, resolved)

--- a/akka-discovery/src/test/scala/akka/discovery/dns/DnsServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/dns/DnsServiceDiscoverySpec.scala
@@ -4,25 +4,32 @@
 
 package akka.discovery.dns
 
-import java.net.{ Inet6Address, InetAddress }
-
-import scala.collection.{ immutable => im }
-import scala.concurrent.duration._
-
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpecLike
-
 import akka.actor.ActorRef
 import akka.actor.ExtendedActorSystem
 import akka.discovery
 import akka.discovery.ServiceDiscovery
-import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import akka.discovery.ServiceDiscovery.DiscoveryTimeoutException
-import akka.io.dns.{ AAAARecord, ARecord, DnsProtocol, SRVRecord }
+import akka.discovery.ServiceDiscovery.Resolved
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.io.SimpleDnsCache
+import akka.io.dns.AAAARecord
+import akka.io.dns.ARecord
+import akka.io.dns.CachePolicy
 import akka.io.dns.CachePolicy.Ttl
+import akka.io.dns.DnsProtocol
+import akka.io.dns.DnsProtocol.Ip
+import akka.io.dns.SRVRecord
+import akka.io.dns.internal.AsyncDnsManager.GetCache
 import akka.testkit.AkkaSpec
 import akka.testkit.TestProbe
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.net.Inet6Address
+import java.net.InetAddress
+import scala.collection.{ immutable => im }
+import scala.concurrent.duration._
 
 class DnsServiceDiscoverySpec extends AkkaSpec with AnyWordSpecLike with Matchers with ScalaFutures {
 
@@ -43,6 +50,34 @@ class DnsServiceDiscoverySpec extends AkkaSpec with AnyWordSpecLike with Matcher
       }
       val result = underTest.lookup(discovery.Lookup("cats.com").withPortName("dog").withProtocol("snake"), 1.second)
       result.failed.futureValue shouldBe a[DiscoveryTimeoutException]
+    }
+
+    "use cache" in {
+      val dnsProbe = TestProbe()
+      val underTest = new DnsServiceDiscovery(system.asInstanceOf[ExtendedActorSystem]) {
+        override def initializeDns(): ActorRef = dnsProbe.ref
+      }
+      dnsProbe.expectMsg(GetCache)
+      val cache = new SimpleDnsCache
+      val resolved = DnsProtocol.Resolved(
+        "cats.com",
+        Seq(new ARecord("cats.com", Ttl.effectivelyForever, InetAddress.getByName("127.0.0.1"))))
+      cache.put(("cats.com", Ip()), resolved, CachePolicy.Forever)
+      dnsProbe.sender() ! cache
+
+      // cache field is not synchronized/volatile so might not be seen initially
+      dnsProbe.awaitAssert {
+        val result = underTest.lookup(discovery.Lookup("cats.com").withPortName("dog"), 1.second)
+        dnsProbe.expectNoMessage()
+        result.futureValue
+      }
+
+      cache.drop(("cats.com", Ip()))
+      val result = underTest.lookup(discovery.Lookup("cats.com").withPortName("dog"), 1.second)
+      dnsProbe.expectMsg(DnsProtocol.Resolve("cats.com", Ip()))
+      cache.cached(DnsProtocol.Resolve("cats.com", Ip())) should be(None)
+      dnsProbe.sender() ! resolved
+      result.futureValue
     }
   }
 


### PR DESCRIPTION
This makes it possible to programatically force re-resolution even if TTL is long, needed downstream in Akka gRPC for periodic refresh of nodes used for client side load balancing.