### PR TITLE
fix: Circuit breaker with id for journal and snapshot store

### DIFF
--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -121,6 +121,10 @@ akka.persistence {
         max-failures = 10
         call-timeout = 10s
         reset-timeout = 30s
+        max-reset-timeout = ${akka.circuit-breaker.default.max-reset-timeout}
+        exponential-backoff = ${akka.circuit-breaker.default.exponential-backoff}
+        random-factor = ${akka.circuit-breaker.default.random-factor}
+        exception-allowlist = []
       }
 
       # The replay filter can detect a corrupt event stream by inspecting
@@ -166,6 +170,10 @@ akka.persistence {
         max-failures = 5
         call-timeout = 20s
         reset-timeout = 60s
+        max-reset-timeout = ${akka.circuit-breaker.default.max-reset-timeout}
+        exponential-backoff = ${akka.circuit-breaker.default.exponential-backoff}
+        random-factor = ${akka.circuit-breaker.default.random-factor}
+        exception-allowlist = []
       }
 
       # Set this to true if successful loading of snapshot is not necessary.


### PR DESCRIPTION
An oversight: even though it looked like we were using id:d circuit breakers for the stores, we created an anonymous circuit breaker and put in the registry.