### PR TITLE
Doc: update video links in cluster sharding page

### DIFF
--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -38,7 +38,7 @@ It could for example be actors representing Aggregate Roots in Domain-Driven Des
 Here we call these actors "entities". These actors typically have persistent (durable) state,
 but this feature is not limited to actors with persistent state.
 
-The [Introduction to Akka Cluster Sharding video](https://akka.io/blog/news/2019/12/16/akka-cluster-sharding-intro-video)
+The [Introduction to Akka Cluster Sharding video](https://www.youtube.com/watch?v=SrPubnOKJcQ)
 is a good starting point for learning Cluster Sharding.
 
 Cluster sharding is typically used when you have many stateful actors that together consume
@@ -217,7 +217,7 @@ in one rebalance round. The lower result of `rebalance-relative-limit` and `reba
 An alternative allocation strategy is the @apidoc[ExternalShardAllocationStrategy] which allows
 explicit control over where shards are allocated via the @apidoc[ExternalShardAllocation] extension.
 
-This can be used, for example, to match up Kafka Partition consumption with shard locations. The video [How to co-locate Kafka Partitions with Akka Cluster Shards](https://akka.io/blog/news/2020/03/18/akka-sharding-kafka-video) explains a setup for it. Alpakka Kafka provides [an extension for Akka Cluster Sharding](https://doc.akka.io/libraries/alpakka-kafka/current/cluster-sharding.html).
+This can be used, for example, to match up Kafka Partition consumption with shard locations. The video [How to co-locate Kafka Partitions with Akka Cluster Shards](https://www.youtube.com/watch?v=Ad2DyOn4dlY) explains a setup for it. Alpakka Kafka provides [an extension for Akka Cluster Sharding](https://doc.akka.io/libraries/alpakka-kafka/current/cluster-sharding.html).
 
 To use it set it as the allocation strategy on your @apidoc[typed.*.Entity]:
 


### PR DESCRIPTION
Hi 👋 I found two broken links in the documentation. The blog news are no longer reachable.

As an alternative, I found the following videos, which I think are the ones that were contained in the blog's posts.
Please double-check.

-  Introduction To Akka Cluster Sharding  (https://www.youtube.com/watch?v=SrPubnOKJcQ)
- Distributed processing with Akka Cluster & Kafka (https://www.youtube.com/watch?v=Ad2DyOn4dlY)

Cheers!