### PR TITLE
Docs from main to docs/v2.10.2

### DIFF
--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -64,6 +64,15 @@ If the license key has expired when the `ActorSystem` is started the system will
 The expiry date is exposed by @apidoc[akka.actor.typed.ActorSystem] {scala="#licenseKeyExpiry" java="#getLicenseKeyExpiry"}
 so that you can write a test to remind yourself that it is time for renewal before it has expired.
 
+To verify that your license key is still valid (for example during  CI/CD integration), you can use the following test 
+that will start to fail one month before the license key will expire:
+
+Scala
+: @@snip [ConfigDocSpec.scala](/akka-docs/src/test/scala/docs/config/ConfigDocSpec.scala) { #check-is-key-valid }
+
+Java
+: @@snip [ConfigDocTest.java](/akka-docs/src/test/java/jdocs/config/ConfigDocTest.java) { #check-is-key-valid }
+
 ## When using JarJar, OneJar, Assembly or any jar-bundler
 
 @@@ warning

--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -61,7 +61,7 @@ For local development, Akka can be used without a key, but be aware that the `Ac
 a while when a key isn't configured.
 
 If the license key has expired when the `ActorSystem` is started the system will terminate after a while.
-The expiry date is exposed by @apidoc[akka.actor.typed.ActorSystem] {scala="#licenseKeyExpiry" java="#getLicenseKeyExpiry"}
+The expiry date is exposed by @scala[@scaladoc[ActorSystem.licenseKeyExpiry](akka.actor.typed.ActorSystem#licenseKeyExpiry)]@java[@javadoc[ActorSystem.getLicenseKeyExpiry](akka.actor.typed.ActorSystem#getLicenseKeyExpiry())] 
 so that you can write a test to remind yourself that it is time for renewal before it has expired.
 
 To verify that your license key is still valid (for example during  CI/CD integration), you can use the following test 

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -38,7 +38,7 @@ It could for example be actors representing Aggregate Roots in Domain-Driven Des
 Here we call these actors "entities". These actors typically have persistent (durable) state,
 but this feature is not limited to actors with persistent state.
 
-The [Introduction to Akka Cluster Sharding video](https://akka.io/blog/news/2019/12/16/akka-cluster-sharding-intro-video)
+The [Introduction to Akka Cluster Sharding video](https://www.youtube.com/watch?v=SrPubnOKJcQ)
 is a good starting point for learning Cluster Sharding.
 
 Cluster sharding is typically used when you have many stateful actors that together consume
@@ -217,7 +217,7 @@ in one rebalance round. The lower result of `rebalance-relative-limit` and `reba
 An alternative allocation strategy is the @apidoc[ExternalShardAllocationStrategy] which allows
 explicit control over where shards are allocated via the @apidoc[ExternalShardAllocation] extension.
 
-This can be used, for example, to match up Kafka Partition consumption with shard locations. The video [How to co-locate Kafka Partitions with Akka Cluster Shards](https://akka.io/blog/news/2020/03/18/akka-sharding-kafka-video) explains a setup for it. Alpakka Kafka provides [an extension for Akka Cluster Sharding](https://doc.akka.io/libraries/alpakka-kafka/current/cluster-sharding.html).
+This can be used, for example, to match up Kafka Partition consumption with shard locations. The video [How to co-locate Kafka Partitions with Akka Cluster Shards](https://www.youtube.com/watch?v=Ad2DyOn4dlY) explains a setup for it. Alpakka Kafka provides [an extension for Akka Cluster Sharding](https://doc.akka.io/libraries/alpakka-kafka/current/cluster-sharding.html).
 
 To use it set it as the allocation strategy on your @apidoc[typed.*.Entity]:
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -227,8 +227,8 @@ and can be one of:
 * @scala[@scaladoc[stash](akka.persistence.typed.scaladsl.Effect$#stash[Event,State]():akka.persistence.typed.scaladsl.ReplyEffect[Event,State])]@java[@javadoc[stash](akka.persistence.typed.javadsl.EffectFactories#stash())] the current command is stashed
 * @scala[@scaladoc[unstashAll](akka.persistence.typed.scaladsl.Effect$#unstashAll[Event,State]():akka.persistence.typed.scaladsl.Effect[Event,State])]@java[@javadoc[unstashAll](akka.persistence.typed.javadsl.EffectFactories#unstashAll())] process the commands that were stashed with @scala[`Effect.stash`]@java[`Effect().stash`]
 * @scala[@scaladoc[reply](akka.persistence.typed.scaladsl.Effect$#reply[ReplyMessage,Event,State](replyTo:akka.actor.typed.ActorRef[ReplyMessage])(replyWithMessage:ReplyMessage):akka.persistence.typed.scaladsl.ReplyEffect[Event,State])]@java[@javadoc[reply](akka.persistence.typed.javadsl.EffectFactories#reply(akka.actor.typed.ActorRef,ReplyMessage))] send a reply message to the given @apidoc[typed.ActorRef]
-* @scala[@scaladoc[async](akka.persistence.typed.scaladsl.Effect$#async)]@java[@javadoc[reply](akka.persistence.typed.javadsl.EffectFactories#async)] Asynchronous command handling
-* @scala[@scaladoc[asyncReply](akka.persistence.typed.scaladsl.Effect$#asyncReply)]@java[@javadoc[reply](akka.persistence.typed.javadsl.EffectFactories#asyncReply)] Asynchronous command handling and then reply
+* @scala[@scaladoc[async](akka.persistence.typed.scaladsl.Effect$#async)]@java[@javadoc[async](akka.persistence.typed.javadsl.EffectFactories#async(java.util.concurrent.CompletionStage))] Asynchronous command handling
+* @scala[@scaladoc[asyncReply](akka.persistence.typed.scaladsl.Effect$#asyncReply)]@java[@javadoc[asyncReply](akka.persistence.typed.javadsl.EffectFactories#asyncReply(java.util.concurrent.CompletionStage))] Asynchronous command handling and then reply
 
 Note that only one of those can be chosen per incoming command. It is not possible to both persist and say none/unhandled.
 

--- a/akka-docs/src/test/java/jdocs/config/ConfigDocTest.java
+++ b/akka-docs/src/test/java/jdocs/config/ConfigDocTest.java
@@ -14,6 +14,14 @@ import com.typesafe.config.ConfigFactory;
 // #imports
 import akka.actor.testkit.typed.javadsl.ActorTestKit;
 
+//#check-is-key-valid
+import java.time.LocalDate;
+import java.util.Optional;
+
+//#check-is-key-valid
+
+import static org.junit.Assert.*;
+
 public class ConfigDocTest {
 
   private Behavior<Void> rootBehavior = Behaviors.empty();
@@ -66,5 +74,19 @@ public class ConfigDocTest {
     ActorSystem system = ActorSystem.create(rootBehavior, "myname", complete);
     // #custom-config-2
     return system;
+  }
+
+  public void compileOnlyIsLicenseKeyValid() {
+    //#check-is-key-valid
+    ActorSystem<Void> system = ActorSystem.create(rootBehavior, "name");
+    Optional<LocalDate> licenseKey = system.getLicenseKeyExpiry();
+
+    assertFalse(licenseKey.isEmpty());
+
+    LocalDate nextMonth = LocalDate.now().plusMonths(1);
+    assertTrue(licenseKey.get().isAfter(nextMonth));
+
+    system.terminate();
+    //#check-is-key-valid
   }
 }

--- a/akka-docs/src/test/scala/docs/config/ConfigDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/config/ConfigDocSpec.scala
@@ -109,4 +109,18 @@ class ConfigDocSpec extends AnyWordSpec with Matchers {
     val system = ActorSystem(rootBehavior, "MySystem", conf)
     ActorTestKit.shutdown(system)
   }
+
+  def compileOnlyIsLicenseKeyValid(): Unit = {
+    //#check-is-key-valid
+    val system = ActorSystem(rootBehavior, "name")
+    val licenseKey = system.licenseKeyExpiry
+    licenseKey.isEmpty shouldBe false
+
+    import java.time.LocalDate
+    val nextMonth = LocalDate.now().plusMonths(1)
+    licenseKey.get.isAfter(nextMonth) shouldBe true
+
+    system.terminate()
+    //#check-is-key-valid
+  }
 }


### PR DESCRIPTION
Cherry-picking the following changes `akka/akka:main` into `akka/akka:docs/v2.10.2`:
- https://github.com/sebastian-alfers/akka/commit/8fddc40be6cd10ae8889821ae53bdca83b03b80b
- https://github.com/sebastian-alfers/akka/commit/eb031fc293b49b550113e6cd8a82ae238cda93ee
- https://github.com/sebastian-alfers/akka/commit/eca190366c62ce669784bb79ef9e7ab048520130
- https://github.com/sebastian-alfers/akka/commit/010bbf976648e7657f4d20c0ce3a183e607481e6