### PR TITLE
fix: JoinConfigChecker and Scala 3

### DIFF
--- a/akka-cluster/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster/reflect-config.json
+++ b/akka-cluster/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster/reflect-config.json
@@ -47,7 +47,7 @@
     "name" : "<init>"
   } ]
 }, {
-  "name" : "akka.cluster.JoinConfigCompatChecker$$anon$1",
+  "name" : "akka.cluster.JoinConfigCompatChecker$CompositeChecker",
   "methods" : [ {
     "name" : "<init>"
   } ]

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
@@ -148,17 +148,18 @@ object JoinConfigCompatChecker {
           .get // can't continue if we can't load it
       }
 
-    // composite checker
-    new JoinConfigCompatChecker {
-      override val requiredKeys: im.Seq[String] = {
-        // Always include akka.version (used in join logging)
-        "akka.version" +: checkers.flatMap(_.requiredKeys).to(im.Seq)
-      }
-      override def check(toValidate: Config, clusterConfig: Config): ConfigValidation =
-        checkers.foldLeft(Valid: ConfigValidation) { (acc, checker) =>
-          acc ++ checker.check(toValidate, clusterConfig)
-        }
+    new CompositeChecker(checkers)
+  }
+
+  private final class CompositeChecker(checkers: Set[JoinConfigCompatChecker]) extends JoinConfigCompatChecker {
+    override val requiredKeys: im.Seq[String] = {
+      // Always include akka.version (used in join logging)
+      "akka.version" +: checkers.flatMap(_.requiredKeys).to(im.Seq)
     }
+    override def check(toValidate: Config, clusterConfig: Config): ConfigValidation =
+      checkers.foldLeft(Valid: ConfigValidation) { (acc, checker) =>
+        acc ++ checker.check(toValidate, clusterConfig)
+      }
   }
 }
 


### PR DESCRIPTION
One classpath scanned entry was anonoymous and encoded to different names on Scala 2.13 and Scala 3, so making it an actual class to keep the name stable.

This particular implementation is actually never reflectively created, but filtering it would require adding a new capability to native-image classpath scanning just for this problem so took the shorter path to fix it.