### PR TITLE
chore: Fix GraphApply.scala.template

### DIFF
--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -54,7 +54,7 @@ trait GraphApply {
    *
    * Deprecated: this method signature does not work with Scala 3 type inference, kept for binary compatibility. Use createGraph instead.
    */
-  @deprecated("Use createGraph instead", "2.6.16")
+  @deprecated("Use createGraph instead", "##2.6.##16")
   def create[S <: Shape, Mat, [#M1#]]([#g1: Graph[Shape, M1]#])(combineMat: ([#M1#]) => Mat)(buildBlock: GraphDSL.Builder[Mat] => ([#g1.Shape#]) => S): Graph[S, Mat] = {
     val builder = new GraphDSL.Builder
     val curried = combineMat.curried


### PR DESCRIPTION
Was reported and fixed  in pekko 

Otherwise the number will increase.


