### PR TITLE
fix: Multiple potential issues with the tcp DNS client

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
@@ -6,17 +6,17 @@ package akka.io.dns.internal
 
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-
 import akka.actor.Props
 import akka.io.Udp
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.{ Answer, Question4 }
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 
-class DnsClientSpec extends AkkaSpec with ImplicitSender {
+class DnsClientSpec extends AkkaSpec("""akka.loglevel = DEBUG
+      akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]""") with ImplicitSender with WithLogCapturing {
   "The async DNS client" should {
     val exampleRequest = Question4(42, "akka.io")
     val exampleRequestMessage =

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
@@ -8,6 +8,7 @@ import java.net.InetSocketAddress
 
 import scala.collection.immutable.Seq
 
+import akka.actor.ActorRef
 import akka.actor.Props
 import akka.io.Tcp
 import akka.io.Tcp.{ Connected, PeerClosed, Register }
@@ -72,6 +73,26 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       answerProbe.expectMsg(Answer(42, Nil))
     }
 
+    "respect backpressure from the TCP actor" in {
+      val tcpExtensionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      client ! exampleRequestMessage
+      client ! exampleRequestMessage.copy(id = 43)
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      val ack = expectMsgType[Tcp.Write].ack
+      expectNoMessage()
+      registered ! ack
+
+      expectMsgType[Tcp.Write]
+    }
+
     "accept merged TCP responses" in {
       val tcpExtensionProbe = TestProbe()
       val answerProbe = TestProbe()
@@ -86,8 +107,12 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       expectMsgType[Register]
       val registered = tcpExtensionProbe.lastSender
 
-      expectMsgType[Tcp.Write]
-      expectMsgType[Tcp.Write]
+      var ack = expectMsgType[Tcp.Write].ack
+
+      registered ! ack
+
+      ack = expectMsgType[Tcp.Write].ack
+
       val fullResponse =
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.write() ++
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.copy(id = 43).write()
@@ -96,6 +121,71 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
 
       answerProbe.expectMsg(Answer(42, Nil))
       answerProbe.expectMsg(Answer(43, Nil))
+    }
+
+    "report its failure to the outer client" in {
+      val tcpExtensionProbe = TestProbe()
+      val answerProbe = TestProbe()
+
+      val failToConnectClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      failToConnectClient ! exampleRequestMessage
+
+      val connect = tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+
+      failToConnectClient ! Tcp.CommandFailed(connect)
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+
+      val closesWithErrorClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      closesWithErrorClient ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(connect)
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      registered ! Tcp.ErrorClosed("BOOM!")
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+    }
+
+    "should resort to dropping older requests in response to sufficient backpressure" in {
+      val tcpExtensionProbe = TestProbe()
+      val connectionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      client ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender.tell(Connected(dnsServerAddress, localAddress), connectionProbe.ref)
+      connectionProbe.expectMsgType[Register]
+      val registered = connectionProbe.lastSender
+
+      var write = connectionProbe.expectMsgType[Tcp.Write]
+      write.data.drop(2) shouldBe (exampleRequestMessage.write())
+
+      // Send 20 requests before the ack...
+      // - first 11 get added without dropping (buffer is 1 - 11)
+      // - drop #1 to make room for #12 (buffer is 2 - 12)
+      // - expand for #13 (buffer is 2 - 13)
+      // - drop #2 and #3 to make room for #14 and #15 (buffer is 4 - 15)
+      // - expand for #16 (buffer is 4 - 16)
+      // - drop #4, #5, and #6 to make room for #17, #18, #19 (buffer is 7 - 19)
+      // - expand for #20 (buffer is 7 - 20)
+      (1 to 20).foreach { i =>
+        client ! exampleRequestMessage.copy(id = (exampleRequestMessage.id + i).toShort)
+      }
+
+      (7 to 20).foreach { i =>
+        registered ! write.ack
+        write = connectionProbe.expectMsgType[Tcp.Write]
+        write.data.drop(2) shouldBe (exampleRequestMessage.copy(id = (exampleRequestMessage.id + i).toShort).write())
+      }
     }
   }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -189,7 +189,7 @@ import akka.pattern.{ BackoffOpts, BackoffSupervisor }
         inflightRequests.get(msg.id) match {
           case Some(inFlight) =>
             inflightRequests = inflightRequests.updated(msg.id, inFlight.copy(tcpRequest = true))
-            tcpDnsClient ! msg
+            tcpDnsClient ! inFlight.message
 
           case _ =>
             log.debug("Client for id {} not found. Discarding unsuccessful response.", msg.id)

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -54,6 +54,7 @@ import scala.collection.mutable
     case Ack          => writer = writer.ack()
 
     case failure: Tcp.CommandFailed =>
+      writer.connection ! Tcp.Abort
       throwFailure("TCP command failed", failure.cause)
 
     case Tcp.Received(newData) =>

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -12,6 +12,9 @@ import akka.annotation.InternalApi
 import akka.io.Tcp
 import akka.io.dns.internal.DnsClient.Answer
 import akka.util.ByteString
+import akka.event.LoggingAdapter
+
+import scala.collection.mutable
 
 /**
  * INTERNAL API
@@ -38,32 +41,34 @@ import akka.util.ByteString
     case _: Tcp.Connected =>
       log.debug("Connected to TCP address [{}]", ns)
       val connection = sender()
-      context.become(ready(connection))
+      writer = new Writing(connection, log)
+      context.become(ready())
       connection ! Tcp.Register(self)
       unstashAll()
     case _: Message =>
       stash()
   }
 
-  def ready(connection: ActorRef, buffer: ByteString = ByteString.empty): Receive = {
-    case msg: Message =>
-      val bytes = msg.write()
-      connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes)
-    case failure @ Tcp.CommandFailed(_: Tcp.Write) =>
-      throwFailure("Write failed", failure.cause)
+  def ready(buffer: ByteString = ByteString.empty): Receive = {
+    case msg: Message => writer = writer.maybeWriteMessage(msg)
+    case Ack          => writer = writer.ack()
+
+    case failure: Tcp.CommandFailed =>
+      throwFailure("TCP command failed", failure.cause)
+
     case Tcp.Received(newData) =>
       val data = buffer ++ newData
       // TCP DNS responses are prefixed by 2 bytes encoding the length of the response
       val prefixSize = 2
       if (data.length < prefixSize)
-        context.become(ready(connection, data))
+        context.become(ready(data))
       else {
         val expectedPayloadLength = decodeLength(data)
         if (data.drop(prefixSize).length < expectedPayloadLength)
-          context.become(ready(connection, data))
+          context.become(ready(data))
         else {
           answerRecipient ! parseResponse(data.drop(prefixSize))
-          context.become(ready(connection, ByteString.empty))
+          context.become(ready(ByteString.empty))
           if (data.length > prefixSize + expectedPayloadLength) {
             self ! Tcp.Received(data.drop(prefixSize + expectedPayloadLength))
           }
@@ -71,7 +76,13 @@ import akka.util.ByteString
       }
     case Tcp.PeerClosed =>
       context.become(idle)
+
+    case Tcp.ErrorClosed(cause) =>
+      throwFailure(s"Connection closed with error $cause", None)
+
   }
+
+  private var writer: Writer = _
 
   private def parseResponse(data: ByteString) = {
     val msg = Message.parse(data)
@@ -83,6 +94,9 @@ import akka.util.ByteString
       if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (Nil, Nil)
     Answer(msg.id, recs, additionalRecs)
   }
+
+  private def throwFailure(message: String, cause: Option[Throwable]): Nothing =
+    TcpDnsClient.throwFailure(message, cause, log, answerRecipient)
 }
 private[internal] object TcpDnsClient {
   def encodeLength(length: Int): ByteString =
@@ -91,11 +105,72 @@ private[internal] object TcpDnsClient {
   def decodeLength(data: ByteString): Int =
     ((data(0).toInt + 256) % 256) * 256 + ((data(1) + 256) % 256)
 
-  def throwFailure(message: String, cause: Option[Throwable]): Unit =
+  def throwFailure(message: String, cause: Option[Throwable], log: LoggingAdapter, reportTo: ActorRef): Nothing = {
     cause match {
       case None =>
+        log.warning("TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message)
+
       case Some(throwable) =>
+        log.warning(throwable, "TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message, throwable)
     }
+  }
+
+  abstract class Writer(val connection: ActorRef, val log: LoggingAdapter) {
+    def maybeWriteMessage(msg: Message): Writer
+    def ack(): Writer
+
+    protected def writeMessage(msg: Message): Unit = {
+      val bytes = msg.write()
+      connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes, Ack)
+    }
+  }
+
+  class Writing(connection: ActorRef, log: LoggingAdapter) extends Writer(connection, log) {
+    def maybeWriteMessage(msg: Message): Writer = {
+      writeMessage(msg)
+
+      new Buffering(connection, log)
+    }
+
+    def ack(): Writer = {
+      log.warning("Unexpected Ack in TCP DNS client")
+      this
+    }
+  }
+
+  class Buffering(connection: ActorRef, log: LoggingAdapter) extends Writer(connection, log) {
+    def maybeWriteMessage(msg: Message): Writer = {
+      buffer.enqueue(msg)
+
+      if (buffer.size < 11) {
+        // do nothing, just the above enqueue
+      } else if (toDrop < 1) {
+        toDrop = buffer.size - 10
+      } else {
+        log.info("Dropping DNS request [{}] due to TCP backpressure", buffer.dequeue())
+        toDrop -= 1
+      }
+
+      this
+    }
+
+    def ack(): Writer =
+      if (buffer.isEmpty) new Writing(connection, log)
+      else {
+        writeMessage(buffer.dequeue())
+        if (toDrop > 0) {
+          toDrop -= 1
+        }
+        this
+      }
+
+    private val buffer = mutable.Queue.empty[Message]
+    private var toDrop: Int = 0
+  }
+
+  case object Ack extends Tcp.Event
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -92,6 +92,8 @@ import akka.event.LoggingAdapter
     case Tcp.PeerClosed =>
       if (requestBuffer.nonEmpty) {
         log.warning("Connection closed, dropping {} buffered requests)", requestBuffer.size)
+        // gracefully handled but we are still dropping requests
+        answerRecipient ! DnsClient.TcpDropped
       }
       context.unwatch(connection)
       context.become(idle)


### PR DESCRIPTION
 * Actually handle backpressure from TCP actor
 * Handle that multiple responses may arrive in partial form
 * Always terminate if connection actor terminates unexpectedly

Continuation of #32635 
