### PR TITLE
feat: Recovery based on only the last event

### DIFF
--- a/akka-docs/src/main/paradox/persistence-plugins.md
+++ b/akka-docs/src/main/paradox/persistence-plugins.md
@@ -20,6 +20,8 @@ AWS DynamoDB can be used as backend for Akka Persistence with the [Akka Persiste
 
 @ref:[Durable State](./typed/index-persistence-durable-state.md) is not supported by the DynamoDB plugin.
 
+Recovery from only last event is not supported by the DynamoDB plugin.
+
 ## JDBC plugin
 
 Relational databases with JDBC-drivers are supported through [Akka Persistence JDBC](https://doc.akka.io/libraries/akka-persistence-jdbc/current/). For new projects, the @ref:[R2DBC plugin](#r2dbc-plugin) is recommended.
@@ -38,6 +40,7 @@ Example of concrete features _not_ supported by the Cassandra and JDBC plugins:
 * Projections starting from snapshots
 * Scalability of many Projections
 * Durable State entities (partly supported by JDBC plugin)
+* Recovery from only last event
 
 ## Enabling a plugin
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -546,6 +546,13 @@ Please refer to @ref[snapshots](persistence-snapshot.md#snapshots) if you need t
 
 In any case, the highest sequence number will always be recovered so you can keep persisting new events without corrupting your event log.
 
+@@@ warning
+
+Disable of recovery is not normal behavior of an event sourced actor, since events and snapshots are not used for
+the recovery of the actor.
+
+@@@
+
 ### Recovery from only last event
 
 For some use cases it is enough to recover the actor from the last event, as an optimization to not replay all events.
@@ -558,6 +565,15 @@ Java
 :  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #replay-last }
 
 Snapshots are not loaded when recovery from last event is selected.
+
+@@@ warning
+
+Recovery from only last event is not normal behavior of an event sourced actor, since it typically would need
+all events, or a snapshot and events after the snapshot, to recover its state.
+
+This feature is currently only supported by the R2DBC plugin.
+
+@@@
 
 ## Tagging
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -546,6 +546,19 @@ Please refer to @ref[snapshots](persistence-snapshot.md#snapshots) if you need t
 
 In any case, the highest sequence number will always be recovered so you can keep persisting new events without corrupting your event log.
 
+### Recovery from only last event
+
+For some use cases it is enough to recover the actor from the last event, as an optimization to not replay all events.
+You can enable this recovery mode with:
+
+Scala
+:  @@snip [BasicPersistentBehaviorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #replay-last }
+
+Java
+:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #replay-last }
+
+Snapshots are not loaded when recovery from last event is selected.
+
 ## Tagging
 
 Persistence allows you to use event tags without using an @ref[`EventAdapter`](../persistence.md#event-adapters):

--- a/akka-persistence-tck/src/main/scala/akka/persistence/CapabilityFlags.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/CapabilityFlags.scala
@@ -58,6 +58,11 @@ trait JournalCapabilityFlags extends CapabilityFlags {
    */
   protected def supportsMetadata: CapabilityFlag
 
+  /**
+   * When `true` enables tests which check if the Journal can replay only the last event.
+   */
+  protected def supportsReplayOnlyLast: CapabilityFlag
+
 }
 //#journal-flags
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -181,6 +181,11 @@ abstract class SnapshotStoreSpec(config: Config)
       snapshotStore.tell(SaveSnapshot(metadata, bigSnapshot), senderProbe.ref)
       senderProbe.expectMsgPF() { case SaveSnapshotSuccess(md) => md }
     }
+    "not load a snapshot when criteria is NoSnapshotAndReplayLastEvent" in {
+      snapshotStore.tell(
+        LoadSnapshot(pid, SnapshotSelectionCriteria.NoSnapshotAndReplayOnlyLast, Long.MaxValue), senderProbe.ref)
+      senderProbe.expectMsg(LoadSnapshotResult(None, Long.MaxValue))
+    }
   }
 
   "A snapshot store optionally".may {
@@ -222,5 +227,6 @@ abstract class SnapshotStoreSpec(config: Config)
         }
       }
     }
+
   }
 }

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.snapshot
 
