### PR TITLE
fix: Named CircuitBreakerApi should take ClassicActorSystemProvider

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -14,8 +14,8 @@ import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
-import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
 import akka.testkit._
 
 object CircuitBreakerSpec {
@@ -752,7 +752,11 @@ class CircuitBreakerSpec extends AkkaSpec("""
 
   "An identified asynchronous circuit breaker" must {
 
-    val breaker = new Breaker(CircuitBreaker("identified")(system.asInstanceOf[ExtendedActorSystem]))
+    // verify that new signature is source compatible
+    CircuitBreaker("identified")(system.asInstanceOf[ExtendedActorSystem])
+    CircuitBreaker.lookup("identified", system.asInstanceOf[ExtendedActorSystem])
+
+    val breaker = new Breaker(CircuitBreaker("identified")(system))
     val cb = breaker()
 
     "be closed after success result" taggedAs TimingTest in {

--- a/akka-actor/src/main/mima-filters/2.9.2.backwards.excludes/circuit-breakers.excludes
+++ b/akka-actor/src/main/mima-filters/2.9.2.backwards.excludes/circuit-breakers.excludes
@@ -1,0 +1,4 @@
+# was taking ExtendedActorSystem, now ClassicActorSystemProvider
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.lookup")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.apply")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.apply")

--- a/akka-actor/src/main/mima-filters/2.9.2.backwards.excludes/circuit-breakers.excludes
+++ b/akka-actor/src/main/mima-filters/2.9.2.backwards.excludes/circuit-breakers.excludes
@@ -1,4 +1,3 @@
 # was taking ExtendedActorSystem, now ClassicActorSystemProvider
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.lookup")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.apply")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker.apply")

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.{ Callable, CompletionException, CompletionStage, Co
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicLong }
 import java.util.function.BiFunction
 import java.util.function.Consumer
-
 import scala.annotation.nowarn
 import scala.compat.java8.FutureConverters
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
@@ -18,9 +17,9 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
-
 import akka.AkkaException
-import akka.actor.{ ExtendedActorSystem, Scheduler }
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.Scheduler
 import akka.dispatch.ExecutionContexts.parasitic
 import akka.pattern.internal.{ CircuitBreakerNoopTelemetry, CircuitBreakerTelemetry }
 import akka.util.JavaDurationConverters._
@@ -54,9 +53,9 @@ object CircuitBreaker {
    * Create or find a CircuitBreaker in registry.
    *
    * @param id Circuit Breaker identifier
-   * @param system [[ExtendedActorSystem]] that is storing this [[CircuitBreaker]]
+   * @param system [[ActorSystem]] that is storing this [[CircuitBreaker]]
    */
-  def apply(id: String)(implicit system: ExtendedActorSystem): CircuitBreaker =
+  def apply(id: String)(implicit system: ClassicActorSystemProvider): CircuitBreaker =
     CircuitBreakersRegistry(system).get(id)
 
   /**
@@ -79,12 +78,12 @@ object CircuitBreaker {
     apply(scheduler, maxFailures, callTimeout.asScala, resetTimeout.asScala)
 
   /**
-   * Java API: Lookup a CircuitBreaker in registry.
+   * Java API: Create or find a CircuitBreaker in registry.
    *
    * @param id Circuit Breaker identifier
-   * @param system [[ExtendedActorSystem]] that is storing this [[CircuitBreaker]]
+   * @param system [[ActorSystem]] that is storing this [[CircuitBreaker]]
    */
-  def lookup(id: String, system: ExtendedActorSystem): CircuitBreaker =
+  def lookup(id: String, system: ClassicActorSystemProvider): CircuitBreaker =
     apply(id)(system)
 
   protected def convertJavaFailureFnToScala[T](

--- a/akka-docs/src/main/paradox/project/migration-guide-2.8.x-2.9.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.8.x-2.9.x.md
@@ -59,3 +59,8 @@ version="0.6.1"
 
 Persistent FSM has been deprecated since Akka 2.6.0 (2019-11-06) and has now been dropped. Details on how to migrate can be found in the Akka 2.8
 docs here: https://doc.akka.io/docs/akka/2.8/persistence-fsm.html#migration-to-eventsourcedbehavior
+
+# Migration Guide 2.9.2 to 2.9.3
+
+Named circuit breaker lookup was taking a `ExtendedActorSystem` requiring a typecast, is now requiring a `ClassicActorSystemProvider`.
+This change is source compatible, but not binary compatible, so will require a recompile if you are using named circuit breakers.


### PR DESCRIPTION
Binary breaking but source compatible change. ExtendedActorSystem was a really inconvenient parameter requiring an explicit cast in user code.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/32307
