### PR TITLE
bump: Agrona 1.22.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val aeronVersion = "1.44.1"
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
-  val agronaVersion = "1.19.2"
+  val agronaVersion = "1.22.0"
   val nettyVersion = "4.1.112.Final"
   val protobufJavaVersion = "3.24.0" // also sync with protocVersion in Protobuf.scala
   val logbackVersion = "1.2.13"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,9 +19,11 @@ object Dependencies {
   val junitVersion = "4.13.2"
   val slf4jVersion = "1.7.36"
   // check agrona version when updating this
+  // Note: 1.46 is JDK 17 only so we cannot bump until we stop supporting JDK 11
   val aeronVersion = "1.44.1"
   // needs to be inline with the aeron version, check
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
+  // Note: 1.23+ is JDK 17 only so we cannot bump until we stop supporting JDK 11
   val agronaVersion = "1.22.0"
   val nettyVersion = "4.1.112.Final"
   val protobufJavaVersion = "3.24.0" // also sync with protocVersion in Protobuf.scala


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #32488 

Aeron 1.44.1 depends on a agrona range starting with 1.21.0 but up to 2.0, current agrona 1.23.0 has moved to target JDK 17 so we must stay on 1.22
