### PR TITLE
Document and (partially) handle interactions involving k8s `terminationGracePeriodSeconds`

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -227,6 +227,13 @@ akka.cluster.sharding {
   # Timeout of the shard rebalancing process.
   # Additionally, if an entity doesn't handle the stopMessage
   # after (handoff-timeout - 5.seconds).max(1.second) it will be stopped forcefully
+  #
+  # Note that, by default, if running in Kubernetes, the default time from SIGTERM
+  # (which triggers a rebalance) and SIGKILL (forcible stop of the process) is 30 seconds.
+  # This delay is set by `terminationGracePeriodSeconds` in Kubernetes.
+  #
+  # In the shutdown case, coordinated shutdown (see `akka.coordinated-shutdown`) may
+  # also stop the JVM before this timeout is hit.
   handoff-timeout = 60 s
 
   # Time given to a region to acknowledge it's hosting a shard.

--- a/akka-docs/src/main/paradox/coordinated-shutdown.md
+++ b/akka-docs/src/main/paradox/coordinated-shutdown.md
@@ -101,6 +101,11 @@ via `kill SIGTERM` signal (`SIGINT` ctrl-c doesn't work). This behavior can be d
 akka.coordinated-shutdown.run-by-jvm-shutdown-hook=off
 ```
 
+Note that if running in Kubernetes, a SIGKILL will be issued after a set amount of time has passed
+since SIGTERM.  By default this time is 30 seconds ([`terminationGracePeriodSeconds`](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution)):
+it may be worth adjusting the Kubernetes configuration or the phase timeouts to make `CoordinatedShutdown`
+more likely to completely exectue before SIGKILL is received.
+
 If you have application specific JVM shutdown hooks it's recommended that you register them via the
 `CoordinatedShutdown` so that they are running before Akka internal shutdown hooks, e.g.
 those shutting down Akka Remoting (Artery).


### PR DESCRIPTION
By default Kubernetes will send SIGTERM, wait 30 seconds, and then send SIGKILL.

The SIGTERM will normally trigger CoordinatedShutdown, which triggers a shard rebalance.  In the default configurations, the total CoordinatedShutdown timeout is greater than the k8s `terminationGracePeriodSeconds` and less than the sharding `handoff-timeout`.

Adjusting the various phase timeouts to comport with the Kubernetes setting (or even just the default) seems dicey, so this just adds documentation to `CoordinatedShutdown` suggesting that one consider extending `terminationGracePeriodSeconds`.  It likewise documents that in the shutdown case, the `handoff-timeout` may not apply.

The behavior of the handoff now changes slightly to use a shorter effective handoff timeout when CoordinatedShutdown is in effect.  The visible effect is that, when CoordinatedShutdown triggered the handoff, the warning about how long before entities will be forcibly stopped will be logged and the forcible stop may in fact happen at cluster sharding's hand rather than from the actor system itself.