-import scala.collection.immutable.Seq
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -180,11 +178,6 @@ abstract class SnapshotStoreSpec(config: Config)
       val bigSnapshot = "0" * snapshotByteSizeLimit
       snapshotStore.tell(SaveSnapshot(metadata, bigSnapshot), senderProbe.ref)
       senderProbe.expectMsgPF() { case SaveSnapshotSuccess(md) => md }
-    }
-    "not load a snapshot when criteria is NoSnapshotAndReplayLastEvent" in {
-      snapshotStore.tell(
-        LoadSnapshot(pid, SnapshotSelectionCriteria.NoSnapshotAndReplayOnlyLast, Long.MaxValue), senderProbe.ref)
-      senderProbe.expectMsg(LoadSnapshotResult(None, Long.MaxValue))
     }
   }
 

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
@@ -10,4 +10,6 @@ import akka.persistence.journal.JournalSpec
 
 class InmemJournalSpec extends JournalSpec(config = PersistenceSpec.config("inmem", "InmemJournalSpec")) {
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
+
+  override protected def supportsReplayOnlyLast: CapabilityFlag = CapabilityFlag.on()
 }

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
@@ -9,7 +9,7 @@ import akka.persistence.PersistenceSpec
 import akka.persistence.journal.JournalSpec
 
 class InmemJournalSpec extends JournalSpec(config = PersistenceSpec.config("inmem", "InmemJournalSpec")) {
-  override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.off()
+  override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = false
 
-  override protected def supportsReplayOnlyLast: CapabilityFlag = CapabilityFlag.on()
+  override protected def supportsReplayOnlyLast: CapabilityFlag = true
 }

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/PersistenceTestKitJournalCompatSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/PersistenceTestKitJournalCompatSpec.scala
@@ -38,6 +38,8 @@ class PersistenceTestKitJournalCompatSpec extends JournalSpec(config = Persisten
 
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = true
   override protected def supportsMetadata: CapabilityFlag = true
+  override protected def supportsReplayOnlyLast: CapabilityFlag = true
+
 }
 
 class PersistenceTestKitSnapshotStoreCompatSpec

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplayLastSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplayLastSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2017-2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.annotation.nowarn
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.testkit.PersistenceTestKitPlugin
+import akka.persistence.testkit.PersistenceTestKitSnapshotPlugin
+import akka.persistence.typed.PersistenceId
+import akka.serialization.jackson.CborSerializable
+
+object EventSourcedBehaviorReplayLastSpec extends Matchers {
+
+  sealed trait Command extends CborSerializable
+  final case class Increment(id: String) extends Command
+  final case class GetValue(replyTo: ActorRef[State]) extends Command
+
+  sealed trait Event extends CborSerializable
+  final case class Incremented(id: String) extends Event
+
+  final case class State(value: Int, history: Vector[String]) extends CborSerializable
+
+  def counter(
+      @nowarn("msg=never used") ctx: ActorContext[Command],
+      persistenceId: PersistenceId,
+      probe: Option[ActorRef[(State, Event)]] = None): EventSourcedBehavior[Command, Event, State] = {
+    EventSourcedBehavior[Command, Event, State](
+      persistenceId,
+      emptyState = State(0, Vector.empty),
+      commandHandler = (state, cmd) =>
+        cmd match {
+          case Increment(id) =>
+            Effect.persist(Incremented(id))
+
+          case GetValue(replyTo) =>
+            replyTo ! state
+            Effect.none
+
+        },
+      eventHandler = (state, evt) =>
+        evt match {
+          case Incremented(id) =>
+            probe.foreach(_ ! ((state, evt)))
+            State(state.value + 1, state.history :+ id)
+        })
+  }.withRecovery(Recovery.replayOnlyLast)
+
+}
+
+class EventSourcedBehaviorReplayLastSpec
+    extends ScalaTestWithActorTestKit(
+      PersistenceTestKitPlugin.config.withFallback(PersistenceTestKitSnapshotPlugin.config))
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import EventSourcedBehaviorReplayLastSpec._
+
+  val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()}")
+
+  "EventSourcedBehavior with Recovery.replayOnlyLast" must {
+    "recover from last event only" in {
+      val pid = nextPid()
+      val c = spawn(Behaviors.setup[Command](ctx => counter(ctx, pid)))
+      val replyProbe = TestProbe[State]()
+
+      c ! Increment("a")
+      c ! Increment("b")
+      c ! Increment("c")
+      c ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(3, Vector("a", "b", "c")))
+      testKit.stop(c)
+      replyProbe.expectTerminated(c)
+
+      val probe = TestProbe[(State, Event)]()
+      val c2 = spawn(Behaviors.setup[Command](ctx => counter(ctx, pid, Some(probe.ref))))
+      // replayed the last event
+      probe.expectMessage((State(0, Vector.empty), Incremented("c")))
+      probe.expectNoMessage()
+
+      c2 ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(1, Vector("c")))
+
+      c2 ! Increment("d")
+      c2 ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(2, Vector("c", "d")))
+    }
+
+  }
+}

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
@@ -17,7 +17,6 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
-import akka.persistence.{ Recovery => ClassicRecovery }
 import akka.persistence.typed.NoOpEventAdapter
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
@@ -69,7 +68,7 @@ class EventSourcedBehaviorWatchSpec
       NoOpEventAdapter.instance[String],
       NoOpSnapshotAdapter.instance[String],
       snapshotWhen = SnapshotWhenPredicate.noSnapshot,
