### PR TITLE
chore: Log Dropped inside DeadLetter

### DIFF
--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -28,6 +28,11 @@ akka.actor.typed {
   default-mailbox {
     mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
   }
+
+  pub-sub {
+    # When a message is published to a topic with no subscribers send it to the dead letters.
+    send-to-dead-letters-when-no-subscribers = on
+  }
 }
 
 # Load typed extensions by a classic extension.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -334,4 +334,7 @@ final class Settings(val config: Config, val classicSettings: classic.ActorSyste
 
   val RestartStashCapacity: Int =
     typedConfig.getInt("restart-stash-capacity").requiring(_ >= 0, "restart-stash-capacity must be >= 0")
+
+  val PubSubDeadLettersWhenNoSubscribers: Boolean =
+    typedConfig.getBoolean("pub-sub.send-to-dead-letters-when-no-subscribers")
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -154,7 +154,8 @@ private[akka] final class TopicImpl[T](
       if (topicInstances.isEmpty) {
         if (localSubscribers.isEmpty) {
           context.log.trace("Publishing message of type [{}] but no subscribers, dropping", msg.getClass)
-          context.system.deadLetters[Dropped] ! Dropped(message, "No topic subscribers known", context.self.toClassic)
+          if (context.system.settings.PubSubDeadLettersWhenNoSubscribers)
+            context.system.deadLetters[Dropped] ! Dropped(message, "No topic subscribers known", context.self.toClassic)
         } else {
           context.log.trace(
             "Publishing message of type [{}] to local subscribers only (topic listing not seen yet)",


### PR DESCRIPTION
* for example when using r2dbc it will publish the events and those are sent to dead letters if there are no topic subscribers

Before:
```
INFO  a.r.RemoteActorRefProvider$RemoteDeadLetterActorRef - Message [akka.persistence.query.typed.EventEnvelope] wrapped in [akka.actor.Dropped] to Actor[akka://sys/deadLetters] was not delivered. [1] dead letters encountered. If this is not an expected behavior then Actor[akka://sys/deadLetters] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
```

After:
```
INFO  a.r.RemoteActorRefProvider$RemoteDeadLetterActorRef - Message [akka.persistence.query.typed.EventEnvelope] wrapped in [akka.actor.Dropped] was dropped. No topic subscribers known. [1] dead letters encountered. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
```