### PR TITLE
test: Default logger name changed in Scala 3, #32554

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/EventSourcedBehaviorLoggingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/EventSourcedBehaviorLoggingSpec.scala
@@ -128,6 +128,6 @@ object EventSourcedBehaviorLoggingContextLoggerSpec {
 }
 class EventSourcedBehaviorLoggingContextLoggerSpec
     extends EventSourcedBehaviorLoggingSpec(EventSourcedBehaviorLoggingContextLoggerSpec.config) {
-  override def loggerName = "akka.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$"
+  override def loggerName = "test.ChattyEventSourcingBehavior"
   override def loggerId = "context.log"
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/EventSourcedBehaviorLoggingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/EventSourcedBehaviorLoggingSpec.scala
@@ -33,6 +33,8 @@ object EventSourcedBehaviorLoggingSpec {
 
     def apply(id: PersistenceId): Behavior[Command] = {
       Behaviors.setup { ctx =>
+        // default resolved logger name is slightly different in Scala 2.13 and 3.3 due to the object/object nesting
+        ctx.setLoggerName("test.ChattyEventSourcingBehavior")
         EventSourcedBehavior[Command, Event, Set[Event]](
           id,
           Set.empty,
@@ -66,13 +68,10 @@ abstract class EventSourcedBehaviorLoggingSpec(config: Config)
 
     "always log user message in context.log" in {
       val doneProbe = createTestProbe[Done]()
-      LoggingTestKit
-        .info("received message 'Mary'")
-        .withLoggerName("akka.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$")
-        .expect {
-          chattyActor ! Hello("Mary", doneProbe.ref)
-          doneProbe.receiveMessage()
-        }
+      LoggingTestKit.info("received message 'Mary'").withLoggerName("test.ChattyEventSourcingBehavior").expect {
+        chattyActor ! Hello("Mary", doneProbe.ref)
+        doneProbe.receiveMessage()
+      }
     }
 
     s"log internal messages in '$loggerId' logger without logging user data (Persist)" in {


### PR DESCRIPTION
* probably because of the nested object/object

Comparing the stack trace that is used for resolving the default logger name.
Scala 2.13:
```
class akka.actor.typed.internal.LoggerClass$TrickySecurityManager
class akka.actor.typed.internal.LoggerClass$
class akka.persistence.typed.scaladsl.EventSourcedBehavior$
class akka.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$
class akka.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$$$Lambda$533/0x00000008004b3148
class akka.actor.typed.internal.BehaviorImpl$DeferredBehavior$$anon$1
```

Scala 3.3:
```
class akka.actor.typed.internal.LoggerClass$TrickySecurityManager
class akka.actor.typed.internal.LoggerClass$
class akka.persistence.typed.scaladsl.EventSourcedBehavior$
class akka.persistence.typed.EventSourcedBehaviorLoggingSpec$
class akka.persistence.typed.EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$$$Lambda$545/0x00000008004c1e10
class akka.actor.typed.internal.BehaviorImpl$DeferredBehavior$$anon$2
```

Note `EventSourcedBehaviorLoggingSpec$ChattyEventSourcingBehavior$` vs `EventSourcedBehaviorLoggingSpec$`