### PR TITLE
docs(streams): push module info to page

### DIFF
--- a/akka-docs/src/main/paradox/stream/index.md
+++ b/akka-docs/src/main/paradox/stream/index.md
@@ -3,33 +3,6 @@ project.description: An intuitive and safe way to do asynchronous, non-blocking 
 ---
 # Streams
 
-## Module info
-
-The Akka dependencies are available from Akka's library repository. To access them there, you need to configure the URL for this repository.
-
-@@repository [sbt,Maven,Gradle] {
-id="akka-repository"
-name="Akka library repository"
-url="https://repo.akka.io/maven"
-}
-
-To use Akka Streams, add the module to your project:
-
-@@dependency[sbt,Maven,Gradle] {
-  bomGroup=com.typesafe.akka bomArtifact=akka-bom_$scala.binary.version$ bomVersionSymbols=AkkaVersion
-  symbol1=AkkaVersion
-  value1="$akka.version$"
-  group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary.version$"
-  version=AkkaVersion
-  group2="com.typesafe.akka"
-  artifact2="akka-stream-testkit_$scala.binary.version$"
-  version2=AkkaVersion
-  scope2=test
-}
-
-@@project-info{ projectId="akka-stream" }
-
 @@toc { depth=2 }
 
 @@@ index

--- a/akka-docs/src/main/paradox/stream/stream-introduction.md
+++ b/akka-docs/src/main/paradox/stream/stream-introduction.md
@@ -71,3 +71,31 @@ point.
 @ref:[operator index](operators/index.md)
  * The other sections can be read sequentially or as needed during the previous
 steps, each digging deeper into specific topics.
+
+## Module info
+
+The Akka dependencies are available from Akka's library repository. To access them there, you need to configure the URL for this repository.
+
+@@repository [sbt,Maven,Gradle] {
+id="akka-repository"
+name="Akka library repository"
+url="https://repo.akka.io/maven"
+}
+
+To use Akka Streams, add the module to your project:
+
+@@dependency[sbt,Maven,Gradle] {
+bomGroup=com.typesafe.akka bomArtifact=akka-bom_$scala.binary.version$ bomVersionSymbols=AkkaVersion
+symbol1=AkkaVersion
+value1="$akka.version$"
+group="com.typesafe.akka"
+artifact="akka-stream_$scala.binary.version$"
+version=AkkaVersion
+group2="com.typesafe.akka"
+artifact2="akka-stream-testkit_$scala.binary.version$"
+version2=AkkaVersion
+scope2=test
+}
+
+@@project-info{ projectId="akka-stream" }
+


### PR DESCRIPTION
The "Module info" is not relevant enough to be on the Streams landing page.
Pushing it down to the "Introduction" page.

- https://doc.akka.io/docs/akka/2.9/stream/index.html