### PR TITLE
chore: Make DeltaOps public in RES CRDTs

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/crdt/ORSet.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/crdt/ORSet.scala
@@ -43,8 +43,7 @@ object ORSet {
     def underlying: ORSet[A]
   }
 
-  /** INTERNAL API */
-  @InternalApi private[akka] final case class AddDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  final case class AddDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
 
     override def merge(that: DeltaOp): DeltaOp = that match {
       case AddDeltaOp(u) =>
@@ -67,8 +66,7 @@ object ORSet {
     }
   }
 
-  /** INTERNAL API */
-  @InternalApi private[akka] final case class RemoveDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  final case class RemoveDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
     if (underlying.size != 1)
       throw new IllegalArgumentException(s"RemoveDeltaOp should contain one removed element, but was $underlying")
 
@@ -78,18 +76,15 @@ object ORSet {
     }
   }
 
-  /** INTERNAL API: Used for `clear` but could be used for other cases also */
-  @InternalApi private[akka] final case class FullStateDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  /** Used for `clear` but could be used for other cases also */
+  final case class FullStateDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
     override def merge(that: DeltaOp): DeltaOp = that match {
       case _: AtomicDeltaOp[A @unchecked] => DeltaGroup(Vector(this, that))
       case DeltaGroup(ops)                => DeltaGroup(this +: ops)
     }
   }
 
