### PR TITLE
chore: rasing warning instead of error

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesCoordinatorStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesCoordinatorStore.scala
@@ -102,7 +102,7 @@ private[akka] final class DDataRememberEntitiesCoordinatorStore(
       replyTo ! RememberEntitiesCoordinatorStore.UpdateDone(shardId)
 
     case Replicator.UpdateTimeout(AllShardsKey, Some((replyTo: ActorRef, shardId: ShardId))) =>
-      log.error(
+      log.warning(
         "Remember entities coordinator store unable to update shards state within 'updating-state-timeout': {} millis (retrying), adding shard={}",
         writeConsistency.timeout.toMillis,
         shardId)


### PR DESCRIPTION
The users are getting this error but there's nothing they should/could do about it. I understand the runtime it's retrying.
For these two reasons I think it's better just to warn the user.
