### PR TITLE
fix: parse M1 version smaller then final

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/VersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/VersionSpec.scala
@@ -52,6 +52,8 @@ class VersionSpec extends AnyWordSpec with Matchers {
       Version("1.2-M1") should be < Version("1.2.0")
       Version("1.2.0-M1") should be < Version("1.2.0")
       Version("1.2.3-M2") should be > Version("1.2.3-M1")
+      Version("2.10.0-M1") should be < Version("2.10.0")
+      Version("2.10.0") should be > Version("2.10.0-M1")
     }
 
     "require digits" in {

--- a/akka-actor/src/main/scala/akka/util/Version.scala
+++ b/akka-actor/src/main/scala/akka/util/Version.scala
@@ -160,7 +160,7 @@ final class Version(val version: String) extends Comparable[Version] {
             if (diff == 0) {
               if (rest == "" && other.rest != "")
                 diff = 1
-              if (other.rest == "" && rest != "")
+              else if (other.rest == "" && rest != "")
                 diff = -1
               else
                 diff = rest.compareTo(other.rest)


### PR DESCRIPTION
Return the `1` if `rest` (which is `this`) does **not** have any, but the `other.rest` as some.

Fixes https://github.com/akka/akka/issues/32576