### PR TITLE
fix: improve TCP DNS client interactions with TCP actor

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
@@ -8,6 +8,7 @@ import java.net.InetSocketAddress
 
 import scala.collection.immutable.Seq
 
+import akka.actor.ActorRef
 import akka.actor.Props
 import akka.io.Tcp
 import akka.io.Tcp.{ Connected, PeerClosed, Register }
@@ -72,6 +73,26 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       answerProbe.expectMsg(Answer(42, Nil))
     }
 
+    "respect backpressure from the TCP actor" in {
+      val tcpExtensionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      client ! exampleRequestMessage
+      client ! exampleRequestMessage.copy(id = 43)
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      val ack = expectMsgType[Tcp.Write].ack
+      expectNoMessage()
+      registered ! ack
+
+      expectMsgType[Tcp.Write]
+    }
+
     "accept merged TCP responses" in {
       val tcpExtensionProbe = TestProbe()
       val answerProbe = TestProbe()
@@ -86,8 +107,12 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       expectMsgType[Register]
       val registered = tcpExtensionProbe.lastSender
 
-      expectMsgType[Tcp.Write]
-      expectMsgType[Tcp.Write]
+      var ack = expectMsgType[Tcp.Write].ack
+
+      registered ! ack
+
+      ack = expectMsgType[Tcp.Write].ack
+
       val fullResponse =
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.write() ++
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.copy(id = 43).write()
@@ -96,6 +121,71 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
 
       answerProbe.expectMsg(Answer(42, Nil))
       answerProbe.expectMsg(Answer(43, Nil))
+    }
+
+    "report its failure to the outer client" in {
+      val tcpExtensionProbe = TestProbe()
+      val answerProbe = TestProbe()
+
+      val failToConnectClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      failToConnectClient ! exampleRequestMessage
+
+      val connect = tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+
+      failToConnectClient ! Tcp.CommandFailed(connect)
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+
+      val closesWithErrorClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      closesWithErrorClient ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(connect)
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      registered ! Tcp.ErrorClosed("BOOM!")
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+    }
+
+    "should resort to dropping older requests in response to sufficient backpressure" in {
+      val tcpExtensionProbe = TestProbe()
+      val connectionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      client ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender.tell(Connected(dnsServerAddress, localAddress), connectionProbe.ref)
+      connectionProbe.expectMsgType[Register]
+      val registered = connectionProbe.lastSender
+
+      var write = connectionProbe.expectMsgType[Tcp.Write]
+      write.data.drop(2) shouldBe (exampleRequestMessage.write())
+
+      // Send 20 requests before the ack...
+      // - first 11 get added without dropping (buffer is 1 - 11)
+      // - drop #1 to make room for #12 (buffer is 2 - 12)
+      // - expand for #13 (buffer is 2 - 13)
+      // - drop #2 and #3 to make room for #14 and #15 (buffer is 4 - 15)
+      // - expand for #16 (buffer is 4 - 16)
+      // - drop #4, #5, and #6 to make room for #17, #18, #19 (buffer is 7 - 19)
+      // - expand for #20 (buffer is 7 - 20)
+      (1 to 20).foreach { i =>
+        client ! exampleRequestMessage.copy(id = (exampleRequestMessage.id + i).toShort)
+      }
+
+      (7 to 20).foreach { i =>
+        registered ! write.ack
+        write = connectionProbe.expectMsgType[Tcp.Write]
+        write.data.drop(2) shouldBe (exampleRequestMessage.copy(id = (exampleRequestMessage.id + i).toShort).write())
+      }
     }
   }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -54,6 +54,7 @@ import scala.collection.mutable
     case Ack          => writer = writer.ack()
 
     case failure: Tcp.CommandFailed =>
+      writer.connection ! Tcp.Abort
       throwFailure("TCP command failed", failure.cause)
 
     case Tcp.Received(newData) =>

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -12,6 +12,9 @@ import akka.annotation.InternalApi
 import akka.io.Tcp
 import akka.io.dns.internal.DnsClient.Answer
 import akka.util.ByteString