-  /**
-   * INTERNAL API
-   */
-  @InternalApi private[akka] final case class DeltaGroup[A](ops: immutable.IndexedSeq[DeltaOp]) extends DeltaOp {
+  final case class DeltaGroup[A](ops: immutable.IndexedSeq[DeltaOp]) extends DeltaOp {
     override def merge(that: DeltaOp): DeltaOp = that match {
       case thatAdd: AddDeltaOp[A @unchecked] =>
         // merge AddDeltaOp into last AddDeltaOp in the group, if possible

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/crdt/ORSet.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/crdt/ORSet.scala
@@ -43,7 +43,15 @@ object ORSet {
     def underlying: ORSet[A]
   }
 
-  final case class AddDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  object AddDeltaOp {
+    def apply[A](underlying: ORSet[A]): AddDeltaOp[A] =
+      new AddDeltaOp(underlying)
+
+    def unapply[A](arg: AddDeltaOp[A]): Option[ORSet[A]] =
+      Some(arg.underlying)
+  }
+
+  final class AddDeltaOp[A](val underlying: ORSet[A]) extends AtomicDeltaOp[A] {
 
     override def merge(that: DeltaOp): DeltaOp = that match {
       case AddDeltaOp(u) =>
@@ -54,7 +62,7 @@ object ORSet {
             concatElementsMap(u.elementsMap.asInstanceOf[Map[A, Dot]]),
             underlying.vvector.merge(u.vvector)))
       case _: AtomicDeltaOp[A @unchecked] => DeltaGroup(Vector(this, that))
-      case DeltaGroup(ops)                => DeltaGroup(this +: ops)
+      case g: DeltaGroup[A @unchecked]    => DeltaGroup(this +: g.ops)
     }
 
     private def concatElementsMap(thatMap: Map[A, Dot]): Map[A, Dot] = {
@@ -64,27 +72,78 @@ object ORSet {
       } else
         underlying.elementsMap ++ thatMap
     }
+
+    override def toString: String = s"AddDeltaOp($underlying)"
+
+    override def equals(obj: Any): Boolean = obj match {
+      case other: AddDeltaOp[_] => underlying == other.underlying
+      case _                    => false
+    }
+
+    override def hashCode(): Int = underlying.hashCode
   }
 
-  final case class RemoveDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  object RemoveDeltaOp {
+    def apply[A](underlying: ORSet[A]): RemoveDeltaOp[A] =
+      new RemoveDeltaOp(underlying)
+
+    def unapply[A](arg: RemoveDeltaOp[A]): Option[ORSet[A]] =
+      Some(arg.underlying)
+  }
+
+  final class RemoveDeltaOp[A](val underlying: ORSet[A]) extends AtomicDeltaOp[A] {
     if (underlying.size != 1)
       throw new IllegalArgumentException(s"RemoveDeltaOp should contain one removed element, but was $underlying")
 
     override def merge(that: DeltaOp): DeltaOp = that match {
       case _: AtomicDeltaOp[A @unchecked] => DeltaGroup(Vector(this, that)) // keep it simple for removals
-      case DeltaGroup(ops)                => DeltaGroup(this +: ops)
+      case g: DeltaGroup[A @unchecked]    => DeltaGroup(this +: g.ops)
     }
+
+    override def toString: String = s"RemoveDeltaOp($underlying)"
+
+    override def equals(obj: Any): Boolean = obj match {
+      case other: RemoveDeltaOp[_] => underlying == other.underlying
+      case _                       => false
+    }
+
+    override def hashCode(): Int = underlying.hashCode
+  }
+
+  object FullStateDeltaOp {
+    def apply[A](underlying: ORSet[A]): FullStateDeltaOp[A] =
+      new FullStateDeltaOp(underlying)
+
+    def unapply[A](arg: FullStateDeltaOp[A]): Option[ORSet[A]] =
+      Some(arg.underlying)
   }
 
   /** Used for `clear` but could be used for other cases also */
-  final case class FullStateDeltaOp[A](underlying: ORSet[A]) extends AtomicDeltaOp[A] {
+  final class FullStateDeltaOp[A](val underlying: ORSet[A]) extends AtomicDeltaOp[A] {
     override def merge(that: DeltaOp): DeltaOp = that match {
       case _: AtomicDeltaOp[A @unchecked] => DeltaGroup(Vector(this, that))
-      case DeltaGroup(ops)                => DeltaGroup(this +: ops)
+      case g: DeltaGroup[A @unchecked]    => DeltaGroup(this +: g.ops)
     }
+
+    override def toString: String = s"FullStateDeltaOp($underlying)"
+
+    override def equals(obj: Any): Boolean = obj match {
+      case other: FullStateDeltaOp[_] => underlying == other.underlying
+      case _                          => false
+    }
+
+    override def hashCode(): Int = underlying.hashCode
   }
 
-  final case class DeltaGroup[A](ops: immutable.IndexedSeq[DeltaOp]) extends DeltaOp {
+  object DeltaGroup {
+    def apply[A](ops: immutable.IndexedSeq[DeltaOp]): DeltaGroup[A] =
+      new DeltaGroup(ops)
+
+    def unapply[A](arg: DeltaGroup[A]): Option[immutable.IndexedSeq[DeltaOp]] =
+      Some(arg.ops)
+  }
+
+  final class DeltaGroup[A](val ops: immutable.IndexedSeq[DeltaOp]) extends DeltaOp {
     override def merge(that: DeltaOp): DeltaOp = that match {
       case thatAdd: AddDeltaOp[A @unchecked] =>
         // merge AddDeltaOp into last AddDeltaOp in the group, if possible
@@ -92,9 +151,18 @@ object ORSet {
           case thisAdd: AddDeltaOp[A @unchecked] => DeltaGroup(ops.dropRight(1) :+ thisAdd.merge(thatAdd))
           case _                                 => DeltaGroup(ops :+ thatAdd)
         }
-      case DeltaGroup(thatOps) => DeltaGroup(ops ++ thatOps)
-      case _                   => DeltaGroup(ops :+ that)
+      case g: DeltaGroup[A @unchecked] => DeltaGroup(ops ++ g.ops)
+      case _                           => DeltaGroup(ops :+ that)
     }
+
+    override def toString: String = s"DeltaGroup($ops)"
+
+    override def equals(obj: Any): Boolean = obj match {
+      case other: DeltaGroup[_] => ops == other.ops
+      case _                    => false
+    }
+
+    override def hashCode(): Int = ops.hashCode
 
   }
 
@@ -433,8 +501,8 @@ final class ORSet[A] private[akka] (
       case d: ORSet.AddDeltaOp[A @unchecked]       => merge(d.underlying, addDeltaOp = true)
       case d: ORSet.RemoveDeltaOp[A @unchecked]    => mergeRemoveDelta(d)
       case d: ORSet.FullStateDeltaOp[A @unchecked] => merge(d.underlying, addDeltaOp = false)
-      case ORSet.DeltaGroup(ops) =>
-        ops.foldLeft(this) {
+      case g: ORSet.DeltaGroup[A @unchecked] =>
+        g.ops.foldLeft(this) {
           case (acc, op: ORSet.AddDeltaOp[A @unchecked])       => acc.merge(op.underlying, addDeltaOp = true)
           case (acc, op: ORSet.RemoveDeltaOp[A @unchecked])    => acc.mergeRemoveDelta(op)
           case (acc, op: ORSet.FullStateDeltaOp[A @unchecked]) => acc.merge(op.underlying, addDeltaOp = false)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/serialization/ReplicatedEventSourcingSerializer.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/serialization/ReplicatedEventSourcingSerializer.scala
@@ -322,13 +322,13 @@ import akka.util.ccompat.JavaConverters._
 
     val b = ReplicatedEventSourcing.ORSetDeltaGroup.newBuilder()
     deltaGroup.ops.foreach {
-      case ORSet.AddDeltaOp(u) =>
-        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Add, u))
-      case ORSet.RemoveDeltaOp(u) =>
-        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Remove, u))
-      case ORSet.FullStateDeltaOp(u) =>
-        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Full, u))
-      case ORSet.DeltaGroup(_) =>
+      case add: ORSet.AddDeltaOp[_] =>
+        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Add, add.underlying))
+      case remove: ORSet.RemoveDeltaOp[_] =>
+        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Remove, remove.underlying))
+      case full: ORSet.FullStateDeltaOp[_] =>
+        b.addEntries(createEntry(ReplicatedEventSourcing.ORSetDeltaOp.Full, full.underlying))
+      case _: ORSet.DeltaGroup[_] =>
         throw new IllegalArgumentException("ORSet.DeltaGroup should not be nested")
     }
     b.build()


### PR DESCRIPTION
* For example when embedding the delta ops in application specific events it is useful to be able to access the underlying ORSet of the delta op, and it's value
