### PR TITLE
chore: resolve version in link-checker

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -11,10 +11,14 @@ permissions:
 jobs:
   validate-links:
     runs-on: ubuntu-22.04
-    if: github.repository == 'akka/akka'
+    if: github.event.repository.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        # https://github.com/actions/checkout/releases
+        # v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -23,10 +27,14 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.4.0
+        # https://github.com/coursier/cache-action/releases
+        # v6.4.5
+        uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.3.0
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.5
+        uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.11
           apps: cs


### PR DESCRIPTION
Not sure why I didn't see it before but the links to API docs did not resolve as sbt dynver didn't resolve the version properly on the short git history of just the latest commit.

Fetching tags should be enough, I believe.