### PR TITLE
feat: Expose license key expiry (2.9 backport)

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -4,6 +4,8 @@
 
 package akka.actor.testkit.typed.internal
 
+import java.time.LocalDate
+import java.util.Optional
 import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
 import scala.annotation.nowarn
@@ -126,6 +128,12 @@ import akka.annotation.InternalApi
   override def log: Logger = LoggerFactory.getLogger(getClass)
 
   def address: Address = rootPath.address
+
+  override def licenseKeyExpiry: Option[LocalDate] =
+    throw new UnsupportedOperationException("licenseKeyExpiry not supported by ActorSystemStub")
+
+  def getLicenseKeyExpiry: Optional[LocalDate] =
+    throw new UnsupportedOperationException("getLicenseKeyExpiry not supported by ActorSystemStub")
 }
 
 @InternalApi private[akka] object ActorSystemStub {

--- a/akka-actor-typed/src/main/mima-filters/2.8.x.backwards.excludes/licenseKeyExpiry.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.8.x.backwards.excludes/licenseKeyExpiry.excludes
@@ -1,0 +1,3 @@
+# DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.licenseKeyExpiry")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getLicenseKeyExpiry")

--- a/akka-actor-typed/src/main/mima-filters/2.9.6.backwards.excludes/licenseKeyExpiry.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.9.6.backwards.excludes/licenseKeyExpiry.excludes
@@ -1,0 +1,3 @@
+# DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.licenseKeyExpiry")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getLicenseKeyExpiry")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -4,6 +4,8 @@
 
 package akka.actor.typed
 
+import java.time.LocalDate
+import java.util.Optional
 import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
@@ -186,6 +188,18 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
    * communicate with this node.
    */
   def address: Address
+
+  /**
+   * Scala API: When the license key will expire. `None` for perpetual keys.
+   * If a license key is not defined the expiry date will be today's date.
+   */
+  def licenseKeyExpiry: Option[LocalDate]
+
+  /**
+   * Java API: When the license key will expire. `Optional.empty` for perpetual keys.
+   * If a license key is not defined the expiry date will be today's date.
+   */
+  def getLicenseKeyExpiry: Optional[LocalDate]
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -4,6 +4,8 @@
 
 package akka.actor.typed.internal.adapter
 
+import java.time.LocalDate
+import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters
@@ -127,6 +129,10 @@ import akka.util.OptionVal
   override def refPrefix: String = "user"
 
   override def address: Address = system.provider.getDefaultAddress
+
+  override def licenseKeyExpiry: Option[LocalDate] = system.licenseKeyExpiry
+
+  override def getLicenseKeyExpiry: Optional[LocalDate] = system.getLicenseKeyExpiry
 
 }
 

--- a/akka-actor/src/main/mima-filters/2.8.x.backwards.excludes/licenseKeyExpiry.excludes
+++ b/akka-actor/src/main/mima-filters/2.8.x.backwards.excludes/licenseKeyExpiry.excludes
@@ -1,0 +1,3 @@
+# DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorSystem.licenseKeyExpiry")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorSystem.getLicenseKeyExpiry")

--- a/akka-actor/src/main/mima-filters/2.9.6.backwards.excludes/licenseKeyExpiry.excludes
+++ b/akka-actor/src/main/mima-filters/2.9.6.backwards.excludes/licenseKeyExpiry.excludes
@@ -1,0 +1,3 @@
+# DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorSystem.licenseKeyExpiry")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorSystem.getLicenseKeyExpiry")

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -719,6 +719,18 @@ abstract class ActorSystem extends ActorRefFactory with ClassicActorSystemProvid
    * of the payload, if is in the process of registration from another Thread of execution
    */
   def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean
+
+  /**
+   * Scala API: When the license key will expire. `None` for perpetual keys.
+   * If a license key is not defined the expiry date will be today's date.
+   */
+  def licenseKeyExpiry: Option[LocalDate]
+
+  /**
+   * Java API: When the license key will expire. `Optional.empty` for perpetual keys.
+   * If a license key is not defined the expiry date will be today's date.
+   */
+  def getLicenseKeyExpiry: Optional[LocalDate]
 }
 
 /**
@@ -839,6 +851,23 @@ private[akka] class ActorSystemImpl(
       applicationConfig.withFallback(ConfigFactory.defaultReference(classLoader)),
       _dynamicAccess)
     new Settings(classLoader, config, name, setup)
+  }
+
+  // initialized from `start()`
+  @volatile private var _licenseKeyExpiry: Option[LocalDate] = None
+
+  override def licenseKeyExpiry: Option[LocalDate] = _licenseKeyExpiry
+
+  override def getLicenseKeyExpiry: Optional[LocalDate] = _licenseKeyExpiry.asJava
+
+  private def setLicenseKeyExpiry(expiry: LocalDate): Unit = {
+    _licenseKeyExpiry match {
+      case None =>
+        _licenseKeyExpiry = Some(expiry)
+      case Some(exp) =>
+        if (expiry.isBefore(exp))
+          _licenseKeyExpiry = Some(expiry)
+    }
   }
 
   override def uid: Long = {
@@ -1348,13 +1377,15 @@ private[akka] class ActorSystemImpl(
     }
     val akkaVersion = akka.Version.Current
     val buildDate = LocalDate.ofInstant(Instant.ofEpochMilli(akka.Version.BuildDate), ZoneId.systemDefault())
+    val today = LocalDate.now()
     val revokedLicenseKeyIds = Seq(
       // This actually isn't a revoked license key id, but is here as an example of what one looks like
       "ece608e4a2cc927c3d31d7e1ac0b3b641c1cf569548c5462e659cce412cfcd6c")
 
-    if (LocalDate.now().isAfter(buildDate.plusYears(3))) {
+    if (today.isAfter(buildDate.plusYears(3))) {
       log.info(s"Akka $akkaVersion is more than 3 years old, license check skipped as Apache license is in use.")
     } else if (key == "") {
+      setLicenseKeyExpiry(today)
       if (config.getBoolean("akka.warn-on-no-license-key")) {
         log.warning("Dev use only. Free keys at https://akka.io/key")
       }
@@ -1454,18 +1485,22 @@ private[akka] class ActorSystemImpl(
 
       buildExpiry match {
         case Some(expired) if expired.isBefore(buildDate) =>
+          setLicenseKeyExpiry(expired)
           failExpiredLicenseKey(
             warnOnExpiry,
             s"The key licensed to $issuer user $user is expired for all Akka builds released after $expired, but Akka $akkaVersion was released on $buildDate.")
         case Some(valid) =>
+          // no setLicenseKeyExpiry because for currently used Akka version the key will not expire
           log.info(
             s"License check succeeded for $issuer user $user. License is valid for all Akka builds released prior to $valid.")
         case None =>
       }
       expiry match {
-        case Some(expired) if expired.isBefore(LocalDate.now()) =>
+        case Some(expired) if expired.isBefore(today) =>
+          setLicenseKeyExpiry(expired)
           failExpiredLicenseKey(warnOnExpiry, s"The key licensed to $issuer user $user expired on $expired.")
         case Some(valid) =>
+          setLicenseKeyExpiry(valid)
           log.info(s"License check succeeded for $issuer user $user. License is valid until $valid.")
         case None =>
       }

--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -57,7 +57,12 @@ one library in a `reference.conf` of another library.
 Akka requires a license key for use in production. Free keys can be obtained at [https://akka.io/key](https://akka.io/key).
 Add the key to the configuration property `akka.license-key`.
 
-For local development, Akka can be used without a key, but be aware of that the `ActorSystem` will terminate after a while when a key isn't configured.
+For local development, Akka can be used without a key, but be aware that the `ActorSystem` will terminate after
+a while when a key isn't configured.
+
+If the license key has expired when the `ActorSystem` is started the system will terminate after a while.
+The expiry date is exposed by @apidoc[akka.actor.typed.ActorSystem] {scala="#licenseKeyExpiry" java="#getLicenseKeyExpiry"}
+so that you can write a test to remind yourself that it is time for renewal before it has expired.
 
 ## When using JarJar, OneJar, Assembly or any jar-bundler
 


### PR DESCRIPTION
(cherry picked from commit 76215cab28027baa8c1bda268bf2edfffcf3bc9b)

