### PR TITLE
fix: Native-image JFR enable flag was missing

### DIFF
--- a/akka-actor-typed/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-actor-typed/native-image.properties
+++ b/akka-actor-typed/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-actor-typed/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr

--- a/akka-cluster-sharding/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster-sharding/native-image.properties
+++ b/akka-cluster-sharding/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster-sharding/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr

--- a/akka-remote/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-remote/native-image.properties
+++ b/akka-remote/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-remote/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-monitoring=jfr


### PR DESCRIPTION
Originally had it in akka-actor but now adding in the specific modules that does emit JFR events instead