### PR TITLE
fix: proper path when promise actor terminated quickly

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -602,7 +602,7 @@ private[akka] final class PromiseActorRef(
     case StoppedWithPath(p) => p
     case Stopped            =>
       // even if we are already stopped we still need to produce a proper path
-      updateState(Stopped, StoppedWithPath(provider.tempPath()))
+      updateState(Stopped, StoppedWithPath(provider.tempPath(refPathPrefix)))
       path
     case Registering => path // spin until registration is completed
     case unexpected  => throw new IllegalStateException(s"Unexpected state: $unexpected")


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #32330