+import akka.event.LoggingAdapter
+
+import scala.collection.mutable
 
 /**
  * INTERNAL API
@@ -38,32 +41,34 @@ import akka.util.ByteString
     case _: Tcp.Connected =>
       log.debug("Connected to TCP address [{}]", ns)
       val connection = sender()
-      context.become(ready(connection))
+      writer = new Writing(connection, log)
+      context.become(ready())
       connection ! Tcp.Register(self)
       unstashAll()
     case _: Message =>
       stash()
   }
 
-  def ready(connection: ActorRef, buffer: ByteString = ByteString.empty): Receive = {
-    case msg: Message =>
-      val bytes = msg.write()
-      connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes)
-    case failure @ Tcp.CommandFailed(_: Tcp.Write) =>
-      throwFailure("Write failed", failure.cause)
+  def ready(buffer: ByteString = ByteString.empty): Receive = {
+    case msg: Message => writer = writer.maybeWriteMessage(msg)
+    case Ack          => writer = writer.ack()
+
+    case failure: Tcp.CommandFailed =>
+      throwFailure("TCP command failed", failure.cause)
+
     case Tcp.Received(newData) =>
       val data = buffer ++ newData
       // TCP DNS responses are prefixed by 2 bytes encoding the length of the response
       val prefixSize = 2
       if (data.length < prefixSize)
-        context.become(ready(connection, data))
+        context.become(ready(data))
       else {
         val expectedPayloadLength = decodeLength(data)
         if (data.drop(prefixSize).length < expectedPayloadLength)
-          context.become(ready(connection, data))
+          context.become(ready(data))
         else {
           answerRecipient ! parseResponse(data.drop(prefixSize))
-          context.become(ready(connection, ByteString.empty))
+          context.become(ready(ByteString.empty))
           if (data.length > prefixSize + expectedPayloadLength) {
             self ! Tcp.Received(data.drop(prefixSize + expectedPayloadLength))
           }
@@ -71,7 +76,13 @@ import akka.util.ByteString
       }
     case Tcp.PeerClosed =>
       context.become(idle)
+
+    case Tcp.ErrorClosed(cause) =>
+      throwFailure(s"Connection closed with error $cause", None)
+
   }
+
+  private var writer: Writer = _
 
   private def parseResponse(data: ByteString) = {
     val msg = Message.parse(data)
@@ -83,6 +94,9 @@ import akka.util.ByteString
       if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (Nil, Nil)
     Answer(msg.id, recs, additionalRecs)
   }
+
+  private def throwFailure(message: String, cause: Option[Throwable]): Nothing =
+    TcpDnsClient.throwFailure(message, cause, log, answerRecipient)
 }
 private[internal] object TcpDnsClient {
   def encodeLength(length: Int): ByteString =
@@ -91,11 +105,72 @@ private[internal] object TcpDnsClient {
   def decodeLength(data: ByteString): Int =
     ((data(0).toInt + 256) % 256) * 256 + ((data(1) + 256) % 256)
 
-  def throwFailure(message: String, cause: Option[Throwable]): Unit =
+  def throwFailure(message: String, cause: Option[Throwable], log: LoggingAdapter, reportTo: ActorRef): Nothing = {
     cause match {
       case None =>
+        log.warning("TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message)
+
       case Some(throwable) =>
+        log.warning(throwable, "TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message, throwable)
     }
+  }
+
+  abstract class Writer(val connection: ActorRef, val log: LoggingAdapter) {
+    def maybeWriteMessage(msg: Message): Writer
+    def ack(): Writer
+
+    protected def writeMessage(msg: Message): Unit = {
+      val bytes = msg.write()
+      connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes, Ack)
+    }
+  }
+
+  class Writing(connection: ActorRef, log: LoggingAdapter) extends Writer(connection, log) {
+    def maybeWriteMessage(msg: Message): Writer = {
+      writeMessage(msg)
+
+      new Buffering(connection, log)
+    }
+
+    def ack(): Writer = {
+      log.warning("Unexpected Ack in TCP DNS client")
+      this
+    }
+  }
+
+  class Buffering(connection: ActorRef, log: LoggingAdapter) extends Writer(connection, log) {
+    def maybeWriteMessage(msg: Message): Writer = {
+      buffer.enqueue(msg)
+
+      if (buffer.size < 11) {
+        // do nothing, just the above enqueue
+      } else if (toDrop < 1) {
+        toDrop = buffer.size - 10
+      } else {
+        log.info("Dropping DNS request [{}] due to TCP backpressure", buffer.dequeue())
+        toDrop -= 1
+      }
+
+      this
+    }
+
+    def ack(): Writer =
+      if (buffer.isEmpty) new Writing(connection, log)
+      else {
+        writeMessage(buffer.dequeue())
+        if (toDrop > 0) {
+          toDrop -= 1
+        }
+        this
+      }
+
+    private val buffer = mutable.Queue.empty[Message]
+    private var toDrop: Int = 0
+  }
+
+  case object Ack extends Tcp.Event
 }


### PR DESCRIPTION
The TCP DNS client responds to a backpressure signal (a `CommandFailed(Write(...))`) from the TCP connection actor by shutting itself down (which is, in its own way a form of backpressure), but means that two requests requiring TCP in fast enough succession (the second arriving before the connection actor has been able to hand the data off to the socket) will cause the DNS client to stop before it can receive a response to the first.  DNS resolutions (e.g. through Discovery) will typically retry after some time, but if there are two retries being resolved that failed sufficiently close to each other the scheduler resolution (default 10 millis) will tend to mean that they retry at effectively the same time: it's thus unlikely that this retry loop will ever be broken.

This change implements ack-based throttling, it will not issue a subsequent TCP write until the connection actor has written the data to the socket and sent back an ack (this does not require any response from the other end, to be clear).  Since there typically should not be _that_ many in-flight DNS resolutions happening (the main use is for service discovery), the impact on applications should be minimal.

Also improves the logging within the TCP DNS client.