### PR TITLE
chore: Exclude dependencies from samples from FOSSA scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -11,3 +11,4 @@ paths:
     - ./akka-remote-tests
     - ./akka-stream-tests
     - ./native-image-tests
+    - ./samples


### PR DESCRIPTION
Dependencies other than "runtime" should be excluded from FOSSA scans, so this configures FOSSA to ignore the projects in "samples" dir

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References lightbend/akka-meta#488
