### PR TITLE
chore: Remove comment about reset down-all-when-unstable

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -415,8 +415,7 @@ akka.cluster.split-brain-resolver {
   # partition.
   # As a precaution for that scenario all nodes are downed if no decision is made within
   # `stable-after + down-all-when-unstable` from the first unreachability event.
-  # The measurement is reset if all unreachable have been healed, downed or removed, or
-  # if there are no changes within `stable-after * 2`.
+  # The measurement is reset if all unreachable have been healed, downed or removed.
   # The value can be on, off, or a duration.
   # By default it is 'on' and then it is derived to be 3/4 of stable-after, but not less than
   # 4 seconds.

--- a/akka-docs/src/main/paradox/split-brain-resolver.md
+++ b/akka-docs/src/main/paradox/split-brain-resolver.md
@@ -406,8 +406,7 @@ partition.
 
 As a precaution for that scenario all nodes are downed if no decision is made within
 `stable-after + down-all-when-unstable` from the first unreachability event.
-The measurement is reset if all unreachable have been healed, downed or removed, or
-if there are no changes within `stable-after * 2`.
+The measurement is reset if all unreachable have been healed, downed or removed.
 
 This is enabled by default for all strategies and by default the duration is derived to
 be 3/4 of `stable-after`.


### PR DESCRIPTION
* it doesn't fully correspond to implementation, which is only reseting if down-all-when-unstable is disabled (for logging purpose)

See https://github.com/akka/akka/blob/43966063e49358f9caf1a700435929f9c34c1460/akka-cluster/src/main/scala/akka/cluster/sbr/SplitBrainResolver.scala#L313-L314