-      ClassicRecovery(),
+      Recovery.default,
       RetentionCriteria.disabled,
       holdingRecoveryPermit = false,
       settings = settings,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -6,19 +6,22 @@ package akka.persistence.typed.internal
 
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
+
 import org.slf4j.Logger
 import org.slf4j.MDC
+
 import akka.actor.{ ActorRef => ClassicActorRef }
 import akka.actor.Cancellable
 import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.InternalApi
-import akka.persistence._
+import akka.persistence.Persistence
 import akka.persistence.typed.EventAdapter
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.SnapshotAdapter
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.persistence.typed.scaladsl.Recovery
 import akka.persistence.typed.scaladsl.ReplicationInterceptor
 import akka.persistence.typed.scaladsl.RetentionCriteria
 import akka.persistence.typed.telemetry.EventSourcedBehaviorInstrumentation

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -22,7 +22,6 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation._
 import akka.persistence.JournalProtocol
-import akka.persistence.Recovery
 import akka.persistence.RecoveryPermitter
 import akka.persistence.SnapshotProtocol
 import akka.persistence.journal.Tagged
@@ -41,7 +40,6 @@ import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
 import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.scaladsl._
-import akka.persistence.typed.scaladsl.{ Recovery => TypedRecovery }
 import akka.persistence.typed.scaladsl.RetentionCriteria
 import akka.persistence.typed.telemetry.EventSourcedBehaviorInstrumentationProvider
 
@@ -97,7 +95,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     eventAdapter: EventAdapter[Event, Any] = NoOpEventAdapter.instance[Event],
     snapshotAdapter: SnapshotAdapter[State] = NoOpSnapshotAdapter.instance[State],
     snapshotWhen: SnapshotWhenPredicate[State, Event] = SnapshotWhenPredicate.noSnapshot[State, Event],
-    recovery: Recovery = Recovery(),
+    recovery: Recovery = Recovery.default,
     retention: RetentionCriteria = RetentionCriteria.disabled,
     supervisionStrategy: SupervisorStrategy = SupervisorStrategy.stop,
     override val signalHandler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty,
