### PR TITLE
bump: shaded protobuf-java 3.25.5 (backport)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   // Note: 1.23+ is JDK 17 only so we cannot bump until we stop supporting JDK 11
   val agronaVersion = "1.22.0"
   val nettyVersion = "4.1.112.Final"
-  val protobufJavaVersion = "3.24.0" // also sync with protocVersion in Protobuf.scala
+  val protobufJavaVersion = "3.25.5" // also sync with protocVersion in Protobuf.scala
   val logbackVersion = "1.2.13"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -33,7 +33,7 @@ object Protobuf {
     // this keeps intellij happy for files that use the shaded protobuf
     Compile / unmanagedJars += (LocalProject("akka-protobuf-v3") / assembly).value,
     protoc := "protoc",
-    protocVersion := "24.0", // 3.24.0, also sync with protobufJavaVersion in Dependencies.scala
+    protocVersion := "25.0", // 3.25.5, also sync with protobufJavaVersion in Dependencies.scala
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value


### PR DESCRIPTION
(cherry picked from commit 4d5191b3968b0de20b772fd57ccab5fbaa27af10)

CVE-2024-7254