### PR TITLE
feat: Signal when EventSourcedBehavior persist fails

### DIFF
--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -289,7 +289,8 @@ The recovery of a persistent actor will therefore never be done partially with o
 a single @scala[@scaladoc[persist](akka.persistence.typed.scaladsl.Effect$#persist[Event,State](event:Event):akka.persistence.typed.scaladsl.EffectBuilder[Event,State])]@java[@javadoc[persist](akka.persistence.typed.javadsl.EffectFactories#persist(Event))] effect.
 
 Some journals may not support atomic writes of several events and they will then reject the `persist` with
-multiple events. This is signalled to an @apidoc[typed.*.EventSourcedBehavior] via an @apidoc[typed.EventRejectedException] (typically with a 
+multiple events. This is signalled to an @apidoc[typed.*.EventSourcedBehavior] via an @apidoc[typed.PersistRejected] signal.
+An @apidoc[typed.EventRejectedException] is also thrown (typically with a 
 @javadoc[UnsupportedOperationException](java.lang.UnsupportedOperationException)) and can be handled with a @ref[supervisor](fault-tolerance.md).
 
 ## Cluster Sharding and EventSourcedBehavior
@@ -605,11 +606,16 @@ If there is a problem with recovering the state of the actor from the journal, a
 emitted to the @scala[@scaladoc[receiveSignal](akka.persistence.typed.scaladsl.EventSourcedBehavior#receiveSignal(signalHandler:PartialFunction[(State,akka.actor.typed.Signal),Unit]):akka.persistence.typed.scaladsl.EventSourcedBehavior[Command,Event,State]) handler] @java[@javadoc[receiveSignal](akka.persistence.typed.javadsl.SignalHandlerBuilder#onSignal(java.lang.Class,java.util.function.BiConsumer)) method] and the actor will be stopped
 (or restarted with backoff).
 
+If there is a problem with persisting an event to the journal, a @apidoc[typed.PersistFailed] signal is
+emitted to the @scala[@scaladoc[receiveSignal](akka.persistence.typed.scaladsl.EventSourcedBehavior#receiveSignal(signalHandler:PartialFunction[(State,akka.actor.typed.Signal),Unit]):akka.persistence.typed.scaladsl.EventSourcedBehavior[Command,Event,State]) handler] @java[@javadoc[receiveSignal](akka.persistence.typed.javadsl.SignalHandlerBuilder#onSignal(java.lang.Class,java.util.function.BiConsumer)) method] and the actor will be stopped
+(or restarted with backoff).
+
 ### Journal rejections
 
 Journals can reject events. The difference from a failure is that the journal must decide to reject an event before
-trying to persist it e.g. because of a serialization exception. If an event is rejected it definitely won't be in the journal. 
-This is signalled to an @apidoc[typed.*.EventSourcedBehavior] via an @apidoc[typed.EventRejectedException] and can be handled with a @ref[supervisor](fault-tolerance.md).
+trying to persist it e.g. because of a serialization exception. If an event is rejected it definitely won't be in the journal.
+This is signalled to an @apidoc[typed.*.EventSourcedBehavior] via an @apidoc[typed.PersistRejected] signal.
+An @apidoc[typed.EventRejectedException] is also thrown and can be handled with a @ref[supervisor](fault-tolerance.md).
 Not all journal implementations use rejections and treat these kind of problems also as journal failures. 
 
 ## Stash

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -211,7 +211,7 @@ class EventSourcedBehaviorFailureSpec
     "signal PersistFailure when persist fails" in {
       val probe = TestProbe[String]()
       val behav = failingPersistentActor(PersistenceId.ofUniqueId("fail-persist-2"), probe.ref, {
-        case (_, PersistFailed(_, cmd, _)) =>
+        case (_, PersistFailed(_, cmd)) =>
           probe.ref.tell(s"failed ${cmd.get}")
       })
       val c = spawn(behav)
@@ -267,7 +267,7 @@ class EventSourcedBehaviorFailureSpec
       val behav =
         Behaviors
           .supervise(failingPersistentActor(PersistenceId.ofUniqueId("reject-first"), probe.ref, {
-            case (_, PersistRejected(_, cmd, _)) =>
+            case (_, PersistRejected(_, cmd)) =>
               probe.ref.tell(s"rejected ${cmd.get}")
           }))
           .onFailure[EventRejectedException](

--- a/akka-persistence-typed/src/main/mima-filters/2.9.4.backwards.excludes/fail-signal.excludes
+++ b/akka-persistence-typed/src/main/mima-filters/2.9.4.backwards.excludes/fail-signal.excludes
@@ -1,0 +1,2 @@
+# PR https://github.com/akka/akka/pull/32463
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.Running#HandlingCommands.applyEffects")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
@@ -31,54 +31,52 @@ final case class RecoveryFailed(failure: Throwable) extends EventSourcedSignal {
   def getFailure(): Throwable = failure
 }
 
-final case class PersistFailed[Command, Event](failure: Throwable, command: Option[Command], event: Event)
+/**
+ * @param failure the original cause
+ * @param command the command that persisted the event, may be undefined if it is a replicated event
+ */
+final case class PersistFailed[Command, Event](failure: Throwable, command: Option[Command])
     extends EventSourcedSignal {
 
   /**
-   * Java API
+   * Java API: the original cause
    */
   def getFailure(): Throwable = failure
 
   /**
-   * Java API
+   * Java API: the command that persisted the event, may be undefined if it is a replicated event
    */
   def getCommand(): Optional[Command] = {
     import scala.compat.java8.OptionConverters._
     command.asJava
   }
 
-  /**
-   * Java API
-   */
-  def getEvent(): Event = event
-
   override def toString: String =
-    s"PersistFailed($failure, ${command.getClass.getName}, ${event.getClass.getName})"
+    s"PersistFailed($failure, ${command.map(_.getClass.getName).getOrElse("replicated")})"
 }
 
-final case class PersistRejected[Command, Event](failure: Throwable, command: Option[Command], event: Event)
+/**
+ * @param failure the original cause
+ * @param command the command that persisted the event, may be undefined if it is a replicated event
+ */
+final case class PersistRejected[Command, Event](failure: Throwable, command: Option[Command])
     extends EventSourcedSignal {
 
   /**
-   * Java API
+   * Java API: the original cause
    */
   def getFailure(): Throwable = failure
 
   /**
-   * Java API
+   * Java API: the command that persisted the event, may be undefined if it is a replicated event
    */
   def getCommand(): Optional[Command] = {
     import scala.compat.java8.OptionConverters._
     command.asJava
   }
 
-  /**
-   * Java API
-   */
-  def getEvent(): Event = event
-
   override def toString: String =
-    s"PersistRejected($failure, ${command.getClass.getName}, ${event.getClass.getName})"
+    s"PersistRejected($failure, ${command.map(_.getClass.getName).getOrElse("replicated")})"
 }
 
 final case class SnapshotCompleted(metadata: SnapshotMetadata) extends EventSourcedSignal {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
@@ -4,6 +4,8 @@
 
 package akka.persistence.typed
 
+import java.util.Optional
+
 import akka.actor.typed.Signal
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
@@ -27,6 +29,56 @@ final case class RecoveryFailed(failure: Throwable) extends EventSourcedSignal {
    * Java API
    */
   def getFailure(): Throwable = failure
+}
+
+final case class PersistFailed[Command, Event](failure: Throwable, command: Option[Command], event: Event)
+    extends EventSourcedSignal {
+
+  /**
+   * Java API
+   */
+  def getFailure(): Throwable = failure
+
+  /**
+   * Java API
+   */
+  def getCommand(): Optional[Command] = {
+    import scala.compat.java8.OptionConverters._
+    command.asJava
+  }
+
+  /**
+   * Java API
+   */
+  def getEvent(): Event = event
+
+  override def toString: String =
+    s"PersistFailed($failure, ${command.getClass.getName}, ${event.getClass.getName})"
+}
+
+final case class PersistRejected[Command, Event](failure: Throwable, command: Option[Command], event: Event)
+    extends EventSourcedSignal {
+
+  /**
+   * Java API
+   */
+  def getFailure(): Throwable = failure
+
+  /**
+   * Java API
+   */
+  def getCommand(): Optional[Command] = {
+    import scala.compat.java8.OptionConverters._
+    command.asJava
+  }
+
+  /**
+   * Java API
+   */
+  def getEvent(): Event = event
+
+  override def toString: String =
+    s"PersistRejected($failure, ${command.getClass.getName}, ${event.getClass.getName})"
 }
 
 final case class SnapshotCompleted(metadata: SnapshotMetadata) extends EventSourcedSignal {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -850,7 +850,7 @@ private[akka] object Running {
               p.sequenceNr,
               state.getInstrumentationContext(p.sequenceNr))
             onWriteRejected(setup.context, cause, p)
-            val signal = PersistRejected(cause, command.toOption, p.payload)
+            val signal = PersistRejected(cause, command.toOption)
             if (setup.onSignal(state.state, signal, catchAndLog = false)) {
               setup.internalLogger.debug("Emitted signal [{}].", signal)
             }
@@ -866,7 +866,7 @@ private[akka] object Running {
               p.sequenceNr,
               state.getInstrumentationContext(p.sequenceNr))
             onWriteFailed(setup.context, cause, p)
-            val signal = PersistFailed(cause, command.toOption, p.payload)
+            val signal = PersistFailed(cause, command.toOption)
             if (setup.onSignal(state.state, signal, catchAndLog = false)) {
               setup.internalLogger.debug("Emitted signal [{}].", signal)
             }


### PR DESCRIPTION
* For example useful when replying with error message to the sender, instead of just timing out
