### PR TITLE
fix: Race condition in ReplicatedEventSourcingSpec

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -591,9 +591,7 @@ class ReplicatedEventSourcingSpec
         probe.expectMessageType[State].all.toSet shouldEqual Set("from r1", "from r2")
       }
       val intercepted = interceptProbe.receiveMessages(2)
-      intercepted.toSet shouldEqual Set(
-        Intercepted(ReplicaId("R1"), 2L, "from r1"),
-        Intercepted(ReplicaId("R2"), 2L, "from r2"))
+      intercepted.map(_.event).toSet shouldEqual Set("from r1", "from r2")
     }
 
     "fail entity if replicated event interceptor fails" in {


### PR DESCRIPTION
No guarantee on sequence numbers, just compare the events instead.