@@ -273,7 +271,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
   override def withSnapshotSelectionCriteria(
       selection: SnapshotSelectionCriteria): EventSourcedBehavior[Command, Event, State] = {
-    copy(recovery = Recovery(selection.toClassic))
+    copy(recovery = Recovery.withSnapshotSelectionCriteria(selection))
   }
 
   override def snapshotWhen(predicate: (State, Event, Long) => Boolean): EventSourcedBehavior[Command, Event, State] =
@@ -304,8 +302,8 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
       backoffStrategy: BackoffSupervisorStrategy): EventSourcedBehavior[Command, Event, State] =
     copy(supervisionStrategy = backoffStrategy)
 
-  override def withRecovery(recovery: TypedRecovery): EventSourcedBehavior[Command, Event, State] = {
-    copy(recovery = recovery.toClassic)
+  override def withRecovery(recovery: Recovery): EventSourcedBehavior[Command, Event, State] = {
+    copy(recovery = recovery)
   }
 
   override def withEventPublishing(enabled: Boolean): EventSourcedBehavior[Command, Event, State] = {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -120,7 +120,7 @@ private[akka] trait JournalInteractions[C, E, S] {
 
   protected def replayEvents(fromSeqNr: Long, toSeqNr: Long): Unit = {
     val from =
-      if (setup.recovery == Recovery.replayOnlyLast) {
+      if (setup.recovery == ReplayOnlyLastRecovery) {
         setup.internalLogger.debug("Recovery from last event only.")
         -1L
       } else {
@@ -129,7 +129,7 @@ private[akka] trait JournalInteractions[C, E, S] {
       }
 
     setup.journal.tell(
-      ReplayMessages(from, toSeqNr, setup.recovery.replayMax, setup.persistenceId.id, setup.selfClassic),
+      ReplayMessages(from, toSeqNr, setup.recovery.toClassic.replayMax, setup.persistenceId.id, setup.selfClassic),
       setup.selfClassic)
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RecoveryImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RecoveryImpl.scala
@@ -17,7 +17,7 @@ import akka.persistence.typed.{ javadsl, scaladsl, SnapshotSelectionCriteria }
   /**
    * INTERNAL API
    */
-  override private[akka] def toClassic = akka.persistence.Recovery()
+  override private[akka] def toClassic = akka.persistence.Recovery.default
 }
 
 /**
@@ -43,7 +43,8 @@ import akka.persistence.typed.{ javadsl, scaladsl, SnapshotSelectionCriteria }
   /**
    * INTERNAL API
    */
-  override private[akka] def toClassic = akka.persistence.Recovery.replayOnlyLast
+  override private[akka] val toClassic =
+    akka.persistence.Recovery(akka.persistence.SnapshotSelectionCriteria.None)
 }
 
 /**

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RecoveryImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RecoveryImpl.scala
@@ -36,6 +36,19 @@ import akka.persistence.typed.{ javadsl, scaladsl, SnapshotSelectionCriteria }
 /**
  * INTERNAL API
  */
+@InternalApi private[akka] case object ReplayOnlyLastRecovery extends javadsl.Recovery with scaladsl.Recovery {
+  override def asScala: scaladsl.Recovery = this
+  override def asJava: javadsl.Recovery = this
+
+  /**
+   * INTERNAL API
+   */
+  override private[akka] def toClassic = akka.persistence.Recovery.replayOnlyLast
+}
+
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] case class RecoveryWithSnapshotSelectionCriteria(
     snapshotSelectionCriteria: SnapshotSelectionCriteria)
     extends javadsl.Recovery

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -51,8 +51,6 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
     // protect against snapshot stalling forever because of journal overloaded and such
     setup.startRecoveryTimer(snapshot = true)
 
-    // FIXME we could bypass loadSnapshot when the snapshot criteria is none or replayOnlyLast
-    // For replayOnlyLast we must also use fromSequenceNr = -1 for the replay
     loadSnapshot(setup.recovery.fromSnapshot, setup.recovery.toSequenceNr)
 
     def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -51,7 +51,8 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
     // protect against snapshot stalling forever because of journal overloaded and such
     setup.startRecoveryTimer(snapshot = true)
 
-    loadSnapshot(setup.recovery.fromSnapshot, setup.recovery.toSequenceNr)
+    val classicRecovery = setup.recovery.toClassic
+    loadSnapshot(classicRecovery.fromSnapshot, classicRecovery.toSequenceNr)
 
     def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
       Behaviors
@@ -192,7 +193,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
             "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true",
             setup.persistenceId)
 
-          loadSnapshotResult(snapshot = None, setup.recovery.toSequenceNr)
+          loadSnapshotResult(snapshot = None, setup.recovery.toClassic.toSequenceNr)
         } else {
           onRecoveryFailure(cause)
         }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -51,6 +51,8 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
     // protect against snapshot stalling forever because of journal overloaded and such
     setup.startRecoveryTimer(snapshot = true)
 
+    // FIXME we could bypass loadSnapshot when the snapshot criteria is none or replayOnlyLast
+    // For replayOnlyLast we must also use fromSequenceNr = -1 for the replay
     loadSnapshot(setup.recovery.fromSnapshot, setup.recovery.toSequenceNr)
 
     def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
@@ -7,7 +7,7 @@ package akka.persistence.typed.javadsl
 import akka.annotation.InternalApi
 import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.internal.ReplayOnlyLastRecovery
-import akka.persistence.typed.internal.{DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria}
+import akka.persistence.typed.internal.{ DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria }
 import akka.persistence.typed.scaladsl.Recovery
 
 /**

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
@@ -6,7 +6,9 @@ package akka.persistence.typed.javadsl
 
 import akka.annotation.InternalApi
 import akka.persistence.typed.SnapshotSelectionCriteria
-import akka.persistence.typed.internal.{ DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria }
+import akka.persistence.typed.internal.ReplayOnlyLastRecovery
+import akka.persistence.typed.internal.{DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria}
+import akka.persistence.typed.scaladsl.Recovery
 
 /**
  * Strategy for recovery of snapshots and events.
@@ -46,5 +48,10 @@ object Recovery {
    */
   def withSnapshotSelectionCriteria(snapshotSelectionCriteria: SnapshotSelectionCriteria) =
     RecoveryWithSnapshotSelectionCriteria(snapshotSelectionCriteria)
+
+  /**
+   * Don't load snapshot and replay only last event.
+   */
+  val replayOnlyLast: Recovery = ReplayOnlyLastRecovery
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Recovery.scala
@@ -8,7 +8,6 @@ import akka.annotation.InternalApi
 import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.internal.ReplayOnlyLastRecovery
 import akka.persistence.typed.internal.{ DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria }
-import akka.persistence.typed.scaladsl.Recovery
 
 /**
  * Strategy for recovery of snapshots and events.

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Recovery.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Recovery.scala
@@ -7,7 +7,7 @@ package akka.persistence.typed.scaladsl
 import akka.annotation.InternalApi
 import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.internal.ReplayOnlyLastRecovery
-import akka.persistence.typed.internal.{DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria}
+import akka.persistence.typed.internal.{ DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria }
 
 /**
  * Strategy for recovery of snapshots and events.

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Recovery.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Recovery.scala
@@ -6,7 +6,8 @@ package akka.persistence.typed.scaladsl
 
 import akka.annotation.InternalApi
 import akka.persistence.typed.SnapshotSelectionCriteria
-import akka.persistence.typed.internal.{ DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria }
+import akka.persistence.typed.internal.ReplayOnlyLastRecovery
+import akka.persistence.typed.internal.{DefaultRecovery, DisabledRecovery, RecoveryWithSnapshotSelectionCriteria}
 
 /**
  * Strategy for recovery of snapshots and events.
@@ -47,5 +48,10 @@ object Recovery {
    */
   def withSnapshotSelectionCriteria(snapshotSelectionCriteria: SnapshotSelectionCriteria) =
     RecoveryWithSnapshotSelectionCriteria(snapshotSelectionCriteria)
+
+  /**
+   * Don't load snapshot and replay only last event.
+   */
+  val replayOnlyLast: Recovery = ReplayOnlyLastRecovery
 
 }

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -420,6 +420,13 @@ public class BasicPersistentBehaviorTest {
       }
       // #custom-stash-buffer
 
