### PR TITLE
Use state not var

### DIFF
--- a/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
@@ -40,7 +40,7 @@ object DeviceInProgress2 {
 
   object Device {
     def apply(groupId: String, deviceId: String): Behavior[Command] =
-      Behaviors.setup(context => new Device(context, groupId, deviceId))
+      Behaviors.setup(context => new Device(context, groupId, deviceId, None))
 
     //#read-protocol-2
     sealed trait Command
@@ -49,11 +49,13 @@ object DeviceInProgress2 {
     //#read-protocol-2
   }
 
-  class Device(context: ActorContext[Device.Command], groupId: String, deviceId: String)
+  class Device(
+      context: ActorContext[Device.Command],
+      groupId: String,
+      deviceId: String,
+      lastTemperatureReading: Option[Double])
       extends AbstractBehavior[Device.Command](context) {
     import Device._
-
-    var lastTemperatureReading: Option[Double] = None
 
     context.log.info2("Device actor {}-{} started", groupId, deviceId)
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
From what I've learned so far Actors have an intrinsic mechanizm for keeping  State by returning an updated Behaviour after each interaction. So it is a bit disappointing to see a `var` used here instead. 
I anticipated something like this. Does it make sense?


