### PR TITLE
chore: Mark up all classic internals as such

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
@@ -4,19 +4,21 @@
 
 package akka.actor
 
-import java.lang.reflect.{ Modifier, ParameterizedType, TypeVariable }
-import java.lang.reflect.Constructor
+import akka.annotation.InternalApi
 
+import java.lang.reflect.{Modifier, ParameterizedType, TypeVariable}
+import java.lang.reflect.Constructor
 import scala.annotation.tailrec
 import scala.annotation.varargs
-
 import akka.japi.Creator
 import akka.util.Reflect
 
 /**
- *
  * Java API: Factory for Props instances.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[akka] trait AbstractProps {
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
@@ -6,7 +6,7 @@ package akka.actor
 
 import akka.annotation.InternalApi
 
-import java.lang.reflect.{Modifier, ParameterizedType, TypeVariable}
+import java.lang.reflect.{ Modifier, ParameterizedType, TypeVariable }
 import java.lang.reflect.Constructor
 import scala.annotation.tailrec
 import scala.annotation.varargs

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -127,6 +127,7 @@ final case class Terminated private[akka] (@BeanProperty actor: ActorRef)(
  * The watcher ([[akka.actor.dungeon.DeathWatch]]) subscribes to the `AddressTerminatedTopic`
  * and translates this event to [[akka.actor.Terminated]], which is sent itself.
  */
+@InternalApi
 @SerialVersionUID(1L)
 private[akka] final case class AddressTerminated(address: Address)
     extends AutoReceivedMessage
@@ -156,12 +157,16 @@ trait NotInfluenceReceiveTimeout
 /**
  * IllegalActorStateException is thrown when a core invariant in the Actor implementation has been violated.
  * For instance, if you try to create an Actor that doesn't extend Actor.
+ *
+ * Not for user instatiation
  */
 @SerialVersionUID(1L)
 final case class IllegalActorStateException private[akka] (message: String) extends AkkaException(message)
 
 /**
  * ActorKilledException is thrown when an Actor receives the [[akka.actor.Kill]] message
+ *
+ * Not for user instatiation
  */
 @SerialVersionUID(1L)
 final case class ActorKilledException private[akka] (message: String) extends AkkaException(message) with NoStackTrace

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -357,10 +357,9 @@ private[akka] trait Cell {
 }
 
 /**
- * Everything in here is completely Akka PRIVATE. You will not find any
- * supported APIs in this place. This is not the API you were looking
- * for! (waves hand)
+ * INTERNAL API
  */
