### PR TITLE
chore: Fix typo in akka-stream reference.conf

### DIFF
--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -22,7 +22,7 @@ akka {
       # FQCN of the MailboxType. The Class of the FQCN must have a public
       # constructor with
       # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
-      # defaults to the single consumber mailbox for better performance.
+      # defaults to the single consumer mailbox for better performance.
       mailbox {
         mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
       }


### PR DESCRIPTION
Motivation:
Fix up a typo