### PR TITLE
Doc: update video link in replicated event sourcing

### DIFF
--- a/akka-docs/src/main/paradox/typed/replicated-eventsourcing.md
+++ b/akka-docs/src/main/paradox/typed/replicated-eventsourcing.md
@@ -32,8 +32,8 @@ to handle this.
 
 To be able to use Replicated Event Sourcing the journal and snapshot store used is required to have specific support for the metadata that the replication needs (see @ref[Journal Support](#journal-support)).
 
-The [Replicated Event Sourcing video](https://akka.io/blog/news/2020/09/09/replicated-event-sourcing-video)
-is a good starting point describing the use cases and motivation for when to use Replicated Event Sourcing. The second part, [Replicated Event Sourcing data modelling](https://akka.io/blog/news/2020/10/22/replicated-event-sourcing-data-modelling) guides you to find a suitable model for your use-case.
+The [Replicated Event Sourcing video](https://www.youtube.com/watch?v=SuTPY5MxmUM)
+is a good starting point describing the use cases and motivation for when to use Replicated Event Sourcing. The second part, [Replicated Event Sourcing data modelling](https://www.youtube.com/watch?v=8PnJxTlOP6o) guides you to find a suitable model for your use-case.
 
 ## Relaxing the single-writer principle for availability
 


### PR DESCRIPTION
Hi 👋 I found two broken links in the documentation. The blog news are no longer reachable.

As an alternative, I found the following videos which **I think** are the ones that were contained in the blog's posts. 
Please double-check.

-  Akka Replicated Event Sourcing: https://www.youtube.com/watch?v=SuTPY5MxmUM
-  Data modelling for Replicated Event Sourcing : https://www.youtube.com/watch?v=8PnJxTlOP6o
