### PR TITLE
chore: link validator fixes

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -49,4 +49,4 @@ jobs:
         run: sbt -Dakka.genjavadoc.enabled=true "Javaunidoc/doc; Compile/unidoc; akka-docs/paradox"
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.3 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.5 -- scripts/link-validator.conf

--- a/akka-docs/src/main/paradox/additional/books.md
+++ b/akka-docs/src/main/paradox/additional/books.md
@@ -12,7 +12,7 @@
  * [Mastering Akka](https://www.packtpub.com/application-development/mastering-akka), by Christian Baxter, PACKT Publishing, ISBN: 9781786465023, October 2016
  * [Learning Akka](https://www.packtpub.com/application-development/learning-akka), by Jason Goodwin, PACKT Publishing, ISBN: 9781784393007, December 2015
  * [Reactive Messaging Patterns with the Actor Model](https://www.informit.com/store/reactive-messaging-patterns-with-the-actor-model-applications-9780133846836), by Vaughn Vernon, Addison-Wesley Professional, ISBN: 0133846830, August 2015
- * [Developing an Akka Edge](https://bleedingedgepress.com/developing-an-akka-edge/), by Thomas Lockney and Raymond Tay, Bleeding Edge Press, ISBN: 9781939902054, April 2014
+ * [Developing an Akka Edge](https://www.researchgate.net/publication/260792615_Developing_an_Akka_Edge), by Thomas Lockney and Raymond Tay, Bleeding Edge Press, ISBN: 9781939902054, April 2014
  * [Effective Akka](https://shop.oreilly.com/product/0636920028789.do), by Jamie Allen, O'Reilly Media, ISBN: 1449360076, August 2013
  * [Akka Concurrency](https://www.artima.com/shop/akka_concurrency), by Derek Wyatt, artima developer, ISBN: 0981531660, May 2013
  * [Akka Essentials](https://www.packtpub.com/application-development/akka-essentials), by Munish K. Gupta, PACKT Publishing, ISBN: 1849518289, October 2012

--- a/akka-docs/src/main/paradox/typed/durable-state/persistence-style.md
+++ b/akka-docs/src/main/paradox/typed/durable-state/persistence-style.md
@@ -34,7 +34,7 @@ Java
 @@@ div { .group-java }
 ## Leveraging Java 21 features
 
-When building durable state entities in a project using Java 21 or newer, the @javadoc[DurableStateOnCommandBehavior](akka.persistence.typed.statejavadsl.DurableStateOnCommandBehavior)
+When building durable state entities in a project using Java 21 or newer, the @javadoc[DurableStateOnCommandBehavior](akka.persistence.typed.state.javadsl.DurableStateOnCommandBehavior)
 base class provides an API that let you leverage the switch pattern match feature. When combined with `sealed` command
 and event top types this gives you a more direct handling of commands and events as well as a compile time completeness
 check that you have handled all kinds of commands and events in your event sourced behavior handler methods:

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -46,11 +46,13 @@ site-link-validator {
     "https://javadoc.io/static/"
     # GitHub will block with "429 Too Many Requests"
     "https://github.com/"
-    "https://www.scala-lang.org/api/2.13.13/scala/runtime/AbstractFunction1.html"
-    "https://www.scala-lang.org/api/2.13.13/scala/runtime/AbstractFunction2.html"
-    "https://www.scala-lang.org/api/2.13.13/scala/runtime/AbstractFunction3.html"
-    "https://www.scala-lang.org/api/2.13.13/scala/runtime/AbstractPartialFunction.html"
+    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction1.html"
+    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction2.html"
+    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractFunction3.html"
+    "https://www.scala-lang.org/api/2.13.14/scala/runtime/AbstractPartialFunction.html"
   ]
+
+  ignore-files = []
 
   non-https-whitelist = [
     "http://cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf"


### PR DESCRIPTION
- Adapt ignored URLs after Scala upgrade.
- Fix API package name
- update URL to PDF as the book page is gone

References
- https://github.com/akka/akka/actions/runs/9739035003/job/26873556832#step:8:285
