### PR TITLE
docs: fix/drop links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ You're always welcome to submit your PR straight away and start the discussion (
 ## The Akka Community
 
 Reach out with questions via the forum at [discuss.akka.io](https://discuss.akka.io). 
-You may also check out these [other resources](https://akka.io/get-involved/).
 
 ## Navigating around the project & codebase
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Reference Documentation
 -----------------------
 
 The reference documentation is available at [doc.akka.io](https://doc.akka.io),
-for [Scala](https://doc.akka.io/libraries/akka-core/current/scala.html) and [Java](https://doc.akka.io/libraries/akka-core/current/java.html).
+for [Scala](https://doc.akka.io/libraries/akka-core/current/?language=scala) and [Java](https://doc.akka.io/libraries/akka-core/current/?language=java).
 
 Current versions of all Akka libraries
 --------------------------------------
@@ -35,9 +35,6 @@ You can join these groups and chats to discuss and ask Akka related questions:
 
 In addition to that, you may enjoy following:
 
-- The [news](https://akka.io/blog/news-archive.html) section of the page, which is updated whenever a new version is released
-- The [Akka Team Blog](https://akka.io/blog/article-archive.html)
-- The [Akka articles in the Akka Blog](https://akka.io/blog)
 - Questions tagged [#akka on StackOverflow](https://stackoverflow.com/questions/tagged/akka)
 
 Contributing


### PR DESCRIPTION
Blog and other pages were not kept for the new akka.io site.