### PR TITLE
feat: Add license key check (2.7)

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -65,4 +65,5 @@ jobs:
           -Dakka.test.multi-node=false \
           -Dsbt.log.noformat=false \
           -Dakka.log.timestamps=true \
+          -Dakka.warn-on-no-license-key=false \
           validateCompile validatePullRequest

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -69,6 +69,7 @@ jobs:
             -Dmultinode.Daeron.dir=/opt/volumes/media-driver \
             -Daeron.term.buffer.length=33554432 \
             -Dmultinode.Daeron.term.buffer.length=33554432 \
+            -Dakka.warn-on-no-license-key=false \
             multiNodeTest
 
       - name: Email on failure

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -41,6 +41,7 @@ jobs:
             -Dmultinode.Xmx256M \
             -Dmultinode.Xlog:gc \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
+            -Dakka.warn-on-no-license-key=false \
             clean akka-cluster-metrics/test
 
       - name: Test Reports

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -40,6 +40,7 @@ jobs:
             -Dmultinode.Xms256M \
             -Dmultinode.Xmx256M \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
+            -Dakka.warn-on-no-license-key=false \
             clean test
 
       - name: Test Reports

--- a/akka-actor-tests/src/test/scala/akka/util/Base62Spec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/Base62Spec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.Base64
+import scala.util.Random
+
+class Base62Spec extends AnyWordSpec with Matchers {
+
+  "The Base62 encoder" should {
+
+    def roundTrip(str: String): Unit = {
+      val encoded = Base62.encode(str.getBytes("utf-8"))
+      val decoded = new String(Base62.decode(encoded), "utf-8")
+      decoded should ===(str)
+    }
+
+    "round trip different string lengths" in {
+      roundTrip("")
+      roundTrip("1")
+      roundTrip("12")
+      roundTrip("123")
+      roundTrip("1234")
+      roundTrip("12345")
+      roundTrip("123456")
+      roundTrip("1234567")
+      roundTrip("12345678")
+      roundTrip("123456789")
+      roundTrip("1234567890")
+    }
+
+    "round trip the largest possible encoded block" in {
+      // Special value, 0xffffffffffffffff / 62, to ensure our overflow checks aren 't overly zealous
+      val bytes = Array(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF0).map(_.toByte)
+      val encoded = "LygHa16AHY0"
+
+      Base62.encode(bytes) should ===(encoded)
+      Base64.getEncoder.encodeToString(Base62.decode(encoded)) should ===(Base64.getEncoder.encodeToString(bytes))
+    }
+
+    "round trip strings of random lengths" in {
+      for (_ <- 1 to 10000) {
+        val length = Random.nextInt(500) + 1
+        val bytes = new Array[Byte](length)
+        Random.nextBytes(bytes)
+        val encoded = Base62.encode(bytes)
+        val decoded = Base62.decode(encoded)
+        Base64.getEncoder.encodeToString(decoded) should ===(Base64.getEncoder.encodeToString(bytes))
+      }
+    }
+
+    def testFail(invalid: String): Unit = {
+      a[Base62.Base62EncodingException] should be thrownBy Base62.decode(invalid)
+    }
+
+    "gracefully fail for various invalid base62 strings" in {
+      // Fail due to invalid characters
+      testFail("$")
+      testFail("0@")
+      testFail("00-")
+      testFail("000+")
+      testFail("0000#")
+      testFail("00000!")
+      testFail("000000?")
+      testFail("0000000(")
+      testFail("00000000)")
+      testFail("000000000=")
+      testFail("0000000000_")
+      // Fail due to invalid length of last block
+      testFail("0")
+      testFail("0000")
+      testFail("00000000")
+      testFail("000000000000")
+      testFail("000000000000000")
+      testFail("0000000000000000000")
+      // Fail due to invalid value in last block
+      testFail("z")
+      testFail("zzz")
+      testFail("zzzzz")
+      testFail("zzzzzz")
+      testFail("zzzzzzz")
+      testFail("zzzzzzzzz")
+      testFail("zzzzzzzzzz")
+      testFail("00000000000zzz")
+      // Fail due to a full block containing an invalid value
+      // This is the largest possible base 62 block, which is obviously invalid, but it 's also useful because when it
+      // overflows during decoding, its value is still larger than the value after decoding the previous digit.
+      testFail("zzzzzzzzzzz")
+      // This is one more than 0xffffffffffffffff encoded, it triggers the addition overflow check
+      testFail("LygHa16AHYG")
+      // And this is (0xffffffffffffffff / 62 + 1) * 62, it triggers the multiplication overflow check
+      testFail("LygHa16AHZ0")
+    }
+  }
+}

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -12,6 +12,14 @@ akka {
   # Home directory of Akka, modules in the deploy directory will be loaded
   home = ""
 
+  # The license key to use Akka. Free keys at https://akka.io/key
+  license-key = ""
+
+  # If false, will not warn if there is no Akka license. Note, this only
+  # suppresses the log messages, it does not stop the actor system from
+  # terminating.
+  warn-on-no-license-key = true
+
   # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
   # to STDOUT)
   loggers = ["akka.event.Logging$DefaultLogger"]

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -15,7 +15,7 @@ import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.concurrent.blocking
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, DurationInt }
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.{ ControlThrowable, NonFatal }
 
