### PR TITLE
feat: Access ShardCommand ActorRef via extension

### DIFF
--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.9.4.backwards.excludes/shard-ext.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.9.4.backwards.excludes/shard-ext.excludes
@@ -1,2 +1,4 @@
 # PR #32477 addition to DoNotInherit class
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.typed.javadsl.ClusterSharding.shard")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.typed.scaladsl.ClusterSharding.shard")
+

--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.9.4.backwards.excludes/shard-ext.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.9.4.backwards.excludes/shard-ext.excludes
@@ -1,0 +1,2 @@
+# PR #32477 addition to DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.typed.javadsl.ClusterSharding.shard")

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -241,6 +241,18 @@ import akka.util.JavaDurationConverters._
     ActorRefAdapter(ref)
   }
 
+  override def shard(typeKey: scaladsl.EntityTypeKey[_]): ActorRef[scaladsl.ClusterSharding.ShardCommand] =
+    shardCommandActors.get(typeKey.name) match {
+      case null  => throw new IllegalStateException(s"Entity type [${typeKey.name}] must first be initialized")
+      case shard => shard
+    }
+
+  override def shard(typeKey: javadsl.EntityTypeKey[_]): ActorRef[javadsl.ClusterSharding.ShardCommand] =
+    shardCommandActors.get(typeKey.name) match {
+      case null  => throw new IllegalStateException(s"Entity type [${typeKey.name}] must first be initialized")
+      case shard => shard
+    }
+
   override def entityRefFor[M](typeKey: scaladsl.EntityTypeKey[M], entityId: String): scaladsl.EntityRef[M] = {
     new EntityRefImpl[M](
       classicSharding.shardRegion(typeKey.name),

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -213,6 +213,14 @@ abstract class ClusterSharding {
   def shardState: ActorRef[ClusterShardingQuery]
 
   /**
+   * Access to the `ActorRef` to send `ShardCommand` for a given entity type. For example
+   * [[ClusterSharding.Passivate]] can be sent to this `ActorRef`. Note that this `ActorRef`
+   * is also available in the [[EntityContext]]. The entity type must first be initialized
+   * with the [[ClusterSharding.init]] method.
+   */
+  def shard(typeKey: EntityTypeKey[_]): ActorRef[ClusterSharding.ShardCommand]
+
+  /**
    * The default `ShardAllocationStrategy` is configured by `least-shard-allocation-strategy` properties.
    */
   def defaultShardAllocationStrategy(settings: ClusterShardingSettings): ShardAllocationStrategy

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -214,6 +214,14 @@ trait ClusterSharding extends Extension { javadslSelf: javadsl.ClusterSharding =
   def shardState: ActorRef[ClusterShardingQuery]
 
   /**
+   * Access to the `ActorRef` to send `ShardCommand` for a given entity type. For example
+   * [[ClusterSharding.Passivate]] can be sent to this `ActorRef`. Note that this `ActorRef`
+   * is also available in the [[EntityContext]]. The entity type must first be initialized
+   * with the [[ClusterSharding.init]] method.
+   */
+  def shard(typeKey: EntityTypeKey[_]): ActorRef[ClusterSharding.ShardCommand]
+
+  /**
    * The default `ShardAllocationStrategy` is configured by `least-shard-allocation-strategy` properties.
    */
   def defaultShardAllocationStrategy(settings: ClusterShardingSettings): ShardAllocationStrategy

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
@@ -204,6 +204,8 @@ interface ShardingCompileOnlyTest {
 
     shardRegion.tell(new ShardingEnvelope<>("counter-1", Counter.Increment.INSTANCE));
     // #send
+
+    ActorRef<ClusterSharding.ShardCommand> shard = sharding.shard(typeKey);
   }
 
   public static void roleExample() {

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/testkit/scaladsl/TestEntityRefSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/testkit/scaladsl/TestEntityRefSpec.scala
@@ -69,6 +69,10 @@ class TestEntityRefSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
         override def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M] =
           entityRefFor(typeKey, entityId, "default")
 
+        override def shard(typeKey: EntityTypeKey[_]): ActorRef[ClusterSharding.ShardCommand] = ???
+
+        override def shard(typeKey: javadsl.EntityTypeKey[_]): ActorRef[javadsl.ClusterSharding.ShardCommand] = ???
+
         override def shardState: ActorRef[ClusterShardingQuery] = ???
 
         override def defaultShardAllocationStrategy(


### PR DESCRIPTION
* Passivate is a ShardCommand
* When using Replicated Event Sourcing the EntityContext isn't available, and therefore this extension can be used instead
