### PR TITLE
feat:Expose current interpreter when preStarting the stages.

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -7,6 +7,7 @@ package akka.stream.scaladsl
 import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.Attributes.Attribute
+import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.scaladsl.AttributesSpec.{ whateverAttribute, WhateverAttribute }
 import akka.stream.testkit.StreamSpec
 
@@ -31,6 +32,14 @@ class FromMaterializerSpec extends StreamSpec {
       }
 
       source.runWith(Sink.head).futureValue should not be empty
+    }
+
+    "expose interpreter" in {
+      val flow = Flow.fromMaterializer { (_, _) =>
+        Flow.fromSinkAndSource(Sink.ignore, Source.single(GraphInterpreter.currentInterpreter))
+      }
+
+      Source.empty.via(flow).runWith(Sink.head).futureValue should not be null
     }
 
     "propagate materialized value" in {


### PR DESCRIPTION
Motivation:
Currently, It throws NPE when accessing the current interpreter in `Flow.fromMaterializer`, with this change,  it works.