### PR TITLE
chore: JDK 21 test, commonJournalConfigForEventSourcedOnCommandBehavior

### DIFF
--- a/akka-persistence-typed-tests/src/test/java-21+/jdocs21/akka/persistence/typed/javadsl/ReplicatedEventSourcingTest.java
+++ b/akka-persistence-typed-tests/src/test/java-21+/jdocs21/akka/persistence/typed/javadsl/ReplicatedEventSourcingTest.java
@@ -44,7 +44,7 @@ public class ReplicatedEventSourcingTest extends JUnitSuite {
 
     public static Behavior<Command> create(
         String entityId, ReplicaId replicaId, Set<ReplicaId> allReplicas) {
-      return ReplicatedEventSourcing.onCommandCommonJournalConfig(
+      return ReplicatedEventSourcing.commonJournalConfigForEventSourcedOnCommandBehavior(
           new ReplicationId("ReplicatedEventSourcingTest", entityId, replicaId),
           allReplicas,
           PersistenceTestKitReadJournal.Identifier(),


### PR DESCRIPTION
https://github.com/akka/akka/actions/runs/9589534311/job/26443465001#step:5:33537

Wasn't seen in PR validation because only compiled with JDK 21