+      // #replay-last
+      @Override
+      public Recovery recovery() {
+        return Recovery.replayOnlyLast();
+      }
+      // #replay-last
+
       // #wrapPersistentBehavior
       @Override
       public boolean shouldSnapshot(State state, Event event, long sequenceNr) {

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -133,6 +133,18 @@ object BasicPersistentBehaviorCompileOnly {
     //#recovery-disabled
   }
 
+  object ReplayLastBehavior {
+    def apply(): Behavior[Command] =
+      //#replay-last
+      EventSourcedBehavior[Command, Event, State](
+        persistenceId = PersistenceId.ofUniqueId("abc"),
+        emptyState = State(),
+        commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
+        eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
+        .withRecovery(Recovery.replayOnlyLast)
+    //#replay-last
+  }
+
   object TaggingBehavior {
     def apply(): Behavior[Command] =
       //#tagging

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -101,6 +101,12 @@ object Recovery {
    */
   val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
 
+  /**
+   * Don't load snapshot and replay only last event.
+   */
+  val replayOnlyLast: Recovery =
+    Recovery(fromSnapshot = SnapshotSelectionCriteria.NoSnapshotAndReplayOnlyLast)
+
 }
 
 final class RecoveryTimedOut(message: String) extends RuntimeException(message) with NoStackTrace

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -56,11 +56,24 @@ final case class Recovery(
 
 object Recovery {
 
+  val default: Recovery = Recovery()
+
+  /**
+   * Convenience method for skipping recovery in [[PersistentActor]].
+   *
+   * It will still retrieve previously highest sequence number so that new events are persisted with
+   * higher sequence numbers rather than starting from 1 and assuming that there are no
+   * previous event with that sequence number.
+   *
+   * @see [[Recovery]]
+   */
+  val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
+
   /**
    * Java API
    * @see [[Recovery]]
    */
-  def create() = Recovery()
+  def create() = default
 
   /**
    * Java API
@@ -89,23 +102,6 @@ object Recovery {
    */
   def create(fromSnapshot: SnapshotSelectionCriteria, toSequenceNr: Long, replayMax: Long) =
     Recovery(fromSnapshot, toSequenceNr, replayMax)
-
-  /**
-   * Convenience method for skipping recovery in [[PersistentActor]].
-   *
-   * It will still retrieve previously highest sequence number so that new events are persisted with
-   * higher sequence numbers rather than starting from 1 and assuming that there are no
-   * previous event with that sequence number.
-   *
-   * @see [[Recovery]]
-   */
-  val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
-
-  /**
-   * Don't load snapshot and replay only last event.
-   */
-  val replayOnlyLast: Recovery =
-    Recovery(fromSnapshot = SnapshotSelectionCriteria.NoSnapshotAndReplayOnlyLast)
 
 }
 

--- a/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
@@ -5,8 +5,6 @@
 package akka.persistence
 import scala.runtime.AbstractFunction3
 
-import akka.annotation.InternalApi
-
 /**
  * Snapshot metadata.
  *
@@ -218,14 +216,6 @@ object SnapshotSelectionCriteria {
    */
   def none() = None
 
-  /**
-   * INTERNAL API: No saved snapshot matches and the replay will start from last event, i.e.
-   * recovery is based on only the last event.
-   *
-   * Doesn't need to be public because it is used via `Recovery.replayOnlyLast`.
-   */
-  @InternalApi private[akka] val NoSnapshotAndReplayOnlyLast =
-    SnapshotSelectionCriteria(minSequenceNr = -1, maxSequenceNr = 0L, maxTimestamp = 0L)
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
@@ -5,6 +5,8 @@
 package akka.persistence
 import scala.runtime.AbstractFunction3
 
+import akka.annotation.InternalApi
+
 /**
  * Snapshot metadata.
  *
@@ -195,12 +197,6 @@ object SnapshotSelectionCriteria {
   val None = SnapshotSelectionCriteria(maxSequenceNr = 0L, maxTimestamp = 0L)
 
   /**
-   * No saved snapshot matches and the replay will start from last event, i.e.
-   * recovery is based on only the last event.
-   */
-  val NoSnapshotAndReplayOnlyLast = SnapshotSelectionCriteria(minSequenceNr = -1, maxSequenceNr = 0L, maxTimestamp = 0L)
-
-  /**
    * Java API.
    */
   def create(maxSequenceNr: Long, maxTimestamp: Long) =
@@ -223,9 +219,13 @@ object SnapshotSelectionCriteria {
   def none() = None
 
   /**
-   * Java API.
+   * INTERNAL API: No saved snapshot matches and the replay will start from last event, i.e.
+   * recovery is based on only the last event.
+   *
+   * Doesn't need to be public because it is used via `Recovery.replayOnlyLast`.
    */
-  def noSnapshotAndReplayOnlyLast = NoSnapshotAndReplayOnlyLast
+  @InternalApi private[akka] val NoSnapshotAndReplayOnlyLast =
+    SnapshotSelectionCriteria(minSequenceNr = -1, maxSequenceNr = 0L, maxTimestamp = 0L)
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala
@@ -192,7 +192,13 @@ object SnapshotSelectionCriteria {
   /**
    * No saved snapshot matches.
    */
-  val None = SnapshotSelectionCriteria(0L, 0L)
+  val None = SnapshotSelectionCriteria(maxSequenceNr = 0L, maxTimestamp = 0L)
+
+  /**
+   * No saved snapshot matches and the replay will start from last event, i.e.
+   * recovery is based on only the last event.
+   */
+  val NoSnapshotAndReplayOnlyLast = SnapshotSelectionCriteria(minSequenceNr = -1, maxSequenceNr = 0L, maxTimestamp = 0L)
 
   /**
    * Java API.
@@ -215,6 +221,11 @@ object SnapshotSelectionCriteria {
    * Java API.
    */
   def none() = None
+
+  /**
+   * Java API.
+   */
+  def noSnapshotAndReplayOnlyLast = NoSnapshotAndReplayOnlyLast
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncRecovery.scala
@@ -29,6 +29,9 @@ trait AsyncRecovery {
    * This does imply that this call is always preceded by reading the highest sequence
    * number for the given `persistenceId`.
    *
+   * A special case is `fromSequenceNr` of -1, which means that only the last message if any
+   * should be replayed.
+   *
    * This call is NOT protected with a circuit-breaker because it may take long time
    * to replay all events. The plugin implementation itself must protect against
    * an unresponsive backend store and make sure that the returned Future is
@@ -41,7 +44,6 @@ trait AsyncRecovery {
    * @param max maximum number of messages to be replayed.
    * @param recoveryCallback called to replay a single message. Can be called from any
    *                       thread.
-   *
    * @see [[AsyncWriteJournal]]
    */
   def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
@@ -97,6 +99,9 @@ trait AsyncReplay {
    * returned highest sequence number must still be the highest of all stored messages. In this case
    * the implementation would typically have to read the actual highest sequence number but can skip
    * replay of messages.
+   *
+   * Another special case is `fromSequenceNr` of -1, which means that only the last message if any
+   * should be replayed.
    *
    * This call is NOT protected with a circuit-breaker because it may take long time
    * to replay all events. The plugin implementation itself must protect against


### PR DESCRIPTION
* Introduced in a compatible way so that it still works if used with a plugin that doesn't implement this. In that case the snapshot will still not be loaded but all events will be replayed instead of only the last.

- [x] I'll add some more tests