### PR TITLE
chore: fetch more history for the link validator

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -18,6 +18,7 @@ jobs:
         # v4.1.1
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          fetch-depth: 2000
           fetch-tags: true
 
       - name: Checkout GitHub merge


### PR DESCRIPTION
Dynver needs more history to figure out the current version.

References
- https://github.com/akka/akka/pull/32319
