### PR TITLE
[backport 2.9] fix: Multiple potential issues with the tcp DNS client (#32636)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
@@ -6,17 +6,17 @@ package akka.io.dns.internal
 
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-
 import akka.actor.Props
 import akka.io.Udp
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.{ Answer, Question4 }
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 
-class DnsClientSpec extends AkkaSpec with ImplicitSender {
+class DnsClientSpec extends AkkaSpec("""akka.loglevel = DEBUG
+      akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]""") with ImplicitSender with WithLogCapturing {
   "The async DNS client" should {
     val exampleRequest = Question4(42, "akka.io")
     val exampleRequestMessage =

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
@@ -5,17 +5,19 @@
 package akka.io.dns.internal
 
 import java.net.InetSocketAddress
-
-import scala.collection.immutable.Seq
-
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.io.Tcp
 import akka.io.Tcp.{ Connected, PeerClosed, Register }
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.Answer
+import akka.testkit.EventFilter
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 
-class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
+class TcpDnsClientSpec extends AkkaSpec("""akka.loglevel = DEBUG
+      akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]""") with ImplicitSender with WithLogCapturing {
   import TcpDnsClient._
 
   "The async TCP DNS client" should {
@@ -51,6 +53,27 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
     }
 
+    "terminated if the connection terminates unexpectedly" in {
+      val tcpExtensionProbe = TestProbe()
+      val answerProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      client ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      expectMsgType[Tcp.Write]
+
+      answerProbe.watch(client)
+
+      registered ! PoisonPill
+      answerProbe.expectTerminated(client)
+    }
+
     "accept a fragmented TCP response" in {
       val tcpExtensionProbe = TestProbe()
       val answerProbe = TestProbe()
@@ -72,6 +95,60 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       answerProbe.expectMsg(Answer(42, Nil))
     }
 
+    "accept multiple fragmented TCP responses" in {
+      val tcpExtensionProbe = TestProbe()
+      val answerProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      client ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      // pretend write+ack+write happened, so three requests written, now both coming back.
+      // (we need to make sure buffer is not reordered by sandwitched responses)
+      expectMsgType[Tcp.Write]
+      val fullResponse1 = encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.write()
+      val exampleResponseMessage2 = exampleResponseMessage.copy(id = 43)
+      val fullResponse2 = encodeLength(exampleResponseMessage2.write().length) ++ exampleResponseMessage2.write()
+      val exampleResponseMessage3 = exampleResponseMessage.copy(id = 44)
+      val fullResponse3 = encodeLength(exampleResponseMessage3.write().length) ++ exampleResponseMessage3.write()
+      registered ! Tcp.Received(fullResponse1.take(8))
+      Thread.sleep(30) // give things some time to go wrong
+      registered ! Tcp.Received(fullResponse1.drop(8) ++ fullResponse2.take(8))
+      Thread.sleep(30)
+      registered ! Tcp.Received(fullResponse2.drop(8) ++ fullResponse3.take(8))
+      Thread.sleep(30)
+      registered ! Tcp.Received(fullResponse3.drop(8))
+
+      answerProbe.expectMsg(Answer(42, Nil))
+      answerProbe.expectMsg(Answer(43, Nil))
+      answerProbe.expectMsg(Answer(44, Nil))
+    }
+
+    "respect backpressure from the TCP actor" in {
+      val tcpExtensionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      client ! exampleRequestMessage
+      client ! exampleRequestMessage.copy(id = 43)
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      val ack = expectMsgType[Tcp.Write].ack
+      expectNoMessage()
+      registered ! ack
+
+      expectMsgType[Tcp.Write]
+    }
+
     "accept merged TCP responses" in {
       val tcpExtensionProbe = TestProbe()
       val answerProbe = TestProbe()
@@ -86,8 +163,12 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
       expectMsgType[Register]
       val registered = tcpExtensionProbe.lastSender
 
-      expectMsgType[Tcp.Write]
-      expectMsgType[Tcp.Write]
+      var ack = expectMsgType[Tcp.Write].ack
+
+      registered ! ack
+
+      ack = expectMsgType[Tcp.Write].ack
+
       val fullResponse =
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.write() ++
         encodeLength(exampleResponseMessage.write().length) ++ exampleResponseMessage.copy(id = 43).write()
@@ -96,6 +177,72 @@ class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
 
       answerProbe.expectMsg(Answer(42, Nil))
       answerProbe.expectMsg(Answer(43, Nil))
+    }
+
+    "report its failure to the outer client" in {
+      val tcpExtensionProbe = TestProbe()
+      val answerProbe = TestProbe()
+
+      val failToConnectClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      failToConnectClient ! exampleRequestMessage
+
+      val connect = tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+
+      failToConnectClient ! Tcp.CommandFailed(connect)
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+
+      val closesWithErrorClient =
+        system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, answerProbe.ref)))
+
+      closesWithErrorClient ! exampleRequestMessage
+
+      tcpExtensionProbe.expectMsg(connect)
+      tcpExtensionProbe.lastSender ! Connected(dnsServerAddress, localAddress)
+      expectMsgType[Register]
+      val registered = tcpExtensionProbe.lastSender
+
+      registered ! Tcp.ErrorClosed("BOOM!")
+
+      answerProbe.expectMsg(DnsClient.TcpDropped)
+    }
+
+    "should drop older requests when TCP connection backpressures" in {
+      val tcpExtensionProbe = TestProbe()
+      val connectionProbe = TestProbe()
+
+      val client = system.actorOf(Props(new TcpDnsClient(tcpExtensionProbe.ref, dnsServerAddress, ActorRef.noSender)))
+
+      // initial request
+      val initialRequest = exampleRequestMessage.copy(id = 1)
+      client ! initialRequest
+
+      tcpExtensionProbe.expectMsg(Tcp.Connect(dnsServerAddress))
+      tcpExtensionProbe.lastSender.tell(Connected(dnsServerAddress, localAddress), connectionProbe.ref)
+      connectionProbe.expectMsgType[Register]
+      val registered = connectionProbe.lastSender
+
+      var write = connectionProbe.expectMsgType[Tcp.Write]
+      write.data.drop(2) shouldBe initialRequest.write()
+
+      // 1 in flight, 14 more, buffer fits 10, should drop 5 oldest (id 2 - 6)
+      EventFilter.warning(occurrences = 5, pattern = "Dropping oldest buffered DNS request").intercept {
+        (2 to 16).foreach { i =>
+          client ! exampleRequestMessage.copy(id = i.toShort)
+        }
+      }
+
+      // initial write is acked
+      registered ! write.ack
+
+      // the rest of the buffered should be handled
+      (7 to 16).foreach { i =>
+        write = connectionProbe.expectMsgType[Tcp.Write]
+        write.data.drop(2) shouldBe exampleRequestMessage.copy(id = i.toShort).write()
+        registered ! write.ack // next ack
+      }
     }
   }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -5,13 +5,14 @@
 package akka.io.dns.internal
 
 import java.net.InetSocketAddress
-
 import akka.AkkaException
+import akka.actor.Terminated
 import akka.actor.{ Actor, ActorLogging, ActorRef, Stash }
 import akka.annotation.InternalApi
 import akka.io.Tcp
 import akka.io.dns.internal.DnsClient.Answer
 import akka.util.ByteString
+import akka.event.LoggingAdapter
 
 /**
  * INTERNAL API
@@ -38,39 +39,110 @@ import akka.util.ByteString
     case _: Tcp.Connected =>
       log.debug("Connected to TCP address [{}]", ns)
       val connection = sender()
-      context.become(ready(connection))
+      context.watch(connection)
+      context.become(ready(connection, Vector.empty, ByteString.empty, waitingForWriteAck = false))
       connection ! Tcp.Register(self)
       unstashAll()
     case _: Message =>
       stash()
   }
 
-  def ready(connection: ActorRef, buffer: ByteString = ByteString.empty): Receive = {
+  private def ready(
+      connection: ActorRef,
+      requestBuffer: Vector[Message],
+      responseBuffer: ByteString,
+      waitingForWriteAck: Boolean): Receive = {
+
     case msg: Message =>
-      val bytes = msg.write()
-      connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes)
-    case failure @ Tcp.CommandFailed(_: Tcp.Write) =>
-      throwFailure("Write failed", failure.cause)
+      if (!waitingForWriteAck) {
+        if (requestBuffer.nonEmpty)
+          throwFailure(
+            s"Unexpected state, not waiting for ack but request buffer is not empty, this is a bug${requestBufferExtraMsg(requestBuffer)}")
+        sendWrite(connection, Vector.empty, responseBuffer, msg)
+      } else if (requestBuffer.size < MaxRequestsBuffered) {
+        // buffer, wait for ack
+        context.become(ready(connection, requestBuffer :+ msg, responseBuffer, waitingForWriteAck))
+      } else {
+        val oldest = requestBuffer.head
+        val newRequestBuffer = requestBuffer.tail :+ msg
+        log.warning("Dropping oldest buffered DNS request [{}] due to TCP backpressure", oldest)
+        context.become(ready(connection, newRequestBuffer, responseBuffer, waitingForWriteAck))
+      }
+
+    case Ack =>
+      if (waitingForWriteAck) {
+        if (requestBuffer.nonEmpty) {
+          val bufferedRequest = requestBuffer.head
+          val newRequestBuffer = requestBuffer.tail
+          sendWrite(connection, newRequestBuffer, responseBuffer, bufferedRequest)
+        } else {
+          context.become(ready(connection, Vector.empty, responseBuffer, waitingForWriteAck = false))
+        }
+      } else {
+        log.debug("Unexpected Ack in TCP DNS client")
+      }
+
     case Tcp.Received(newData) =>
-      val data = buffer ++ newData
-      // TCP DNS responses are prefixed by 2 bytes encoding the length of the response
-      val prefixSize = 2
-      if (data.length < prefixSize)
-        context.become(ready(connection, data))
+      onNewResponseData(connection, requestBuffer, waitingForWriteAck, responseBuffer ++ newData)
+
+    case failure: Tcp.CommandFailed =>
+      connection ! Tcp.Abort
+      throwFailure(s"TCP command failed${requestBufferExtraMsg(requestBuffer)}", failure.cause)
+
+    case Tcp.PeerClosed =>
+      if (requestBuffer.nonEmpty) {
+        log.warning("Connection closed, dropping {} buffered requests)", requestBuffer.size)
+        // gracefully handled but we are still dropping requests
+        answerRecipient ! DnsClient.TcpDropped
+      }
+      context.unwatch(connection)
+      context.become(idle)
+
+    case Tcp.ErrorClosed(cause) =>
+      throwFailure(s"Connection closed with error $cause${requestBufferExtraMsg(requestBuffer)}")
+
+    case Terminated(`connection`) =>
+      throwFailure(s"Connection terminated unexpectedly${requestBufferExtraMsg(requestBuffer)}")
+  }
+
+  private def requestBufferExtraMsg(requestBuffer: Vector[Message]): String =
+    if (requestBuffer.nonEmpty) s" (dropping ${requestBuffer.size} buffered requests)" else ""
+
+  private def onNewResponseData(
+      connection: ActorRef,
+      requestBuffer: Vector[Message],
+      waitingForWriteAck: Boolean,
+      responseBuffer: ByteString): Unit = {
+    // TCP DNS responses are prefixed by 2 bytes encoding the length of the response
+    val prefixSize = 2
+    if (responseBuffer.length < prefixSize)
+      context.become(ready(connection, requestBuffer, responseBuffer, waitingForWriteAck))
+    else {
+      val expectedPayloadLength = decodeLength(responseBuffer)
+      if (responseBuffer.drop(prefixSize).length < expectedPayloadLength)
+        context.become(ready(connection, requestBuffer, responseBuffer, waitingForWriteAck))
       else {
-        val expectedPayloadLength = decodeLength(data)
-        if (data.drop(prefixSize).length < expectedPayloadLength)
-          context.become(ready(connection, data))
-        else {
-          answerRecipient ! parseResponse(data.drop(prefixSize))
-          context.become(ready(connection, ByteString.empty))
-          if (data.length > prefixSize + expectedPayloadLength) {
-            self ! Tcp.Received(data.drop(prefixSize + expectedPayloadLength))
-          }
+        answerRecipient ! parseResponse(responseBuffer.drop(prefixSize))
+        if (responseBuffer.length > prefixSize + expectedPayloadLength) {
+          val newBuffer = responseBuffer.drop(prefixSize + expectedPayloadLength)
+          // needs to happen right away to not risk re-order with additional replies
+          onNewResponseData(connection, requestBuffer, waitingForWriteAck, newBuffer)
+        } else {
+          context.become(ready(connection, requestBuffer, ByteString.empty, waitingForWriteAck))
         }
       }
-    case Tcp.PeerClosed =>
-      context.become(idle)
+    }
+
+  }
+
+  private def sendWrite(
+      connection: ActorRef,
+      requestBuffer: Vector[Message],
+      responseBuffer: ByteString,
+      message: Message): Unit = {
+    val bytes = message.write()
+    connection ! Tcp.Write(encodeLength(bytes.length) ++ bytes, Ack)
+    context.become(ready(connection, requestBuffer, responseBuffer, waitingForWriteAck = true))
   }
 
   private def parseResponse(data: ByteString) = {
@@ -83,19 +155,42 @@ import akka.util.ByteString
       if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (Nil, Nil)
     Answer(msg.id, recs, additionalRecs)
   }
+
+  private def throwFailure(message: String, cause: Option[Throwable] = None): Nothing =
+    TcpDnsClient.throwFailure(message, cause, log, answerRecipient)
 }
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[internal] object TcpDnsClient {
-  def encodeLength(length: Int): ByteString =
+
+  private val MaxRequestsBuffered = 10
+
+  private[internal] def encodeLength(length: Int): ByteString =
     ByteString((length / 256).toByte, length.toByte)
 
-  def decodeLength(data: ByteString): Int =
+  private def decodeLength(data: ByteString): Int =
     ((data(0).toInt + 256) % 256) * 256 + ((data(1) + 256) % 256)
 
-  def throwFailure(message: String, cause: Option[Throwable]): Unit =
+  private def throwFailure(
+      message: String,
+      cause: Option[Throwable],
+      log: LoggingAdapter,
+      reportTo: ActorRef): Nothing = {
     cause match {
       case None =>
+        log.warning("TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message)
+
       case Some(throwable) =>
+        log.warning(throwable, "TCP DNS client failed: {}", message)
+        reportTo ! DnsClient.TcpDropped
         throw new AkkaException(message, throwable)
     }
+  }
+
+  private case object Ack extends Tcp.Event
 }


### PR DESCRIPTION
Backport https://github.com/akka/akka/pull/32636 into `release-2.9`.