### PR TITLE
build: cache-action version

### DIFF
--- a/.github/workflows/check-samples.yml
+++ b/.github/workflows/check-samples.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
-        # v6.4.4
-        uses: coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7
+        # v6.4.5
+        uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
       - name: Set up JDK 17
         # https://github.com/coursier/setup-action/releases


### PR DESCRIPTION
* coursier/cache-action@a0e7cd24be81bc84f0d7461e02bd1a96980553d7 is not allowed to be used in akka/akka

I don't know why, but it failed in https://github.com/akka/akka/actions/runs/8723334467
Trying same version as in another workflow.
