### PR TITLE
Update expiry to use assumption that expiry is counted as day of also

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -865,7 +865,7 @@ private[akka] class ActorSystemImpl(
       case None =>
         _licenseKeyExpiry = Some(expiry)
       case Some(exp) =>
-        if (expiry.isBefore(exp))
+        if (expiry.isBefore(exp) || expiry.isEqual(exp))
           _licenseKeyExpiry = Some(expiry)
     }
   }
@@ -1484,7 +1484,7 @@ private[akka] class ActorSystemImpl(
       }
 
       buildExpiry match {
-        case Some(expired) if expired.isBefore(buildDate) =>
+        case Some(expired) if expired.isBefore(buildDate) || expired.isEqual(buildDate) =>
           setLicenseKeyExpiry(expired)
           failExpiredLicenseKey(
             warnOnExpiry,
@@ -1496,7 +1496,7 @@ private[akka] class ActorSystemImpl(
         case None =>
       }
       expiry match {
-        case Some(expired) if expired.isBefore(today) =>
+        case Some(expired) if expired.isBefore(today) || expired.isEqual(today) =>
           setLicenseKeyExpiry(expired)
           failExpiredLicenseKey(warnOnExpiry, s"The key licensed to $issuer user $user expired on $expired.")
         case Some(valid) =>


### PR DESCRIPTION
This should have been caught previously, but better late than never. [Per this google search](https://www.google.com/search?q=is+an+expiration+date+the+day+of+or+after) (and you can replicate in many ways):

> An expiration date is the last day a product is guaranteed to be safe and effective, so it is the day after which the product should no longer be used.