### PR TITLE
feat: TTL for typed pub/sub topic actors

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.internal.pubsub.TopicImpl
 import akka.actor.typed.scaladsl.Behaviors
+import akka.testkit.TimingTest
 import akka.util.WallClock
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -179,7 +180,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       }
     }
 
-    "shut down topic after ttl" in {
+    "shut down topic after ttl" taggedAs TimingTest in {
       def createTopic() =
         testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
           Behaviors.withTimers[TopicImpl.Command[String]](timers =>
@@ -189,7 +190,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       probe.expectTerminated(topic)
     }
 
-    "keep topic with ttl alive with publishing" in {
+    "keep topic with ttl alive with publishing" taggedAs TimingTest in {
       def createTopic() =
         testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
           Behaviors.withTimers[TopicImpl.Command[String]](timers =>
@@ -215,7 +216,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       probe.expectTerminated(topic)
     }
 
-    "keep topic with ttl alive with subscriber" in {
+    "keep topic with ttl alive with subscriber" taggedAs TimingTest in {
       def createTopic() =
         testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
           Behaviors.withTimers[TopicImpl.Command[String]](timers =>

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
@@ -4,12 +4,15 @@
 
 package akka.actor.typed.pubsub
 
-import scala.concurrent.duration._
-
-import org.scalatest.wordspec.AnyWordSpecLike
-
+import akka.actor.Dropped
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.internal.pubsub.TopicImpl
+import akka.actor.typed.scaladsl.Behaviors
+import akka.util.WallClock
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.duration._
 
 class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
@@ -175,5 +178,60 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
         testKit.stop(numberTopic)
       }
     }
+
+    "shut down topic after ttl" in {
+      def createTopic() =
+        testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
+          Behaviors.withTimers[TopicImpl.Command[String]](timers =>
+            new TopicImpl[String]("fruit6", context, Some((300.millis, timers, WallClock.AlwaysIncreasingClock))))))
+      val topic = createTopic()
+      val probe = testKit.createTestProbe()
+      probe.expectTerminated(topic)
+    }
+
+    "keep topic with ttl alive with publishing" in {
+      def createTopic() =
+        testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
+          Behaviors.withTimers[TopicImpl.Command[String]](timers =>
+            new TopicImpl[String]("fruit7", context, Some((500.millis, timers, WallClock.AlwaysIncreasingClock))))))
+      val deadLetters = testKit.createDeadLetterProbe()
+      val topic = createTopic()
+      // no subscribers, only local publish
+      (0 to 4).foreach { _ =>
+        Thread.sleep(200)
+        topic ! Topic.Publish("durian")
+      }
+      // Verify it isn't dead yet through no dead letters from the topic being dead (but it does drop because no subscribers)
+      deadLetters
+        .receiveMessages(4)
+        .forall(_.message match {
+          case Dropped(_, reason, _, _) => reason == "No topic subscribers known"
+          case _                        => false
+        }) should ===(true)
+
+      // then it ttl-outs
+      Thread.sleep(600)
+      val probe = testKit.createTestProbe()
+      probe.expectTerminated(topic)
+    }
+
+    "keep topic with ttl alive with subscriber" in {
+      def createTopic() =
+        testKit.spawn(Behaviors.setup[TopicImpl.Command[String]](context =>
+          Behaviors.withTimers[TopicImpl.Command[String]](timers =>
+            new TopicImpl[String]("fruit8", context, Some((300.millis, timers, WallClock.AlwaysIncreasingClock))))))
+      val topic = createTopic()
+      val subscriber = testKit.createTestProbe[String]()
+      topic ! Topic.Subscribe(subscriber.ref)
+      Thread.sleep(500)
+      topic ! Topic.Publish("cherimoya")
+      subscriber.expectMessage("cherimoya")
+      topic ! Topic.Unsubscribe(subscriber.ref)
+      Thread.sleep(500)
+      // now it should have ttl-outed
+      val probe = testKit.createTestProbe()
+      probe.expectTerminated(topic)
+    }
+
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -4,8 +4,6 @@
 
 package akka.actor.typed.internal.pubsub
 
-import scala.reflect.ClassTag
-
 import akka.actor.Dropped
 import akka.actor.InvalidMessageException
 import akka.actor.typed.ActorRef
@@ -15,9 +13,16 @@ import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
+import akka.actor.typed.scaladsl.TimerScheduler
 import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.InternalApi
+import akka.util.PrettyDuration.PrettyPrintableDuration
+import akka.util.WallClock
+
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
 
 /**
  * INTERNAL API
@@ -47,9 +52,14 @@ private[akka] object TopicImpl {
  * INTERNAL API
  */
 @InternalApi
-private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[TopicImpl.Command[T]])(
+private[akka] final class TopicImpl[T](
+    topicName: String,
+    context: ActorContext[TopicImpl.Command[T]],
+    ttlAndTimers: Option[(FiniteDuration, TimerScheduler[TopicImpl.Command[T]], WallClock)])(
     implicit classTag: ClassTag[T])
     extends AbstractBehavior[TopicImpl.Command[T]](context) {
+
+  private case object TtlTick extends TopicImpl.Command[T]
 
   /*
    * The topic actor keeps a local set of subscribers, whenever that is non-empty it registers itself for
@@ -69,6 +79,8 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
 
   private var topicInstances = Set.empty[ActorRef[TopicImpl.Command[T]]]
   private var localSubscribers = Set.empty[ActorRef[T]]
+  // Note: timestamp when last publish or when the subscriber list became empty because of last unsubscribe
+  private var lastActivityForTtl: Long = Long.MinValue
 
   private val receptionist = context.system.receptionist
   private val receptionistAdapter = context.messageAdapter[Receptionist.Listing] {
@@ -95,6 +107,7 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
         val pub = MessagePublished(message)
         topicInstances.foreach(_ ! pub)
       }
+      activity()
       this
 
     case MessagePublished(msg) =>
@@ -128,6 +141,7 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
         context.log.debug("Last local subscriber [{}] unsubscribed, deregistering from receptionist", subscriber)
         // that was the lost subscriber, deregister from the receptionist
         receptionist ! Receptionist.Deregister(topicServiceKey, context.self)
+        activity()
       } else {
         context.log.debug("Local subscriber [{}] unsubscribed", subscriber)
       }
@@ -147,14 +161,45 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
     case TopicInstancesUpdated(newTopics) =>
       context.log.debug("Topic list updated [{}]", newTopics)
       topicInstances = newTopics
+      if (lastActivityForTtl == Long.MinValue) {
+        ttlAndTimers.foreach {
+          case (ttl, timers, _) =>
+            timers.startTimerWithFixedDelay(TtlTick.asInstanceOf[Command[T]], ttl / 2L)
+        }
+      }
       this
 
     case GetTopicStats(replyTo) =>
       replyTo ! TopicStats(localSubscribers.size, topicInstances.size)
       this
 
+    case TtlTick =>
+      if (localSubscribers.isEmpty) {
+        // only ever arrives if ttl is defined
+        ttlAndTimers match {
+          case Some((ttl, _, clock)) =>
+            val limit = clock.currentTimeMillis() - ttl.toMillis
+            if (lastActivityForTtl < limit) {
+              context.log.debug(
+                "Topic [{}] reached TTL [{}] without activity, terminating",
+                topicName,
+                PrettyPrintableDuration(ttl))
+              Behaviors.stopped
+            } else {
+              this
+            }
+          case _ => this
+        }
+      } else this
+
     case other =>
       // can't do exhaustiveness check correctly because of protocol internal/public design
       throw new IllegalArgumentException(s"Unexpected command type ${other.getClass}")
+  }
+
+  private def activity(): Unit = ttlAndTimers match {
+    case Some((_, _, clock)) =>
+      lastActivityForTtl = clock.currentTimeMillis()
+    case _ =>
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -180,10 +180,7 @@ private[akka] final class TopicImpl[T](
           case Some((ttl, _, clock)) =>
             val limit = clock.currentTimeMillis() - ttl.toMillis
             if (lastActivityForTtl < limit) {
-              context.log.debug(
-                "Topic [{}] reached TTL [{}] without activity, terminating",
-                topicName,
-                PrettyPrintableDuration(ttl))
+              context.log.debug("Topic [{}] reached TTL [{}] without activity, terminating", topicName, ttl.pretty)
               Behaviors.stopped
             } else {
               this


### PR DESCRIPTION
Related to #31053 

A topic actor can now shut itself down after a period of inactivity - the inactivity counter starts from when from when the subscriber list becomes empty, or the last local message was published.
