### PR TITLE
build: align mima for 2.10.0 release

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -21,6 +21,8 @@ object MiMa extends AutoPlugin {
   private val latestPatchOf28 = 7
   private val firstPatchOf29 = 0
   private val latestPatchOf29 = 7
+  private val firstPatchOf210 = 0
+  private val latestPatchOf210 = 0
 
   override def requires = MimaPlugin
   override def trigger = allRequirements
@@ -34,10 +36,10 @@ object MiMa extends AutoPlugin {
     checkMimaFilterDirectories := checkFilterDirectories(baseDirectory.value))
 
   def checkFilterDirectories(moduleRoot: File): Unit = {
-    val nextVersionFilterDir = moduleRoot / "src" / "main" / "mima-filters" / s"2.9.${latestPatchOf29 + 1}.backwards.excludes"
+    val nextVersionFilterDir = moduleRoot / "src" / "main" / "mima-filters" / s"2.10.${latestPatchOf210 + 1}.backwards.excludes"
     if (nextVersionFilterDir.exists()) {
       throw new IllegalArgumentException(s"Incorrect mima filter directory exists: '$nextVersionFilterDir' " +
-      s"should be with number from current release '${moduleRoot / "src" / "main" / "mima-filters" / s"2.9.$latestPatchOf29.backwards.excludes"}")
+      s"should be with number from current release '${moduleRoot / "src" / "main" / "mima-filters" / s"2.10.$latestPatchOf210.backwards.excludes"}")
     }
   }
 
@@ -47,10 +49,11 @@ object MiMa extends AutoPlugin {
       scalaBinaryVersion: String): Set[sbt.ModuleID] = {
     val akka28Previous = expandVersions(2, 8, firstPatchOf28 to latestPatchOf28) :+ "2.7.1"
     val akka29Previous = expandVersions(2, 9, firstPatchOf29 to latestPatchOf29)
+    val akka210Previous = expandVersions(2, 10, firstPatchOf210 to latestPatchOf210)
     val versions: Seq[String] =
       if (scalaBinaryVersion.startsWith("3")) {
         // was experimental before 2.7.0
-        akka28Previous ++ akka29Previous
+        akka28Previous ++ akka29Previous ++ akka210Previous
       } else {
         val akka26Previous = expandVersions(2, 6, firstPatchOf26 to latestPatchOf26)
         val akka27Previous = expandVersions(2, 7, firstPatchOf27 to latestPatchOf27)


### PR DESCRIPTION
Follow up item from the release issue: https://github.com/akka/akka/issues/32561