### PR TITLE
feat: Optimize recoverWith stream operator for single source.

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -52,6 +52,20 @@ class FlowRecoverWithSpec extends StreamSpec {
         .expectComplete()
     }
 
+    "recover with single source" in {
+      Source(1 to 4)
+        .map { a =>
+          if (a == 3) throw ex else a
+        }
+        .recoverWith { case _: Throwable => Source.single(3) }
+        .runWith(TestSink[Int]())
+        .request(2)
+        .expectNextN(1 to 2)
+        .request(1)
+        .expectNext(3)
+        .expectComplete()
+    }
+
     "cancel substream if parent is terminated when there is a handler" in {
       Source(1 to 4)
         .map { a =>

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2158,8 +2158,13 @@ private[akka] object TakeWithin {
             case source: Graph[SourceShape[T] @unchecked, M @unchecked] if TraversalBuilder.isEmptySource(source) =>
               completeStage()
             case other: Graph[SourceShape[T] @unchecked, M @unchecked] =>
-              switchTo(other)
-              attempt += 1
+              TraversalBuilder.getSingleSource(other) match {
+                case OptionVal.Some(singleSource) =>
+                  emit(out, singleSource.elem.asInstanceOf[T], () => completeStage())
+                case _ =>
+                  switchTo(other)
+                  attempt += 1
+              }
             case _ => throw new IllegalStateException() // won't happen, compiler exhaustiveness check pleaser
           }
         } else


### PR DESCRIPTION
Motivation:
Event there is a dedicated `recover` which can provide a single value, user can sometime use `recoverWith` a `Source.single` too.
seems like Reactor's special onErrorReturn ,where a single value is recovered , we can avoid the sub materialization too.

Result:
Sub-materialization is avoid for `recoverWith(Source.single(..))`