@@ -23,6 +23,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.ConfigurationException
 import akka.actor.dungeon.ChildrenContainer
+import akka.actor.dungeon.LicenseKeySupplier
 import akka.actor.setup.{ ActorSystemSetup, Setup }
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
@@ -33,6 +34,11 @@ import akka.japi.Util.immutableSeq
 import akka.serialization.SerializationExtension
 import akka.util._
 import akka.util.Helpers.toRootLowerCase
+import java.net.URLDecoder
+import java.security.{ KeyFactory, MessageDigest, Signature }
+import java.security.spec.X509EncodedKeySpec
+import java.time.Instant
+import java.time.{ LocalDate, ZoneId }
 
 object BootstrapSetup {
 
@@ -835,10 +841,10 @@ private[akka] class ActorSystemImpl(
             if (cause.isInstanceOf[IncompatibleClassChangeError] && cause.getMessage.startsWith("akka"))
               System.err.println(
                 s"""Detected ${cause.getClass.getName} error, which MAY be caused by incompatible Akka versions on the classpath.
-                  | Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
-                  | e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core
-                  | Akka modules MUST be of the same version. External projects like Alpakka, Persistence plugins or Akka
-                  | HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
+                   | Please note that a given Akka version MUST be the same across all modules of Akka that you are using,
+                   | e.g. if you use akka-actor [${akka.Version.current} (resolved from current classpath)] all other core
+                   | Akka modules MUST be of the same version. External projects like Alpakka, Persistence plugins or Akka
+                   | HTTP etc. have their own version numbers - please make sure you're using a compatible set of libraries.
                  """.stripMargin.replaceAll("[\r\n]", ""))
 
             if (settings.JvmExitOnFatalError)
@@ -1037,6 +1043,7 @@ private[akka] class ActorSystemImpl(
     if (settings.LogDeadLetters > 0)
       logDeadLetterListener = Some(systemActorOf(Props[DeadLetterListener](), "deadLetterListener"))
     eventStream.startUnsubscriber()
+    checkLicenseKey()
     ManifestInfo(this).checkSameVersion("Akka", allModules, logWarning = true)
     if (!terminating)
       loadExtensions()
@@ -1292,5 +1299,161 @@ private[akka] class ActorSystemImpl(
      * Returns a Future which will be completed once all registered callbacks have been executed.
      */
     def terminationFuture: Future[T] = done.future
+  }
+
+  private def checkLicenseKey(): Unit = {
+    val maybeSupplier = Option(LicenseKeySupplier.instance.get())
+    val key = maybeSupplier match {
+      case Some(supplier) => supplier.get(config)
+      case None           => config.getString("akka.license-key")
+    }
+    val akkaVersion = akka.Version.Current
+    val buildDate = Instant.ofEpochMilli(akka.Version.BuildDate).atZone(ZoneId.systemDefault()).toLocalDate
+    val revokedLicenseKeyIds = Seq(
+      // This actually isn't a revoked license key id, but is here as an example of what one looks like
+      "ece608e4a2cc927c3d31d7e1ac0b3b641c1cf569548c5462e659cce412cfcd6c")
+
+    if (LocalDate.now().isAfter(buildDate.plusYears(3))) {
+      log.info(s"Akka $akkaVersion is more than 3 years old, license check skipped as Apache license is in use.")
+    } else if (key == "") {
+      if (config.getBoolean("akka.warn-on-no-license-key")) {
+        log.warning("Dev use only. Free keys at https://akka.io/key")
+      }
+      scheduler.scheduleOnce(15.minutes) {
+        log.error("Akka terminated. Obtain free keys at https://akka.io/key")
+        terminate()
+      }(dispatcher)
+    } else {
+      val publicKeyEncoded =
+        "49M9dBWX5VO6FXdkO6KvIgBWn97ANHFad5fJdkVkhy0DG0jzE5l4SZY6I5am2DmnaHJ4cIx54umRoCy1q3SzjLHbBMcczLIaO2p2CQKUNgwK8y4KITrUTYn6U0EqUb"
+      val publicKeySpec = new X509EncodedKeySpec(Base62.decode(publicKeyEncoded))
+      val publicKey = KeyFactory.getInstance("EC").generatePublic(publicKeySpec)
+
+      val licenseBytes = try Base62.decode(key)
+      catch {
+        case NonFatal(e) => failInvalidLicenseKey(s"Error decoding license key: ${e.getMessage}")
+      }
+      if (licenseBytes.length < 3) {
+        failInvalidLicenseKey("Invalid license key")
+      }
+      if (licenseBytes(0) != 0x25 || licenseBytes(1) != 0x52) {
+        failInvalidLicenseKey("Invalid license key")
+      }
+      val version = licenseBytes(2)
+      if (version != 0) {
+        failInvalidLicenseKey(s"Unrecognized license key version: $version")
+      }
+      val hashSep = licenseBytes.indexOf('#', 2)
+      if (hashSep == -1) {
+        failInvalidLicenseKey("Invalid license key")
+      }
+      val signedContent = licenseBytes.take(hashSep)
+      val sigBytes = licenseBytes.drop(hashSep + 1)
+      val sig = Signature.getInstance("SHA256withECDSA")
+      sig.initVerify(publicKey)
+      sig.update(signedContent)
+      if (!sig.verify(sigBytes)) {
+        failInvalidLicenseKey("Failed to validate license signature")
+      }
+
+      val licenseKeyId = MessageDigest
+        .getInstance("SHA-256")
+        .digest(sigBytes)
+        // Not efficient, would use HexFormat.of(), but that requires JDK17
+        .map(byte => "%02X".format(byte))
+        .mkString
+      if (revokedLicenseKeyIds.contains(licenseKeyId)) {
+        failInvalidLicenseKey("The license key has been revoked")
+      }
+
+      val claimsStr = new String(licenseBytes, 3, hashSep - 3, "utf-8")
+      val claims = claimsStr.split('&').map { claim =>
+        claim.split("=", 2) match {
+          case Array(key, value) => key -> URLDecoder.decode(value, "utf-8")
+          case _                 => failInvalidLicenseKey("Invalid license key claim")
+        }
+      }
+
+      val epoch = LocalDate.of(2024, 8, 22)
+
+      def opt(key: String): Option[String] = claims.collectFirst {
+        case (`key`, value) => value
+      }
+
+      def optDate(key: String): Option[LocalDate] = opt(key).map(v => epoch.plusDays(Integer.parseInt(v, 16)))
+
+      val user = opt("s").getOrElse("unknown user")
+      val issuer = opt("i") match {
+        case Some("k") =>
+          "Kalix"
+        case _ =>
+          "Lightbend"
+      }
+
+      val buildExpiry = optDate("b")
+      val expiry = optDate("e")
+      val warnOnExpiry = opt("w").contains("1")
+      val supplierClaim = opt("supplier")
+      val buildVersion = opt("v")
+
+      supplierClaim.foreach { expectedSupplierClass =>
+        maybeSupplier match {
+          case Some(supplier) if expectedSupplierClass != supplier.getClass.getName =>
+            failInvalidLicenseKey("Not compatible with this distribution of Akka. Wrong supplier.")
+          case Some(_) =>
+          // ok, right supplier
+          case None =>
+            failInvalidLicenseKey("Not compatible with this distribution of Akka. Missing supplier.")
+        }
+      }
+
+      buildVersion.foreach { version =>
+        if (version != akkaVersion) {
+          failInvalidLicenseKey("Not permitted for use with this version of Akka")
+        }
+      }
+
+      buildExpiry match {
+        case Some(expired) if expired.isBefore(buildDate) =>
+          failExpiredLicenseKey(
+            warnOnExpiry,
+            s"The key licensed to $issuer user $user is expired for all Akka builds released after $expired, but Akka $akkaVersion was released on $buildDate.")
+        case Some(valid) =>
+          log.info(
+            s"License check succeeded for $issuer user $user. License is valid for all Akka builds released prior to $valid.")
+        case None =>
+      }
+      expiry match {
+        case Some(expired) if expired.isBefore(LocalDate.now()) =>
+          failExpiredLicenseKey(warnOnExpiry, s"The key licensed to $issuer user $user expired on $expired.")
+        case Some(valid) =>
+          log.info(s"License check succeeded for $issuer user $user. License is valid until $valid.")
+        case None =>
+      }
+
+      if (buildExpiry.isEmpty && expiry.isEmpty) {
+        log.info(s"License check succeeded for $issuer user $user. License is perpetual.")
+      }
+    }
+  }
+
+  private def failInvalidLicenseKey(detailedMsg: String): Nothing = {
+    log.error("Invalid key. Free keys at https://akka.io/key")
+    log.debug(s"The supplied license key is not valid: $detailedMsg")
+    throw new RuntimeException(s"Invalid key: $detailedMsg")
+  }
+
+  private def failExpiredLicenseKey(warnOnExpiry: Boolean, detailedMsg: String): Unit = {
+    log.error(
+      "Expired key. {}Obtain refresh key at https://akka.io/key",
+      if (warnOnExpiry) "" else "Akka will terminate in 15 mins. ")
+    log.debug(s"The supplied license key has expired: $detailedMsg")
+    if (!warnOnExpiry) {
+      val terminateAfter = 15.minutes + ThreadLocalRandom.current().nextInt(5 * 60).seconds
+      scheduler.scheduleOnce(terminateAfter) {
+        log.error("Akka terminated due to expired key. Obtain refresh key at https://akka.io/key")
+        terminate()
+      }(dispatcher)
+    }
   }
 }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/LicenseKeySupplier.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/LicenseKeySupplier.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.dungeon
+
+import akka.annotation.InternalStableApi
+import com.typesafe.config.Config
+
+/** INTERNAL API */
+@InternalStableApi
+object LicenseKeySupplier {
+  val instance: ThreadLocal[LicenseKeySupplier] = new ThreadLocal[LicenseKeySupplier]
+}
+
+/** INTERNAL API: Supplies an Akka license key. */
+@InternalStableApi
+trait LicenseKeySupplier {
+
+  /**
+   * This method exists to make clear to anyone that is trying to circumvent the Akka license check
+   * that doing so is a violation of the Akka license.
+   */
+  def implementing_this_is_a_violation_of_the_akka_license(): Unit
+
+  def get(config: Config): String
+}

--- a/akka-actor/src/main/scala/akka/util/Base62.scala
+++ b/akka-actor/src/main/scala/akka/util/Base62.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2023-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+/**
+ * Base62 encoder/decoder.
+ *
+ * Unlike an encoding like Base64, a perfect Base62 encoding never aligns with the bytes - there are no whole numbers
+ * for which you can say "for every n bytes, there are m characters output." This is because 62 and 256 share no common
+ * exponents. So you can't perfectly break the input up into blocks, and encode it one block at a time, like you can
+ * with Base64.
+ *
+ * Instead, we approximate it. We break the raw bytes into blocks of 8 bytes, and encoded blocks of 11 base62 digits.
+ * This size was chosen because 62^^11 is greater than, but somewhat close to logarithmically, 256^^8. Because it's
+ * greater than, it guarantees that every 8 byte block value can fit in 11 base62 characters, while the closeness
+ * minimises the overhead due to values of 11 base62 characters that are too big to map to 8 bytes. I checked block
+ * sizes up to 10, and found this yielded the best efficiency. Also, 8 is the longest input block size that allows us
+ * to do all the arithmetic using primitive data types (in this case, unsigned long), rather than having to use a big
+ * integer type, which would impact performance and make our code more complex.
+ *
+ * So, our encoded string is 11/8 (1.375) times longer than the input bytes, which is slightly worse than the optimal
+ * base62 encoding efficiency of 8/log2(62), ie 1.344 times longer than the input bytes. But, implementing the optimal
+ * encoding requires dividing the entire input byte array by 62 over and over, which would mean our encoding would run
+ * in O(n2) rather than O(n).
+ *
+ * This does mean certain input strings, containing only valid base62 characters, may not be possible to decode. This
+ * is also true with base64, but such corruptions can only happen in the last block, if the last block is one character
+ * long. Whereas such corruptions can happen in any block in this encoding, for example, a block of only z's is invalid
+ * anywhere in the encoded form.
+ *
+ * The encoder is reasonably performant. I haven't done any fine tunings or micro-benchmarks of it, but I have taken
+ * care to ensure it does run in O(n), and avoided unnecessary buffer copies where possible. For the purposes of license
+ * encoding, its runtime is negligible compared to the cryptographic signing and verification operations.
+ *
+ * There are other Base62 encoders out there, and they use a number of different incompatible approaches. Keybase has
+ * a library called saltpack which contains a Base62 encoder. It uses the same block encoding approach, but with 32
+ * byte blocks. However, its encoder is flexible enough to allow creating an encoder with any arbitrary block length.
+ * This implementation has been verified to be compatible with the Keybase saltpack BaseX encoder for Base62 with a
+ * block size of 8.
+ */
+private[akka] object Base62 {
+  // This implementation cannot handle a raw block size greater than 8 because it reads the raw blocks into a long.
+  private final val RawBlockSize = 8
+  private final val EncodedBlockSize = 11
+  // Technically, this implementation could be used for any sized encoding up to 62, just by changing this.
+  private final val Base = 62
+
+  import java.lang.{ Long => jLong }
+  // The highest value a block can be before adding any digit will cause it to overflow
+  private final val blockOverflowLimit = jLong.divideUnsigned(-1, 62)
+
+  private def encodeDigit(digit: Long): Byte =
+    (digit match {
+      case d if d < 10 => '0' + d
+      case u if u < 36 => 'A' - 10 + u
+      case l           => 'a' - 36 + l
+    }).asInstanceOf[Byte]
+
+  private def decodeDigit(digit: Char): Int = digit match {
+    case d if d >= '0' && d <= '9' => d - '0'
+    case u if u >= 'A' && u <= 'Z' => u - 'A' + 10
+    case l if l >= 'a' && l <= 'z' => l - 'a' + 36
+    case invalid                   => throw new Base62EncodingException(s"Invalid base62 character: $invalid")
+  }
+
+  /**
+   * Encode the given byte array into a string.
+   */
+  def encode(raw: Array[Byte]): String = {
+    // Work out the block parameters, including how many blocks there are, whether there's a last partial block, and
+    // how big it is, both for raw and encoded forms.
+    val fullBlocks = raw.length / RawBlockSize
+    val lastRawBlockSize = raw.length % RawBlockSize
+    val totalBlocks = if (lastRawBlockSize == 0) fullBlocks else fullBlocks + 1
+    val lastEncodedBlockSize = math.ceil(lastRawBlockSize.toDouble / RawBlockSize * EncodedBlockSize).toInt
+
+    val encoded = new Array[Byte](fullBlocks * EncodedBlockSize + lastEncodedBlockSize)
+    for (i <- 0 until totalBlocks) {
+      // This is an unsigned long, we need to make sure all operations done to it operate in an unsigned fashion.
+      // Hence below we use java.lang.Long.*Unsigned operations.
+      var block = 0L
+      val partialBlock = i == totalBlocks - 1 && lastRawBlockSize > 0
+      val rawBlockSize = if (partialBlock) lastRawBlockSize else RawBlockSize
+      for (j <- i * RawBlockSize until i * RawBlockSize + rawBlockSize) {
+        block = (block << 8) | (raw(j) & 0xff)
+      }
+      val encodedBlockSize = if (partialBlock) lastEncodedBlockSize else EncodedBlockSize
+      for (j <- i * EncodedBlockSize + encodedBlockSize - 1 to i * EncodedBlockSize by -1) {
+        val digit = jLong.remainderUnsigned(block, Base)
+        encoded(j) = encodeDigit(digit)
+        block = jLong.divideUnsigned(block, Base)
+      }
+    }
+    new String(encoded, "utf-8")
+  }
+
+  private def computeLastRawBlockSize(lastEncodedBlockSize: Int): Int =
+    math.floor(lastEncodedBlockSize.toDouble / EncodedBlockSize * RawBlockSize).toInt
+
+  /**
+   * Decode the given encoded string into a byte array.
+   */
+  def decode(encoded: String): Array[Byte] = {
+    // Work out the block parameters, including how many blocks there are, whether there's a last partial block, and
+    // how big it is, both for the encoded and raw forms.
+    val fullBlocks = encoded.length / EncodedBlockSize
+    val lastEncodedBlockSize = encoded.length % EncodedBlockSize
+    val totalBlocks = if (lastEncodedBlockSize == 0) fullBlocks else fullBlocks + 1
+    val lastRawBlockSize = computeLastRawBlockSize(lastEncodedBlockSize)
+
+    // Need to validate that the size of the last block is valid, not all last block sizes are valid. It's invalid if
+    // one less than the encoded last block size would have the same raw block size.
+    if (lastEncodedBlockSize != 0) {
+      if (lastRawBlockSize == computeLastRawBlockSize(lastEncodedBlockSize - 1)) {
+        throw new Base62EncodingException("Invalid base62 length")
+      }
+    }
+    val raw = new Array[Byte](fullBlocks * RawBlockSize + lastRawBlockSize)
+    for (i <- 0 until totalBlocks) {
+      val partialBlock = i == totalBlocks - 1 && lastEncodedBlockSize > 0
+      val encodedBlockSize = if (partialBlock) lastEncodedBlockSize else EncodedBlockSize
+      // This is an unsigned long, we need to make sure all operations done to it operate in an unsigned fashion.
+      // Multiply/add operate identically for signed/unsigned, but the logical bitshift (>>>) rather than arithmetic
+      // bitshift (>>) is important.
+      var block = 0L
+      for (j <- i * EncodedBlockSize until i * EncodedBlockSize + encodedBlockSize) {
+        // There are two possibilities for overflow, first is that multiplying by the base will trigger an overflow,
+        // second is adding the digit will trigger an overflow. We need to check for both. Multiplying by the base
+        // triggering an overflow can only be checked beforehand
+        if (jLong.compareUnsigned(block, blockOverflowLimit) > 0) {
+          throw new Base62EncodingException("Invalid base62 encoding")
+        }
+        val newBlock = block * Base + decodeDigit(encoded.charAt(j))
+        // Now detect if the addition caused an overflow, because we're only adding a small value, an overflow can be
+        // detected by checking if the new value is less than the first
+        if (jLong.compareUnsigned(newBlock, block) < 0) {
+          throw new Base62EncodingException("Invalid base62 encoding")
+        }
+        block = newBlock
+      }
+      val rawBlockSize = if (partialBlock) lastRawBlockSize else RawBlockSize
+      for (j <- i * RawBlockSize + rawBlockSize - 1 to i * RawBlockSize by -1) {
+        raw(j) = (block & 0xFF).asInstanceOf[Byte]
+        block = block >>> 8
+      }
+      // Check for an invalid last block
+      if (partialBlock && block != 0) {
+        throw new Base62EncodingException("Invalid base62 encoding")
+      }
+    }
+    raw
+  }
+
+  class Base62EncodingException(msg: String) extends RuntimeException(msg)
+
+}

--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -52,6 +52,13 @@ one library in a `reference.conf` of another library.
 
 @@@
 
+## License key
+
+Akka requires a license key for use in production. Free keys can be obtained at [https://akka.io/key](https://akka.io/key).
+Add the key to the configuration property `akka.license-key`.
+
+For local development, Akka can be used without a key, but be aware of that the `ActorSystem` will terminate after a while when a key isn't configured.
+
 ## When using JarJar, OneJar, Assembly or any jar-bundler
 
 @@@ warning

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -31,6 +31,7 @@ object AkkaSpec {
         loggers = ["akka.testkit.TestEventListener"]
         loglevel = "WARNING"
         stdout-loglevel = "WARNING"
+        warn-on-no-license-key = off
         actor {
           default-dispatcher {
             executor = "fork-join-executor"

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -6,6 +6,7 @@ package akka
 
 import sbt._
 import sbt.Keys._
+import sbtdynver.DynVerPlugin.autoImport.dynverGitDescribeOutput
 
 /**
  * Generate version.conf and akka/Version.scala files based on the version setting.
@@ -15,17 +16,41 @@ object VersionGenerator {
   val settings: Seq[Setting[_]] = inConfig(Compile)(
     Seq(
       resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.version = "%s"
+         |akka.versionReleaseDateMillis = %d
          |"""),
-      sourceGenerators += generateVersion(sourceManaged, _ / "akka" / "Version.scala", """|package akka
+      sourceGenerators += generateVersion(
+          sourceManaged,
+          _ / "akka" / "Version.scala",
+          """|package akka
+         |
+         |import akka.annotation.InternalApi
          |
          |object Version {
-         |  val current: String = "%s"
+         |  /** INTERNAL API: Compile time constant. */
+         |  @InternalApi private[akka] final val Current = "%s"
+         |
+         |  val current: String = Current
+         |
+         |  /** INTERNAL API: Build date as epoch millis. Compile time constant. */
+         |  @InternalApi private[akka] final val BuildDate = %dL
          |}
          |""")))
 
   def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
     val file = locate(dir.value)
-    val content = template.stripMargin.format(version.value)
+
+    import scala.sys.process._
+    val buildDate = dynverGitDescribeOutput.value match {
+      case Some(output) if output.ref.isTag && output.isCleanAfterTag =>
+        Seq("git", "tag", "-l", output.ref.value, "--format=%(creatordate:unix)").!!.trim.toLong * 1000
+      case Some(output) if !output.isDirty && !output.commitSuffix.isEmpty =>
+        Seq("git", "show", output.commitSuffix.sha, "-s", "--format=%ct").!!.trim.toLong * 1000
+      case _ =>
+        System.currentTimeMillis()
+    }
+
+    val content = template.stripMargin.format(version.value, buildDate)
+
     if (!file.exists || IO.read(file) != content) IO.write(file, content)
     Seq(file)
   }


### PR DESCRIPTION
* Check license key at startup
* Base62 decoding with validation of invalid strings
* Added Base62 specs
* Added warn on expiry support
* Added license revocation list support.
* Added license supplier
* Adjustments to log messages and termination after expiry
* Mention in docs
* Version and BuildDate as compile time constants
* silence log in tests

(cherry picked from commit 644c9114b8cfbd884f36e8bca063400507a54cde)
