### PR TITLE
bump: slf4j 2.0.16, logback 1.5.7

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -245,23 +245,12 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
       .toList
   }
 
-  /**
-   * SL4FJ changed the API in SubstituteLoggingEvent from getMarker in 1.7 to getMarkers in 2.0.
-   * Using reflection to be able to support both.
-   */
   private def marker(evt: SubstituteLoggingEvent): Option[Marker] = {
-    try {
-      val slf4j1Method = evt.getClass.getMethod("getMarker")
-      Option(slf4j1Method.invoke(evt).asInstanceOf[Marker])
-    } catch {
-      case _: NoSuchMethodException =>
-        val slf4j2Method = evt.getClass.getMethod("getMarkers")
-        val markers = slf4j2Method.invoke(evt).asInstanceOf[java.util.List[Marker]]
-        if ((markers eq null) || markers.isEmpty)
-          None
-        else
-          Option(markers.get(0))
-    }
+    val markers = evt.getMarkers
+    if ((markers eq null) || markers.isEmpty)
+      None
+    else
+      Option(markers.get(0))
   }
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
@@ -84,11 +84,19 @@ import akka.annotation.InternalApi
       loggerName = event.getLoggerName,
       threadName = event.getThreadName,
       timeStamp = event.getTimeStamp,
-      marker = Option(event.getMarker),
+      marker = getMarker(event),
       throwable = throwable,
       mdc = event.getMDCPropertyMap.asScala.toMap)
 
     filter(loggingEvent)
+  }
+
+  private def getMarker(event: ILoggingEvent) = {
+    val markers = event.getMarkerList
+    if ((markers eq null) || markers.isEmpty)
+      None
+    else
+      Option(markers.get(0))
   }
 
   private def filter(event: LoggingEvent): Boolean = {

--- a/akka-docs/src/main/paradox/project/migration-guide-2.9.x-2.10.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.9.x-2.10.x.md
@@ -1,0 +1,8 @@
+---
+project.description: Migrating to Akka 2.9.
+---
+# Migration Guide 2.9.x to 2.10.x
+
+## Support for slf4j 1.7.x and logback 1.2.x removed
+
+This is the first release that only supports slf4j 2.0.x and logback 1.5.x.

--- a/akka-docs/src/main/paradox/project/migration-guides.md
+++ b/akka-docs/src/main/paradox/project/migration-guides.md
@@ -7,6 +7,7 @@ project.description: Akka version migration guides.
 
 @@@ index
 
+* [migration-guide-2.9.x-2.10.x](migration-guide-2.9.x-2.10.x.md)
 * [migration-guide-2.8.x-2.9.x](migration-guide-2.8.x-2.9.x.md)
 * [migration-guide-2.7.x-2.8.x](migration-guide-2.7.x-2.8.x.md)
 * [migration-guide-2.6.x-2.7.x](migration-guide-2.6.x-2.7.x.md)

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -173,9 +173,9 @@ in the `ActorContext`.
 
 ## SLF4J API compatibility
 
-The SLF4J API broke binary compatibility between versions 1.7 and 2.0. Akka depends on 1.7 but supports either versions. 
+Since Akka 2.10.0, only SLF4j version `2.0` is supported. 
 
-It is however not possible to mix a logger backend supporting one version with SLF4J API of other version, that will lead
+It is not possible to mix a logger backend supporting one version with SLF4J API of other version, that will lead
 to no logging to output like this:  
 
 ```

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -175,41 +175,7 @@ in the `ActorContext`.
 
 Since Akka 2.10.0, only SLF4j version `2.0` is supported. 
 
-It is not possible to mix a logger backend supporting one version with SLF4J API of older versions, that will lead
-to no logging to output like this:  
-
-```
-SLF4J(W): No SLF4J providers were found.
-SLF4J(W): Defaulting to no-operation (NOP) logger implementation
-SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
-SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
-SLF4J(W): Ignoring binding found at [jar:file:/../../../logback-classic-1.2.13.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-```
-
-@@@ div { .group-scala }
-
-Working around this for sbt based projects can either be done by depending on a newer version of the chosen logging backend,
-for example logback 1.4.0+ which support slf4j-api 2.0, or pinning `slf4j-api` to the older version using `dependencyOverrides`:
-```
-dependencyOverrides += "org.slf4j" % "slf4j-api" % "1.7.36"
-```
-
-@@@
-
-@@@ div { .group-java }
-
-Working around this for maven based projects can either be done by depending on a newer version of the chosen logging backend,
-for example logback 1.4.0+ which support slf4j-api 2.0, or pin `slf4j-api` to the older version using a direct dependency on the `slf4j-api` module:
-
-```xml
-<dependency>
-  <groupId>org.slf4j</groupId>
-  <artifactId>slf4j-api</artifactId>
-  <version>1.7.36</version>
-</dependency>
-```
-
-@@@
+It is not possible to mix a logger backend supporting one version with SLF4J API of older versions.
 
 ## SLF4J backend
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -175,7 +175,7 @@ in the `ActorContext`.
 
 Since Akka 2.10.0, only SLF4j version `2.0` is supported. 
 
-It is not possible to mix a logger backend supporting one version with SLF4J API of other version, that will lead
+It is not possible to mix a logger backend supporting one version with SLF4J API of older versions, that will lead
 to no logging to output like this:  
 
 ```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val java8CompatVersion = "1.0.2"
 
   val junitVersion = "4.13.2"
-  val slf4jVersion = "1.7.36"
+  val slf4jVersion = "2.0.16"
   // check agrona version when updating this
   // Note: 1.46 is JDK 17 only so we cannot bump until we stop supporting JDK 11
   val aeronVersion = "1.44.1"
@@ -27,7 +27,7 @@ object Dependencies {
   val agronaVersion = "1.22.0"
   val nettyVersion = "4.1.112.Final"
   val protobufJavaVersion = "3.24.0" // also sync with protocVersion in Protobuf.scala
-  val logbackVersion = "1.2.13"
+  val logbackVersion = "1.5.7"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"
   val jacksonCoreVersion = "2.15.4" // https://github.com/FasterXML/jackson/wiki/Jackson-Releases


### PR DESCRIPTION
Reverts the reflection based workaround introduced in https://github.com/akka/akka/pull/31825.