### PR TITLE
fix: lastSequenceNumber for initial stashed command

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedMetadataSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedMetadataSpec.scala
@@ -109,6 +109,12 @@ class EventSourcedMetadataSpec
 
       // and during replay
       val ref2 = spawn(behavior(PersistenceId.ofUniqueId("ess-1"), probe.ref))
+
+      // This command will be handled after the replay.
+      // It will most likely be stashed during the replay and it should see seqNr 5 when handled.
+      // Reproducer of issue #32651
+      ref2 ! "cmd"
+
       probe.expectMessage("Some(meta) eventHandler evt")
       probe.expectMessage("Some(meta) eventHandler evt")
       probe.expectMessage("Some(meta-1) eventHandler evt1")
@@ -116,7 +122,6 @@ class EventSourcedMetadataSpec
       probe.expectMessage("Some(meta-3) eventHandler evt3")
       probe.expectMessage("Some(meta-3) RecoveryCompleted")
 
-      ref2 ! "cmd"
       probe.expectMessage("None onCommand")
       probe.expectMessage("Some(meta) eventHandler evt")
       probe.expectMessage("None thenRun")

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -102,6 +102,12 @@ class EventSourcedSequenceNumberSpec
 
       // and during replay
       val ref2 = spawn(behavior(PersistenceId.ofUniqueId("ess-1"), probe.ref))
+
+      // This command will be handled after the replay.
+      // It will most likely be stashed during the replay and it should see seqNr 5 when handled.
+      // Reproducer of issue #32651
+      ref2 ! "cmd"
+
       probe.expectMessage("1 eventHandler evt")
       probe.expectMessage("2 eventHandler evt")
       probe.expectMessage("3 eventHandler evt1")
@@ -109,7 +115,6 @@ class EventSourcedSequenceNumberSpec
       probe.expectMessage("5 eventHandler evt3")
       probe.expectMessage("5 onRecoveryComplete")
 
-      ref2 ! "cmd"
       probe.expectMessage("5 onCommand")
       probe.expectMessage("6 eventHandler evt")
       probe.expectMessage("6 thenRun")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -102,6 +102,12 @@ private[akka] final class BehaviorSetup[C, E, S](
 
   private var mdcPhase = PersistenceMdc.Initializing
 
+  // Needed for WithSeqNrAccessible
+  var currentSequenceNumber = 0L
+
+  // Needed for WithMetadataAccessible
+  var currentMetadata: Option[Any] = None
+
   if (isOnlyOneSnapshot) {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, keepNSnapshots, _) if keepNSnapshots > 1 =>

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -171,6 +171,9 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
 
       setup.cancelRecoveryTimer()
 
+      setup.currentSequenceNumber = seqNr
+      setup.currentMetadata = metadata
+
       ReplayingEvents[C, E, S](
         setup,
         ReplayingEvents.ReplayingState(
@@ -182,8 +185,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           System.nanoTime(),
           version,
           seenPerReplica,
-          eventsReplayed = 0,
-          metadata = metadata))
+          eventsReplayed = 0))
     }
 
     response match {


### PR DESCRIPTION
* place currentSequenceNumber in mutable field in BehaviorSetup
* similar for currentMetadata

Refs https://github.com/akka/akka/issues/32359