### PR TITLE
feat: default to not need jsoncreator annotations

### DIFF
--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -96,37 +96,6 @@ The binary format is more compact, with slightly better performance than the JSO
 
 ## Annotations
 
-@@@ div {.group-java}
-
-### Constructor with single parameter
-
-You might run into an exception like this:
-
-```
-MismatchedInputException: Cannot construct instance of `...` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
-```
-
-That is probably because the class has a constructor with a single parameter, like:
-
-Java
-:  @@snip [SerializationDocTest.java](/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/SerializationDocTest.java) { #one-constructor-param-1 }
-
-That can be solved by adding @javadoc[@JsonCreator](com.fasterxml.jackson.annotation.JsonCreator) or @javadoc[@JsonProperty](com.fasterxml.jackson.annotation.JsonProperty) annotations:
-
-Java
-:  @@snip [SerializationDocTest.java](/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/SerializationDocTest.java) { #one-constructor-param-2 }
-
-or
-
-Java
-:  @@snip [SerializationDocTest.java](/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/SerializationDocTest.java) { #one-constructor-param-3 }
-
-
-The `ParameterNamesModule` is configured with `JsonCreator.Mode.PROPERTIES` as described in the
-[Jackson documentation](https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names#delegating-creator)
-
-@@@
-
 ### Polymorphic types
 
 A polymorphic type is when a certain base type has multiple alternative implementations. When nested fields or

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -233,7 +233,7 @@ backwards compatible without migration code.
 
 Implement the transformation of the old JSON structure to the new JSON structure in the @apidoc[transform(fromVersion, jsonNode)](JacksonMigration) {scala="#transform(fromVersion:Int,json:com.fasterxml.jackson.databind.JsonNode):com.fasterxml.jackson.databind.JsonNode" java="#transform(int,com.fasterxml.jackson.databind.JsonNode)"} method.
 The @javadoc[JsonNode](com.fasterxml.jackson.databind.JsonNode)
-is mutable so you can add and remove fields, or change values. Note that you have to cast to specific sub-classes
+is mutable, so you can add and remove fields, or change values. Note that you have to cast to specific sub-classes
 such as @javadoc[ObjectNode](com.fasterxml.jackson.databind.node.ObjectNode)
 and @javadoc[ArrayNode](com.fasterxml.jackson.databind.node.ArrayNode)
 to get access to mutators.
@@ -334,7 +334,7 @@ That type of migration must be configured with the old class name as key. The ac
 
 ### Remove from serialization-bindings
 
-When a class is not used for serialization any more it can be removed from `serialization-bindings` but to still
+When a class is not used for serialization anymore it can be removed from `serialization-bindings` but to still
 allow deserialization it must then be listed in the `allowed-class-prefix` configuration. This is useful for example
 during rolling update with serialization changes, or when reading old stored data. It can also be used
 when changing from Jackson serializer to another serializer (e.g. Protobuf) and thereby changing the serialization
@@ -448,7 +448,7 @@ The type will be embedded as an object with the fields:
 
 ### Configuration per binding
 
-By default the configuration for the Jackson serializers and their @javadoc[ObjectMapper](com.fasterxml.jackson.databind.ObjectMapper)s is defined in
+By default, the configuration for the Jackson serializers and their @javadoc[ObjectMapper](com.fasterxml.jackson.databind.ObjectMapper)s is defined in
 the `akka.serialization.jackson` section. It is possible to override that configuration in a more
 specific `akka.serialization.jackson.<binding name>` section.
 
@@ -491,7 +491,7 @@ other purposes, such as persistence or distributed data.
 ## Additional features
 
 Additional Jackson serialization features can be enabled/disabled in configuration. The default values from
-Jackson are used aside from the the following that are changed in Akka's default configuration.
+Jackson are used aside from the following that are changed in Akka's default configuration.
 
 @@snip [reference.conf](/akka-serialization-jackson/src/main/resources/reference.conf) { #features }
 
@@ -504,4 +504,4 @@ you can change the following configuration for better performance of date/time f
 
 @@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #date-time }
 
-Jackson is still be able to deserialize the other format independent of this setting.
+Jackson is still able to deserialize the other format independent of this setting.

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -140,6 +140,8 @@ class EventSourcedSequenceNumberSpec
       probe.expectMessage("6 eventHandler evt2")
       probe.expectMessage("7 eventHandler evt3")
       probe.expectMessage("7 thenRun")
+
+      ref ! "stop"
     }
 
     // reproducer for #27935

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -140,8 +140,6 @@ class EventSourcedSequenceNumberSpec
       probe.expectMessage("6 eventHandler evt2")
       probe.expectMessage("7 eventHandler evt3")
       probe.expectMessage("7 thenRun")
-
-      ref ! "stop"
     }
 
     // reproducer for #27935

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -67,6 +67,12 @@ akka.serialization.jackson {
   # }
   mapper-features {}
 
+  # Allowed values USE_PROPERTIES_BASED, USE_DELEGATING, DEFAULT, EXPLICIT_ONLY
+  # see com.fasterxml.jackson.databind.cfg.ConstructorDetector for details for each option
+  # The default USE_PROPERTIES_BASED allows for detecting single argument constructors without @JsonCreator annotations
+  # while DEAFULT provides the old Jackson behavior of requiring such an annotation.
+  constructor-detector-mode = "USE_PROPERTIES_BASED"
+
   # Configuration of the ObjectMapper JsonParser features.
   # See com.fasterxml.jackson.core.JsonParser.Feature
   # Enum values corresponding to the JsonParser.Feature and their

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -6,13 +6,11 @@ package akka.serialization.jackson
 
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 import scala.util.Failure
 import scala.util.Success
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.PropertyAccessor
@@ -32,7 +30,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import com.typesafe.config.Config
-
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.actor.DynamicAccess
@@ -45,6 +42,7 @@ import akka.annotation.InternalStableApi
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.util.unused
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector
 
 object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvider] with ExtensionIdProvider {
   override def get(system: ActorSystem): JacksonObjectMapperProvider = super.get(system)
@@ -166,6 +164,17 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
         // of the ObjectMapper
         objectMapper.configure(feature, value)
     }
+
+    val constructorDetector = config.getString("constructor-detector-mode") match {
+      case "USE_PROPERTIES_BASED" => ConstructorDetector.USE_PROPERTIES_BASED
+      case "USE_DELEGATING"       => ConstructorDetector.USE_DELEGATING
+      case "DEFAULT"              => ConstructorDetector.DEFAULT
+      case "EXPLICIT_ONLY"        => ConstructorDetector.EXPLICIT_ONLY
+      case unknown =>
+        throw new IllegalArgumentException(
+          s"Unknown constructor-detector-mode [$unknown], must be one of [USE_PROPERTIES_BASED, USE_DELEGATING, DEFAULT, EXPLICIT_ONLY]")
+    }
+    objectMapper.setConstructorDetector(constructorDetector)
 
     val configuredJsonParserFeatures = features(config, "json-parser-features").map {
       case (enumName, value) => JsonParser.Feature.valueOf(enumName) -> value

--- a/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
+++ b/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
@@ -6,7 +6,6 @@ package akka.serialization.jackson;
 
 import akka.actor.ActorRef;
 import akka.actor.Address;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -23,10 +22,6 @@ public interface JavaTestMessages {
   public class SimpleCommand implements TestMessage {
     private final String name;
 
-    // @JsonCreator or @JsonProperty needed due to single argument constructor, see
-    // rejected change request in Jackson https://github.com/FasterXML/jackson-databind/issues/1631
-    // See also https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names
-    @JsonCreator
     public SimpleCommand(String name) {
       this.name = name;
     }
@@ -207,7 +202,6 @@ public interface JavaTestMessages {
   public class InstantCommand implements TestMessage {
     public final Instant instant;
 
-    @JsonCreator
     public InstantCommand(Instant instant) {
       this.instant = instant;
     }
@@ -424,7 +418,6 @@ public interface JavaTestMessages {
   public class Zoo implements TestMessage {
     public final Animal first;
 
-    @JsonCreator
     public Zoo(Animal first) {
       this.first = first;
     }
@@ -455,7 +448,6 @@ public interface JavaTestMessages {
   public final class Lion implements Animal {
     public final String name;
 
-    @JsonCreator
     public Lion(String name) {
       this.name = name;
     }
@@ -507,7 +499,6 @@ public interface JavaTestMessages {
   final class Cockroach implements Animal {
     public final String name;
 
-    @JsonCreator
     public Cockroach(String name) {
       this.name = name;
     }
@@ -535,7 +526,6 @@ public interface JavaTestMessages {
     protected final String protectedField = "vwxyz";
     private final String privateField = "ABCD";
 
-    @JsonCreator
     public ClassWithVisibility() {}
   }
 }

--- a/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/SerializationDocTest.java
+++ b/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/SerializationDocTest.java
@@ -5,7 +5,6 @@
 package jdoc.akka.serialization.jackson;
 
 import akka.serialization.jackson.JsonSerializable;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -30,7 +29,6 @@ public class SerializationDocTest {
     public class SimpleCommand implements JsonSerializable {
       private final String name;
 
-      @JsonCreator
       public SimpleCommand(String name) {
         this.name = name;
       }
@@ -55,7 +53,6 @@ public class SerializationDocTest {
     public class Zoo implements JsonSerializable {
       public final Animal primaryAttraction;
 
-      @JsonCreator
       public Zoo(Animal primaryAttraction) {
         this.primaryAttraction = primaryAttraction;
       }
@@ -71,7 +68,6 @@ public class SerializationDocTest {
     public final class Lion implements Animal {
       public final String name;
 
-      @JsonCreator
       public Lion(String name) {
         this.name = name;
       }

--- a/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/v1/OrderAdded.java
+++ b/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/v1/OrderAdded.java
@@ -5,13 +5,11 @@
 package jdoc.akka.serialization.jackson.v1;
 
 import akka.serialization.jackson.JsonSerializable;
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 // #rename-class
 public class OrderAdded implements JsonSerializable {
   public final String shoppingCartId;
 
-  @JsonCreator
   public OrderAdded(String shoppingCartId) {
     this.shoppingCartId = shoppingCartId;
   }

--- a/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/v2a/OrderPlaced.java
+++ b/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/v2a/OrderPlaced.java
@@ -5,13 +5,11 @@
 package jdoc.akka.serialization.jackson.v2a;
 
 import akka.serialization.jackson.JsonSerializable;
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 // #rename-class
 public class OrderPlaced implements JsonSerializable {
   public final String shoppingCartId;
 
-  @JsonCreator
   public OrderPlaced(String shoppingCartId) {
     this.shoppingCartId = shoppingCartId;
   }

--- a/native-image-tests/local-scala/src/main/java/com/lightbend/JavaJacksonModels.java
+++ b/native-image-tests/local-scala/src/main/java/com/lightbend/JavaJacksonModels.java
@@ -4,7 +4,6 @@
 package com.lightbend;
 
 import akka.serialization.jackson.JsonSerializable;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -14,7 +13,6 @@ public class JavaJacksonModels {
 
     public static class SimpleCommand implements JsonSerializable {
         private final String name;
-        @JsonCreator
         public SimpleCommand(String name) {
             this.name = name;
         }
@@ -38,7 +36,6 @@ public class JavaJacksonModels {
     public static class Zoo implements JsonSerializable {
         public final Animal primaryAttraction;
 
-        @JsonCreator
         public Zoo(Animal primaryAttraction) {
             this.primaryAttraction = primaryAttraction;
         }
@@ -69,7 +66,6 @@ public class JavaJacksonModels {
     public static final class Lion implements Animal {
         public final String name;
 
-        @JsonCreator
         public Lion(String name) {
             this.name = name;
         }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #32328

I don't see from the discussion in https://github.com/FasterXML/jackson-databind/issues/1631 why this would be a problem for us, in our case the hierarchy of messages is explicit through the marker trait, so "It will expose all kinds of constructors" seems moot.

For the unlikely case of ending up with conflict it is possible to completely opt-out or annotate such a class with an explicit `@JsonCreator` on one of the conflicting constructors to choose or selectively opt out for a class using `@JsonCreator(mode = JsonCreator.Mode.DEFAULT)`.