+@InternalApi
 private[akka] object ActorCell {
   val contextStack = new ThreadLocal[List[ActorContext]] {
     override def initialValue: List[ActorContext] = Nil
@@ -402,10 +401,9 @@ private[akka] object ActorCell {
 //vars don't need volatile since it's protected with the mailbox status
 //Make sure that they are not read/written outside of a message processing (systemInvoke/invoke)
 /**
- * Everything in here is completely Akka PRIVATE. You will not find any
- * supported APIs in this place. This is not the API you were looking
- * for! (waves hand)
+ * INTERNAL API
  */
+@InternalApi
 @nowarn("msg=deprecated")
 private[akka] class ActorCell(
     val system: ActorSystemImpl,

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -311,6 +311,9 @@ final case class RootActorPath(address: Address, name: String = "/") extends Act
 
 }
 
+/**
+ * Not for user instantiation
+ */
 @SerialVersionUID(1L)
 final class ChildActorPath private[akka] (val parent: ActorPath, val name: String, override private[akka] val uid: Int)
     extends ActorPath {

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -103,7 +103,10 @@ object ActorRef {
  * If you need to keep track of actor references in a collection and do not care
  * about the exact actor incarnation you can use the ``ActorPath`` as key because
  * the unique id of the actor is not taken into account when comparing actor paths.
+ *
+ * Not for user extension
  */
+@DoNotInherit
 @nowarn("msg=deprecated")
 abstract class ActorRef extends java.lang.Comparable[ActorRef] with Serializable {
   scalaRef: InternalActorRef with ActorRefScope =>
@@ -209,14 +212,20 @@ trait ScalaActorRef { ref: ActorRef with InternalActorRef with ActorRefScope =>
  * All ActorRefs have a scope which describes where they live. Since it is
  * often necessary to distinguish between local and non-local references, this
  * is the only method provided on the scope.
+ *
+ * Internal API
  */
+@InternalApi
 private[akka] trait ActorRefScope {
   def isLocal: Boolean
 }
 
 /**
  * Refs which are statically known to be local inherit from this Scope
+ *
+ * Internal API
  */
+@InternalApi
 private[akka] trait LocalRef extends ActorRefScope {
   final def isLocal = true
 }
@@ -251,7 +260,7 @@ private[akka] trait RepointableRef extends ActorRefScope {
  * Internal trait for assembling all the functionality needed internally on
  * ActorRefs. NOTE THAT THIS IS NOT A STABLE EXTERNAL INTERFACE!
  *
- * DO NOT USE THIS UNLESS INTERNALLY WITHIN AKKA!
+ * INTERNAL API
  */
 @nowarn("msg=deprecated")
 @InternalApi private[akka] abstract class InternalActorRef extends ActorRef with ScalaActorRef { this: ActorRefScope =>
@@ -304,7 +313,10 @@ private[akka] trait RepointableRef extends ActorRefScope {
  * LocalActorRef and RepointableActorRef. The former specializes the return
  * type of `underlying` so that follow-up calls can use invokevirtual instead
  * of invokeinterface.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[akka] abstract class ActorRefWithCell extends InternalActorRef { this: ActorRefScope =>
   def underlying: Cell
   def children: immutable.Iterable[ActorRef]
@@ -313,7 +325,10 @@ private[akka] abstract class ActorRefWithCell extends InternalActorRef { this: A
 
 /**
  * This is an internal look-up failure token, not useful for anything else.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[akka] case object Nobody extends MinimalActorRef {
   override val path: RootActorPath = new RootActorPath(Address("akka", "all-systems"), "/Nobody")
   override def provider = throw new UnsupportedOperationException("Nobody does not provide")
@@ -327,6 +342,7 @@ private[akka] case object Nobody extends MinimalActorRef {
 /**
  * INTERNAL API
  */
+@InternalApi
 @SerialVersionUID(1L) private[akka] class SerializedNobody extends Serializable {
   @throws(classOf[java.io.ObjectStreamException])
   private def readResolve(): AnyRef = Nobody
@@ -337,6 +353,7 @@ private[akka] case object Nobody extends MinimalActorRef {
  *
  *  INTERNAL API
  */
+@InternalApi
 private[akka] class LocalActorRef private[akka] (
     _system: ActorSystemImpl,
     _props: Props,
@@ -457,6 +474,7 @@ private[akka] class LocalActorRef private[akka] (
  * Memento pattern for serializing ActorRefs transparently
  * INTERNAL API
  */
+@InternalApi
 @SerialVersionUID(1L)
 private[akka] final case class SerializedActorRef private (path: String) {
   import akka.serialization.JavaSerializer.currentSystem
@@ -479,6 +497,7 @@ private[akka] final case class SerializedActorRef private (path: String) {
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] object SerializedActorRef {
   def apply(actorRef: ActorRef): SerializedActorRef = {
     new SerializedActorRef(actorRef)
@@ -490,6 +509,7 @@ private[akka] object SerializedActorRef {
  *
  * INTERNAL API
  */
+@InternalApi
 private[akka] trait MinimalActorRef extends InternalActorRef with LocalRef {
 
   override def getParent: InternalActorRef = Nobody
@@ -657,6 +677,7 @@ private[akka] object DeadLetterActorRef {
  *
  * INTERNAL API
  */
+@InternalApi
 private[akka] class EmptyLocalActorRef(
     override val provider: ActorRefProvider,
     override val path: ActorPath,
@@ -719,6 +740,7 @@ private[akka] class EmptyLocalActorRef(
  *
  * INTERNAL API
  */
+@InternalApi
 private[akka] class DeadLetterActorRef(_provider: ActorRefProvider, _path: ActorPath, _eventStream: EventStream)
     extends EmptyLocalActorRef(_provider, _path, _eventStream) {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -176,7 +176,10 @@ import akka.util.OptionVal
 /**
  * Interface implemented by ActorSystem and ActorContext, the only two places
  * from which you can get fresh actors.
+ *
+ * Not for user extension
  */
+@DoNotInherit
 @implicitNotFound(
   "implicit ActorRefFactory required: if outside of an Actor you need an implicit ActorSystem, inside of an actor this should be the implicit ActorContext")
 trait ActorRefFactory {
@@ -280,11 +283,13 @@ trait ActorRefFactory {
 /**
  * Internal Akka use only, used in implementation of system.stop(child).
  */
+@InternalApi
 private[akka] final case class StopChild(child: ActorRef)
 
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] object SystemGuardian {
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -4,9 +4,10 @@
 
 package akka.actor
 
+import akka.annotation.InternalApi
+
 import java.util.concurrent.CompletionStage
 import java.util.regex.Pattern
-
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -16,7 +17,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.Success
-
 import akka.dispatch.ExecutionContexts
 import akka.pattern.ask
 import akka.routing.MurmurHash
@@ -307,6 +307,7 @@ private[akka] sealed trait SelectionPathElement
 /**
  * INTERNAL API
  */
+@InternalApi
 @SerialVersionUID(2L)
 private[akka] final case class SelectChildName(name: String) extends SelectionPathElement {
   override def toString: String = name
@@ -315,6 +316,7 @@ private[akka] final case class SelectChildName(name: String) extends SelectionPa
 /**
  * INTERNAL API
  */
+@InternalApi
 @SerialVersionUID(2L)
 private[akka] final case class SelectChildPattern(patternStr: String) extends SelectionPathElement {
   val pattern: Pattern = Helpers.makePattern(patternStr)
@@ -324,6 +326,7 @@ private[akka] final case class SelectChildPattern(patternStr: String) extends Se
 /**
  * INTERNAL API
  */
+@InternalApi
 @SerialVersionUID(2L)
 private[akka] case object SelectParent extends SelectionPathElement {
   override def toString: String = ".."

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -22,6 +22,8 @@ import akka.annotation.InternalApi
  * This class is final to allow use as a case class (copy method etc.); if
  * for example a remote transport would want to associate additional
  * information with an address, then this must be done externally.
+ *
+ * Not for user instantiation
  */
 @SerialVersionUID(1L)
 final case class Address private[akka] (protocol: String, system: String, host: Option[String], port: Option[Int]) {
@@ -133,6 +135,10 @@ object Address {
   }
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] trait PathUtils {
   protected def split(s: String, fragment: String): List[String] = {
     @tailrec

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -290,6 +290,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
   /**
    * INTERNAL API
    */
+  @InternalApi
   private[akka] final case class Phase(
       dependsOn: Set[String],
       timeout: FiniteDuration,
@@ -355,6 +356,9 @@ private[akka] object JVMShutdownHooks extends JVMShutdownHooks {
   override def removeHook(t: Thread): Boolean = Runtime.getRuntime.removeShutdownHook(t)
 }
 
+/**
+ * Not for user instantiation, use the extension to access
+ */
 final class CoordinatedShutdown private[akka] (
     system: ExtendedActorSystem,
     phases: Map[String, CoordinatedShutdown.Phase],

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -211,7 +211,10 @@ case object NoScopeGiven extends NoScopeGiven {
 
 /**
  * Deployer maps actor paths to actor deployments.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAccess: DynamicAccess) {
 
   import akka.util.ccompat.JavaConverters._

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -24,11 +24,13 @@ import akka.util.ccompat._
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] sealed trait ChildStats
 
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] case object ChildNameReserved extends ChildStats
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
+++ b/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
@@ -4,9 +4,10 @@
 
 package akka.actor
 
+import akka.annotation.InternalApi
+
 import scala.annotation.nowarn
 import scala.collection.immutable
-
 import akka.japi.Creator
 import akka.util.Reflect
 
@@ -68,6 +69,7 @@ private[akka] object IndirectActorProducer {
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] class CreatorFunctionConsumer(creator: () => Actor) extends IndirectActorProducer {
   override def actorClass = classOf[Actor]
   override def produce() = creator()
@@ -76,6 +78,7 @@ private[akka] class CreatorFunctionConsumer(creator: () => Actor) extends Indire
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] class CreatorConsumer(clazz: Class[_ <: Actor], creator: Creator[Actor]) extends IndirectActorProducer {
   override def actorClass = clazz
   override def produce() = creator.create()
@@ -84,6 +87,7 @@ private[akka] class CreatorConsumer(clazz: Class[_ <: Actor], creator: Creator[A
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] class TypedCreatorFunctionConsumer(clz: Class[_ <: Actor], creator: () => Actor)
     extends IndirectActorProducer {
   override def actorClass = clz
@@ -93,6 +97,7 @@ private[akka] class TypedCreatorFunctionConsumer(clz: Class[_ <: Actor], creator
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] class ArgsReflectConstructor(clz: Class[_ <: Actor], args: immutable.Seq[Any])
     extends IndirectActorProducer {
   private[this] val constructor = Reflect.findConstructor(clz, args)
@@ -103,6 +108,7 @@ private[akka] class ArgsReflectConstructor(clz: Class[_ <: Actor], args: immutab
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] class NoArgsReflectConstructor(clz: Class[_ <: Actor]) extends IndirectActorProducer {
   Reflect.findConstructor(clz, List.empty)
   override def actorClass = clz

--- a/akka-actor/src/main/scala/akka/actor/Props.scala
+++ b/akka-actor/src/main/scala/akka/actor/Props.scala
@@ -7,8 +7,8 @@ package akka.actor
 import scala.annotation.varargs
 import scala.collection.immutable
 import scala.reflect.ClassTag
-
 import akka.actor.Deploy.{ NoDispatcherGiven, NoMailboxGiven }
+import akka.annotation.InternalApi
 import akka.dispatch._
 import akka.routing._
 
@@ -51,6 +51,7 @@ object Props extends AbstractProps {
    *
    * (Not because it is so immensely complicated, only because we might remove it if no longer needed internally)
    */
+  @InternalApi
   private[akka] class EmptyActor extends Actor {
     def receive = Actor.emptyBehavior
   }

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -6,13 +6,12 @@ package akka.actor
 
 import java.util.{ LinkedList => JLinkedList }
 import java.util.concurrent.locks.ReentrantLock
-
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
-
 import akka.actor.dungeon.ChildrenContainer
+import akka.annotation.InternalApi
 import akka.dispatch._
 import akka.dispatch.sysmsg._
 import akka.event.Logging.Warning
@@ -25,7 +24,10 @@ import akka.util.{ unused, Unsafe }
  * response to the Supervise() message, which will replace the contained Cell
  * with a fully functional one, transfer all messages from dummy to real queue
  * and swap out the cell ref.
+ *
+ * INTERNAL API
  */
+@InternalApi
 private[akka] class RepointableActorRef(
     val system: ActorSystemImpl,
     val props: Props,
@@ -186,6 +188,10 @@ private[akka] class RepointableActorRef(
   protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] class UnstartedCell(
     val systemImpl: ActorSystemImpl,
     val self: RepointableActorRef,

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -9,7 +9,12 @@ import scala.util.control.NoStackTrace
 import akka.AkkaException
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
-import akka.dispatch.{DequeBasedMessageQueueSemantics, Envelope, RequiresMessageQueue, UnboundedDequeBasedMessageQueueSemantics}
+import akka.dispatch.{
+  DequeBasedMessageQueueSemantics,
+  Envelope,
+  RequiresMessageQueue,
+  UnboundedDequeBasedMessageQueueSemantics
+}
 
 /**
  *  The `Stash` trait enables an actor to temporarily stash away messages that can not or

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -6,15 +6,10 @@ package akka.actor
 
 import scala.collection.immutable
 import scala.util.control.NoStackTrace
-
 import akka.AkkaException
+import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
-import akka.dispatch.{
-  DequeBasedMessageQueueSemantics,
-  Envelope,
-  RequiresMessageQueue,
-  UnboundedDequeBasedMessageQueueSemantics
-}
+import akka.dispatch.{DequeBasedMessageQueueSemantics, Envelope, RequiresMessageQueue, UnboundedDequeBasedMessageQueueSemantics}
 
 /**
  *  The `Stash` trait enables an actor to temporarily stash away messages that can not or
@@ -99,6 +94,7 @@ trait UnrestrictedStash extends Actor with StashSupport {
  *
  * @see [[StashSupport]]
  */
+@InternalApi
 private[akka] trait StashFactory { this: Actor =>
   private[akka] def createStash()(implicit ctx: ActorContext, ref: ActorRef): StashSupport = new StashSupport {
     def context: ActorContext = ctx

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -5,21 +5,28 @@
 package akka.actor.dungeon
 
 import java.util.Optional
-
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
-
 import akka.actor._
+import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }
 import akka.util.{ Helpers, Unsafe }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] object Children {
   val GetNobody = () => Nobody
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] trait Children { this: ActorCell =>
 
   import ChildrenContainer._

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
@@ -5,13 +5,14 @@
 package akka.actor.dungeon
 
 import scala.collection.immutable
-
 import akka.actor.{ ActorRef, ChildNameReserved, ChildRestartStats, ChildStats, InvalidActorNameException }
+import akka.annotation.InternalApi
 import akka.util.Collections.{ EmptyImmutableSeq, PartialImmutableValuesIterable }
 
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] trait ChildrenContainer {
 
   def add(name: String, stats: ChildRestartStats): ChildrenContainer
@@ -40,6 +41,7 @@ private[akka] trait ChildrenContainer {
  * This object holds the classes performing the logic of managing the children
  * of an actor, hence they are intimately tied to ActorCell.
  */
+@InternalApi
 private[akka] object ChildrenContainer {
 
   sealed trait SuspendReason

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -5,11 +5,16 @@
 package akka.actor.dungeon
 
 import akka.actor.{ Actor, ActorCell, ActorRef, ActorRefScope, Address, InternalActorRef, Terminated }
+import akka.annotation.InternalApi
 import akka.dispatch.sysmsg.{ DeathWatchNotification, Unwatch, Watch }
 import akka.event.AddressTerminatedTopic
 import akka.event.Logging.{ Debug, Warning }
 import akka.util.unused
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] trait DeathWatch { this: ActorCell =>
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -6,15 +6,23 @@ package akka.actor.dungeon
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.ActorCell
 import akka.actor.Cancellable
 import akka.actor.NotInfluenceReceiveTimeout
+import akka.annotation.InternalApi
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] object ReceiveTimeout {
   final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] trait ReceiveTimeout { this: ActorCell =>
 
   import ActorCell._


### PR DESCRIPTION
Just adding `@InternalApi` and Scaladoc on `private[akka]` types where it was missing, and aligning some of the old "fun" ways of saying `INTERNAL API` in docs.