### PR TITLE
build: avoid sbt deprecation warning for ValidatePullRequest imports

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -4,8 +4,8 @@
 
 package akka
 
-import com.hpe.sbt.ValidatePullRequest
-import com.hpe.sbt.ValidatePullRequest.PathGlobFilter
+import com.github.sbt.pullrequestvalidator.ValidatePullRequest
+import com.github.sbt.pullrequestvalidator.ValidatePullRequest.PathGlobFilter
 import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport.paradox
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaReportBinaryIssues


### PR DESCRIPTION
Before this change, I see the following warnings when starting `sbt`:

```
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:26:27: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]   override def requires = ValidatePullRequest
[warn]                           ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:42:5: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     validatePullRequest / includeFilter := PathGlobFilter("akka-*/**"),
[warn]     ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:42:44: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     validatePullRequest / includeFilter := PathGlobFilter("akka-*/**"),
[warn]                                            ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:43:5: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     validatePullRequestBuildAll / excludeFilter := PathGlobFilter("project/MiMa.scala"),
[warn]     ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:43:52: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     validatePullRequestBuildAll / excludeFilter := PathGlobFilter("project/MiMa.scala"),
[warn]                                                    ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:44:5: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     prValidatorGithubRepository := Some("akka/akka"),
[warn]     ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:45:5: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]     prValidatorTargetBranch := "origin/main")
[warn]     ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:56:7: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]       prValidatorTasks := Seq(ValidatePR / test) ++ additionalTasks.value,
[warn]       ^
[warn] /Users/alf/dev/sebastian-alfers/akka/project/ValidatePullRequest.scala:57:7: value ValidatePullRequest in package sbt is deprecated (since 2.0.0): com.github.sbt.pullrequestvalidator.ValidatePullRequest
[warn]       prValidatorEnforcedBuildAllTasks := Seq(Test / test) ++ additionalTasks.value)
[warn]       ^
[warn] one feature warning; re-run with -feature for details
[warn] 10 warnings found
```