### PR TITLE
chore: Fix leak in PrefixAndTail.

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -225,7 +225,9 @@ import scala.jdk.CollectionConverters._
     override def onUpstreamFinish(): Unit = {
       if (!prefixComplete) {
         // This handles the unpulled out case as well
-        emit(out, (builder.result(), Source.empty), () => completeStage())
+        val prefix = builder.result()
+        builder = null // free for GC
+        emit(out, (prefix, Source.empty), () => completeStage())
       } else {
         if (!tailSource.isClosed) tailSource.complete()
         completeStage()


### PR DESCRIPTION
Motivation:
When the downstream is not polling it will leak the builder, it was reported in pekko project.
refs: https://github.com/apache/pekko/pull/1623

Modification:
Set the builder to `null` before submitting to `emit`.

Result:
Fix leak.
