### PR TITLE
build: bump actions/upload-artifact to v4.6.0

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -145,7 +145,7 @@ jobs:
 
       # Archive test results so we can do some diagnostics later
       - name: Upload test results
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4.6.0
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: 'test-results-${{ matrix.jdkVersion }}-${{ matrix.scalaVersion }}'


### PR DESCRIPTION
Bumping [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to `v4.6.0`.

A [recent nightly](https://github.com/akka/akka/actions/runs/13125482148/job/36620851243) failed with the following message:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3.1.1`.
```