### PR TITLE
perf: Use spliterator directly in Source.fromJavaStream #32380

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/JavaStreamSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JavaStreamSource.scala
@@ -8,6 +8,8 @@ import akka.annotation.InternalApi
 import akka.stream._
 import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 
+import java.util.function.Consumer
+
 /** INTERNAL API */
 @InternalApi private[stream] final class JavaStreamSource[T, S <: java.util.stream.BaseStream[T, S]](
     open: () => java.util.stream.BaseStream[T, S])
@@ -17,15 +19,17 @@ import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
   override val shape: SourceShape[T] = SourceShape(out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with OutHandler {
+    new GraphStageLogic(shape) with OutHandler with Consumer[T] {
       private[this] var stream: java.util.stream.BaseStream[T, S] = _
-      private[this] var iter: java.util.Iterator[T] = _
+      private[this] var iter: java.util.Spliterator[T] = _
 
       setHandler(out, this)
 
+      override def accept(t: T): Unit = push(out, t)
+
       override def preStart(): Unit = {
         stream = open()
-        iter = stream.iterator()
+        iter = stream.spliterator()
       }
 
       override def postStop(): Unit = {
@@ -34,11 +38,8 @@ import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
       }
 
       override def onPull(): Unit = {
-        if (iter.hasNext) {
-          push(out, iter.next())
-        } else {
+        if (!iter.tryAdvance(this))
           complete(out)
-        }
       }
     }
 }


### PR DESCRIPTION
Refs #32380

Very slight optimization with one less iterator wrapper per stream. Stronger motivation is perhaps that it interacts more directly with the given BaseStream
