### PR TITLE
docs: Old version warning used the wrong base url and was broken

### DIFF
--- a/akka-docs/src/main/paradox/_template/projectSpecificFooter.st
+++ b/akka-docs/src/main/paradox/_template/projectSpecificFooter.st
@@ -1,4 +1,4 @@
 <script type="text/javascript" src="$page.base$assets/js/warnOldVersion.js"></script>
 <script type="text/javascript">//<![CDATA[
-jQuery(function(jq){initOldVersionWarnings(jq, '$page.properties.("project.version")$', '$page.properties.("project.url")$')});
+jQuery(function(jq){initOldVersionWarnings(jq, '$page.properties.("project.version")$', '$page.properties.("canonical.base_url")$')});
 //]]></script>


### PR DESCRIPTION
Refs #32458 

The problem was that project.url is the sbt homepage setting, which for other projects is the docs but for Akka we set it to `https://akka.io` and not at all the docs, so the url to the paradox.json file was wrong (even wrong hostname). `canonical.base_url` is defined in the paradox props and points to Akka docs current so should sort the problem.