### PR TITLE
docs: add links to "Actor Fundamentals" course

### DIFF
--- a/akka-docs/src/main/paradox/general/actor-systems.md
+++ b/akka-docs/src/main/paradox/general/actor-systems.md
@@ -112,3 +112,9 @@ stopping all running actors.
 
 If you want to execute some operations while terminating @apidoc[ActorSystem](typed.ActorSystem),
 look at @ref:[`CoordinatedShutdown`](../coordinated-shutdown.md).
+
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@

--- a/akka-docs/src/main/paradox/general/actors.md
+++ b/akka-docs/src/main/paradox/general/actors.md
@@ -175,3 +175,9 @@ The mailbox is then replaced within the actor reference with a system mailbox,
 redirecting all new messages to the EventStream as DeadLetters. This
 is done on a best effort basis, though, so do not rely on it in order to
 construct “guaranteed delivery”.
+
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@

--- a/akka-docs/src/main/paradox/general/addressing.md
+++ b/akka-docs/src/main/paradox/general/addressing.md
@@ -169,3 +169,9 @@ supervisors are remote actor references
 The need to structure the name space for actors like this arises from a central
 and very simple design goal: everything in the hierarchy is an actor, and all
 actors function in the same way. 
+
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@

--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -132,4 +132,8 @@ supervision process is started. Depending on the
 supervisor’s decision the actor is resumed (as if nothing happened), restarted
 (wiping out its internal state and starting from scratch) or terminated.
 
+@@@note
 
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -45,7 +45,13 @@ concurrent and parallel systems. Actors were defined in the 1973 paper by Carl
 Hewitt but have been popularized by the Erlang language, and used for example at
 Ericsson with great success to build highly concurrent and reliable telecom
 systems. The API of Akka’s Actors has borrowed some of its syntax from Erlang.
- 
+
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@
+
 ## First example
 
 If you are new to Akka we recommend watching the short [introduction video to Akka actors](https://akka.io/blog/news/2019/12/03/akka-typed-actor-intro-video).

--- a/akka-docs/src/main/paradox/typed/guide/actors-intro.md
+++ b/akka-docs/src/main/paradox/typed/guide/actors-intro.md
@@ -96,4 +96,10 @@ dead (with the notable exception of entering an infinite loop) instead they are 
 strategy can react to the fault, or they are stopped (in which case interested parties are notified).
 There is always a responsible entity for managing an actor: its parent. Restarts are not visible from the outside: collaborating actors can keep sending messages while the target actor restarts.
 
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@
+
 Now, let's take a short tour of the functionality Akka provides.

--- a/akka-docs/src/main/paradox/typed/guide/actors-motivation.md
+++ b/akka-docs/src/main/paradox/typed/guide/actors-motivation.md
@@ -144,6 +144,12 @@ that the thread was currently working on, is no longer in the shared memory loca
 the task state is fully lost! **We have lost a message even though this is local communication with no networking
 involved (where message losses are to be expected).**
 
+@@@note
+
+🎓 For a deeper understanding of the Actor Model, consider the free online course [**Actor Fundamentals**](https://akkademy.akka.io/learn/courses/21/actor-fundamentals) in Akkademy.
+
+@@@
+
 **In summary:**
 
  * **To achieve any meaningful concurrency and performance on current systems, threads must delegate tasks among each


### PR DESCRIPTION
Add links to relevant areas of the docs.

Refs https://github.com/lightbend/akka-meta/issues/383

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/67ec5801-6e37-47b1-b9da-047e7d793ae0">
