### PR TITLE
docs: Shutdown hook in logback config sample to not lose async

### DIFF
--- a/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
@@ -18,6 +18,10 @@
         <appender-ref ref="FILE" />
     </appender>
 
+    <!-- Give the async appender a chance to output all buffered log entries in the face of JVM shutdown -->
+    <import class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+    <shutdownHook class="DefaultShutdownHook"/>
+
     <root level="INFO">
         <appender-ref ref="ASYNC"/>
     </root>


### PR DESCRIPTION
The async appender may not have time to emit entries logged just before the JVM exits without this.