### PR TITLE
docs: add links to "Akka Basics" courses

### DIFF
--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -181,6 +181,12 @@ The console output may look like this:
 
 You will also need to add a @ref:[logging dependency](logging.md) to see that output when running.
 
+@@@note
+
+🎓 For a deeper introduction to actors, consider the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala) in Akkademy.
+
+@@@
+
 ## A More Complex Example
 
 The next example is more realistic and demonstrates some important patterns:
@@ -487,3 +493,9 @@ the `Main` Actor terminates there is nothing more to do.
 Therefore after creating the Actor system with the `Main` Actor’s
 @apidoc[typed.Behavior] we can let the `main` method return, the @apidoc[typed.ActorSystem] will continue running and 
 the JVM alive until the root actor stops.
+
+@@@note
+
+🎓 For a deeper introduction to actors, consider the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala) in Akkademy.
+
+@@@

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -183,7 +183,7 @@ You will also need to add a @ref:[logging dependency](logging.md) to see that ou
 
 @@@note
 
-🎓 For a deeper introduction to actors, consider the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala) in Akkademy.
+🎓 For a deeper introduction to actors, consider the free online courses @java[[**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java)]@scala[[**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala)]) in Akkademy.
 
 @@@
 
@@ -496,6 +496,6 @@ the JVM alive until the root actor stops.
 
 @@@note
 
-🎓 For a deeper introduction to actors, consider the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala) in Akkademy.
+🎓 For a deeper introduction to actors, consider the free online courses @java[[**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java)]@scala[[**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala)] in Akkademy.
 
 @@@

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_5.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_5.md
@@ -229,7 +229,7 @@ In the context of the IoT system, this guide introduced the following concepts, 
 To continue your journey with Akka, we recommend:
 
 * Start building your own applications with Akka, make sure you [get involved in our amazing community](https://akka.io/get-involved/) for help if you get stuck.
-* If you’d like some additional background, and detail, read the rest of the @ref:[reference documentation](../actors.md) and check out some of the @ref:[books and videos](../../additional/books.md) on Akka.
+* If you’d like some additional background, and detail, read the rest of the @ref:[reference documentation](../actors.md), check out some @ref:[books and videos](../../additional/books.md), or even explore the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala).
 * If you are interested in functional programming, read how actors can be defined in a @ref:[functional style](../actors.md#functional-style). In this guide the object-oriented style was used, but you can mix both as you like.
 
 To get from this guide to a complete application you would likely need to provide either an UI or an API. For this we recommend that you look at the following technologies and see what fits you:

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_5.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_5.md
@@ -229,7 +229,7 @@ In the context of the IoT system, this guide introduced the following concepts, 
 To continue your journey with Akka, we recommend:
 
 * Start building your own applications with Akka, make sure you [get involved in our amazing community](https://akka.io/get-involved/) for help if you get stuck.
-* If you’d like some additional background, and detail, read the rest of the @ref:[reference documentation](../actors.md), check out some @ref:[books and videos](../../additional/books.md), or even explore the free online courses [**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java) or [**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala).
+* If you’d like some additional background, and detail, read the rest of the @ref:[reference documentation](../actors.md), check out some @ref:[books and videos](../../additional/books.md), or even explore the free online courses @java[[**Akka Basics for Java**](https://akkademy.akka.io/learn/courses/23/akka-basics-for-java)]@scala[[**Akka Basics for Scala**](https://akkademy.akka.io/learn/courses/22/akka-basics-for-scala)].
 * If you are interested in functional programming, read how actors can be defined in a @ref:[functional style](../actors.md#functional-style). In this guide the object-oriented style was used, but you can mix both as you like.
 
 To get from this guide to a complete application you would likely need to provide either an UI or an API. For this we recommend that you look at the following technologies and see what fits you:


### PR DESCRIPTION
Add links to relevant areas of the docs.

Refs lightbend/akka-meta#383

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/e86b189a-2b86-4941-8190-cd2475a54867">
