### PR TITLE
fix: Regression in parsing arbitrary pem file blocks

### DIFF
--- a/akka-pki/src/test/scala/akka/pki/pem/DERPrivateKeyLoaderSpec.scala
+++ b/akka-pki/src/test/scala/akka/pki/pem/DERPrivateKeyLoaderSpec.scala
@@ -37,7 +37,7 @@ class DERPrivateKeyLoaderSpec extends AnyWordSpec with Matchers with EitherValue
 
     }
 
-    "parse EdDSA keys" in {
+    "parse ed25519 keys" in {
       assume(sys.props("java.specification.version").toInt >= 15, "Only available in JDK 15 and newer")
       load("ed25519.pem")
     }
@@ -51,7 +51,7 @@ class DERPrivateKeyLoaderSpec extends AnyWordSpec with Matchers with EitherValue
   }
 
   private def load(resource: String): PrivateKey = {
-    val derData: PEMDecoder.DERData = loadDerData(resource)
+    val derData: Seq[PEMDecoder.DERData] = loadDerData(resource)
     DERPrivateKeyLoader.load(derData)
   }
 
@@ -61,7 +61,7 @@ class DERPrivateKeyLoaderSpec extends AnyWordSpec with Matchers with EitherValue
     val path = new File(resourceUrl.toURI).toPath
     val bytes = Files.readAllBytes(path)
     val str = new String(bytes, Charset.forName("UTF-8"))
-    val derData = PEMDecoder.decode(str)
+    val derData = PEMDecoder.decodeAll(str)
     derData
   }
 

--- a/akka-pki/src/test/scala/akka/pki/pem/PEMDecoderSpec.scala
+++ b/akka-pki/src/test/scala/akka/pki/pem/PEMDecoderSpec.scala
@@ -46,6 +46,13 @@ class PEMDecoderSpec extends AnyWordSpec with Matchers with EitherValues {
       new String(result.bytes) should ===("abc")
     }
 
+    "decode data with whatever label" in {
+      val result = PEMDecoder.decode(
+        "-----BEGIN FOO-----" + Base64.getEncoder.encodeToString("abc".getBytes()) + "-----END FOO-----")
+      result.label should ===("FOO")
+      new String(result.bytes) should ===("abc")
+    }
+
     "decode data with lots of spaces" in {
       val result = PEMDecoder.decode(
         "\n \t \r -----BEGIN CERTIFICATE-----\n" +


### PR DESCRIPTION
For parsing EDCSA a pem file contains multiple blocks, I caused a regression by only extracting private keys to support that in #32341 however the pem parser allowed reading arbitrary pem blocks before that. 

This fixes the regression and allows for reading arbitrary entries again, to support the EDCSA use case it introduces a separate few APIs to read all pem entries, and hand a sequence of entries to the DerPrivateKeyLoader to load the first supported private key or fail if none exists.