### PR TITLE
feat: Use EntityRef without ShardingEnvelope

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
@@ -21,9 +21,10 @@ class ClusterShardingStateSpec
 
   private val sharding = ClusterSharding(system)
 
-  private val shardExtractor = ShardingMessageExtractor.noEnvelope[IdTestProtocol](10, IdStopPlz()) {
+  private val shardExtractor = ShardingMessageExtractor.noEnvelope[IdTestProtocol](10) {
     case IdReplyPlz(id, _)  => id
     case IdWhoAreYou(id, _) => id
+    case IdStopPlz(id)      => id
     case other              => throw new IllegalArgumentException(s"Unexpected message $other")
   }
 
@@ -42,7 +43,7 @@ class ClusterShardingStateSpec
 
       val shardingRef: ActorRef[IdTestProtocol] = sharding.init(
         Entity(typeKey)(_ => ClusterShardingSpec.behaviorWithId())
-          .withStopMessage(IdStopPlz())
+          .withStopMessage(IdStopPlz(""))
           .withMessageExtractor(idTestProtocolMessageExtractor))
 
       sharding.shardState ! GetShardRegionState(typeKey, probe.ref)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStatsSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStatsSpec.scala
@@ -49,7 +49,7 @@ class ClusterShardingStatsSpec
     "allow querying of statistics of the currently running sharded entities in the entire cluster" in {
       val shardingRef: ActorRef[IdTestProtocol] = sharding.init(
         Entity(typeKey)(_ => ClusterShardingSpec.behaviorWithId())
-          .withStopMessage(IdStopPlz())
+          .withStopMessage(IdStopPlz(""))
           .withMessageExtractor(idTestProtocolMessageExtractor))
 
       val replyProbe = createTestProbe[String]()


### PR DESCRIPTION
* if message extractor is a NoEnvelopeMessageExtractor the EntityRef will send the message without wrapping in ShardingEnvelope
