### PR TITLE
feat: virtual thread executor support

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
@@ -5,9 +5,9 @@
 package akka.dispatch
 
 import com.typesafe.config.ConfigFactory
-
 import akka.actor.{ Actor, Props }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
+import akka.util.JavaVersion
 
 object ForkJoinPoolStarvationSpec {
   val config = ConfigFactory.parseString("""
@@ -52,8 +52,7 @@ class ForkJoinPoolStarvationSpec extends AkkaSpec(ForkJoinPoolStarvationSpec.con
 
     "not starve tasks arriving from external dispatchers under high internal traffic" in {
       // TODO issue #31117: starvation with JDK 17 FJP
-      val javaSpecVersion = System.getProperty("java.specification.version").toInt
-      if (javaSpecVersion >= 17)
+      if (JavaVersion.majorVersion >= 17)
         pending
 
       // Two busy actors that will occupy the threads of the dispatcher

--- a/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
@@ -20,17 +20,16 @@ class VirtualThreadDispatcherSpec extends AnyWordSpec {
         // loom not available yet here
         pending
       } else {
-        var system: ActorSystem = null
-        try {
-          system = ActorSystem(
-            classOf[VirtualThreadDispatcherSpec].getSimpleName,
-            ConfigFactory.parseString("""
+        val system = ActorSystem(
+          classOf[VirtualThreadDispatcherSpec].getSimpleName,
+          ConfigFactory.parseString("""
               my-vt-dispatcher {
                 type = "Dispatcher"
                 executor = virtual-thread-executor
               }
             """).withFallback(ConfigFactory.load()))
 
+        try {
           val vtDispatcher = system.dispatchers.lookup("my-vt-dispatcher")
           val threadIsVirtualProbe = TestProbe()(system)
           vtDispatcher.execute(() => {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
@@ -4,14 +4,40 @@
 
 package akka.dispatch
 
+import akka.actor.Actor
 import akka.actor.ActorSystem
+import akka.actor.Props
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import akka.util.JavaVersion
 import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class VirtualThreadDispatcherSpec extends AnyWordSpec {
+object VirtualThreadDispatcherSpec {
+  final case class ThreadInfo(virtual: Boolean, name: String)
+
+  object ThreadInfoActor {
+    def props() = Props(new ThreadInfoActor)
+  }
+  private class ThreadInfoActor extends Actor {
+    override def receive: Receive = {
+      case "give-me-info" =>
+        sender() ! reflectiveVirtualThreadInfo()
+    }
+  }
+
+  private def reflectiveVirtualThreadInfo(): ThreadInfo = {
+    val thread = Thread.currentThread()
+    // can't use methods directly or test won't compile on jdk < 21
+    val isVirtualMethod = thread.getClass.getMethod("isVirtual")
+    val isVirtual = isVirtualMethod.invoke(thread).asInstanceOf[Boolean]
+    ThreadInfo(isVirtual, thread.getName)
+  }
+}
+
+class VirtualThreadDispatcherSpec extends AnyWordSpec with Matchers {
+  import VirtualThreadDispatcherSpec._
 
   "The virtual thread support" should {
 
@@ -31,19 +57,44 @@ class VirtualThreadDispatcherSpec extends AnyWordSpec {
 
         try {
           val vtDispatcher = system.dispatchers.lookup("my-vt-dispatcher")
+          vtDispatcher shouldBe a[BatchingExecutor]
+
           val threadIsVirtualProbe = TestProbe()(system)
           vtDispatcher.execute(() => {
-            val thread = Thread.currentThread()
-            // can't use methods directly or test won't compile on jdk < 21
-            val isVirtualMethod = thread.getClass.getMethod("isVirtual")
-            val result = isVirtualMethod.invoke(thread).asInstanceOf[Boolean]
-            threadIsVirtualProbe.ref ! result
+            threadIsVirtualProbe.ref ! reflectiveVirtualThreadInfo()
           })
-          threadIsVirtualProbe.expectMsg(true)
+          val info = threadIsVirtualProbe.expectMsgType[ThreadInfo]
+          info.virtual shouldBe true
+          info.name should endWith("my-vt-dispatcher")
         } finally {
-          if (system != null) TestKit.shutdownActorSystem(system)
+          TestKit.shutdownActorSystem(system)
         }
 
+      }
+    }
+
+    "can be used as default dispatcher" in {
+      if (JavaVersion.majorVersion < 21) {
+        // loom not available yet here
+        pending
+      } else {
+        // not necessarily a good idea because of the virtual thread per task overhead, but to know it works
+        // and to cover running actors on it
+        implicit val system = ActorSystem(
+          classOf[VirtualThreadDispatcherSpec].getSimpleName,
+          ConfigFactory.parseString("""
+              akka.actor.default-dispatcher.executor="virtual-thread-executor"
+            """).withFallback(ConfigFactory.load()))
+        try {
+          val echo = system.actorOf(ThreadInfoActor.props())
+          val responseProbe = TestProbe()
+          echo.tell("give-me-info", responseProbe.ref)
+          val info = responseProbe.expectMsgType[ThreadInfo]
+          info.virtual shouldBe true
+          info.name should endWith("akka.actor.default-dispatcher")
+        } finally {
+          TestKit.shutdownActorSystem(system)
+        }
       }
     }
   }

--- a/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.dispatch
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import akka.testkit.TestProbe
+import akka.util.JavaVersion
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpec
+
+class VirtualThreadDispatcherSpec extends AnyWordSpec {
+
+  "The virtual thread support" should {
+
+    "run tasks on virtual threads" in {
+      if (JavaVersion.majorVersion < 21) {
+        // loom not available yet here
+        pending
+      } else {
+        var system: ActorSystem = null
+        try {
+          system = ActorSystem(
+            classOf[VirtualThreadDispatcherSpec].getSimpleName,
+            ConfigFactory.parseString("""
+              my-vt-dispatcher {
+                type = "Dispatcher"
+                executor = virtual-thread-executor
+              }
+            """).withFallback(ConfigFactory.load()))
+
+          val vtDispatcher = system.dispatchers.lookup("my-vt-dispatcher")
+          val threadIsVirtualProbe = TestProbe()(system)
+          vtDispatcher.execute(() => {
+            val thread = Thread.currentThread()
+            // can't use methods directly or test won't compile on jdk < 21
+            val isVirtualMethod = thread.getClass.getMethod("isVirtual")
+            val result = isVirtualMethod.invoke(thread).asInstanceOf[Boolean]
+            threadIsVirtualProbe.ref ! result
+          })
+          threadIsVirtualProbe.expectMsg(true)
+        } finally {
+          if (system != null) TestKit.shutdownActorSystem(system)
+        }
+
+      }
+    }
+  }
+
+}

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -370,6 +370,7 @@ akka {
       #  - "fork-join-executor" requires a "fork-join-executor" section
       #  - "thread-pool-executor" requires a "thread-pool-executor" section
       #  - "affinity-pool-executor" requires an "affinity-pool-executor" section
+      #  - "virtual-thread-executor" requires a "virtual-thread-executor" section
       #  - A FQCN of a class extending ExecutorServiceConfigurator
       executor = "default-executor"
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -531,12 +531,22 @@ akka {
       # This will be used if you have set "executor = "virtual-thread-executor"
       # The virtual thread executor can only be used on JDK 21 an newer and runs each
       # task in a virtual thread.
+      #
       # Note that while running actors on this will make sure they do not interfer with
       # each other, an individual actor should still not be blocked since that means it
       # cannot act on messages while blocked, for example system messages.
       # For other use cases, such as future calls invoking blocking work, or using as
       # blocking-io-dispatcher might be fine.
+      #
+      # It is not possible to tune the carrier thread pool per executor however it is possible to globally
+      # control the JDK carrier thread pool size through system properties. See JVM
+      # Thread documentation for details: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html
       virtual-thread-executor {
+        # if run on a mixture of JDK versions, some not supporting virtual threads (JDK 17 and earlier),
+        # this can be used to specify an alternative executor to make sure an application always works
+        # by default this is empty so that expecting to be able to run virtual threads when it is not possible
+        # will not go unnoticed.
+        fallback = ""
       }
 
 
@@ -577,8 +587,14 @@ akka {
 
     default-blocking-io-dispatcher {
       type = "Dispatcher"
-      executor = "thread-pool-executor"
+      # use virtual threads if available, Java 21 and later
+      executor = "virtual-thread-executor"
       throughput = 1
+
+      virtual-thread-executor {
+        # Fall back to fixed pool on Java 17 and earlier
+        fallback = "thread-pool-executor"
+      }
 
       thread-pool-executor {
         fixed-pool-size = 16

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -527,6 +527,18 @@ akka {
         allow-core-timeout = on
       }
 
+      # This will be used if you have set "executor = "virtual-thread-executor"
+      # The virtual thread executor can only be used on JDK 21 an newer and runs each
+      # task in a virtual thread.
+      # Note that while running actors on this will make sure they do not interfer with
+      # each other, an individual actor should still not be blocked since that means it
+      # cannot act on messages while blocked, for example system messages.
+      # For other use cases, such as future calls invoking blocking work, or using as
+      # blocking-io-dispatcher might be fine.
+      virtual-thread-executor {
+      }
+
+
       # How long time the dispatcher will wait for new actors until it shuts down
       shutdown-timeout = 1s
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -532,17 +532,20 @@ akka {
       # The virtual thread executor can only be used on JDK 21 an newer and runs each
       # task in a virtual thread.
       #
-      # Note that while running actors on this will make sure they do not interfer with
-      # each other, an individual actor should still not be blocked since that means it
-      # cannot act on messages while blocked, for example system messages.
-      # For other use cases, such as future calls invoking blocking work, or using as
-      # blocking-io-dispatcher might be fine.
+      # Note that while running actors on this will make sure they do not interfer with each other by starving
+      # the dispatcher, an individual actor should still not be blocked since that means it cannot act on messages
+      # while blocked, for example system messages such as termination of the actor. Using the virtual-thread-executor
+      # comes at the price of some overhead, since each scheduled task is wrapped in a virtual thread instance, in
+      # benchmarks this has shown up as around 30% lower throughput, a higher allocation rate and 10% more time spent on GC
+      #
+      # For other use cases, such as future calls invoking blocking work, or using as blocking-io-dispatcher the executor
+      # may be a more sound choice.
       #
       # It is not possible to tune the carrier thread pool per executor however it is possible to globally
-      # control the JDK carrier thread pool size through system properties. See JVM
+      # control the JVM carrier thread pool size through system properties. See JVM
       # Thread documentation for details: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html
       virtual-thread-executor {
-        # if run on a mixture of JDK versions, some not supporting virtual threads (JDK 17 and earlier),
+        # If run on a mixture of JDK versions, some not supporting virtual threads (JDK 17 and earlier),
         # this can be used to specify an alternative executor to make sure an application always works
         # by default this is empty so that expecting to be able to run virtual threads when it is not possible
         # will not go unnoticed.
@@ -587,14 +590,8 @@ akka {
 
     default-blocking-io-dispatcher {
       type = "Dispatcher"
-      # use virtual threads if available, Java 21 and later
-      executor = "virtual-thread-executor"
+      executor = "thread-pool-executor"
       throughput = 1
-
-      virtual-thread-executor {
-        # Fall back to fixed pool on Java 17 and earlier
-        fallback = "thread-pool-executor"
-      }
 
       thread-pool-executor {
         fixed-pool-size = 16

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -372,7 +372,7 @@ abstract class MessageDispatcherConfigurator(_config: Config, val prerequisites:
           if (fallbackExecutorName.isEmpty)
             throw new RuntimeException(
               s"Dispatcher configured to use virtual threads, but JVM version ${JavaVersion.majorVersion} does not support that. " +
-              "Use a newer Java version (21 or later), or configure 'fallback' for alternative executor on older Java versions.")
+              "Use a newer Java version (21 or later), or configure 'virtual-thread-executor.fallback' for an alternative executor on older Java versions.")
           else
             configurator(fallbackExecutorName)
         }

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -365,6 +365,8 @@ abstract class MessageDispatcherConfigurator(_config: Config, val prerequisites:
         new ThreadPoolExecutorConfigurator(config.getConfig("thread-pool-executor"), prerequisites)
       case "affinity-pool-executor" =>
         new AffinityPoolConfigurator(config.getConfig("affinity-pool-executor"), prerequisites)
+      case "virtual-thread-executor" =>
+        new VirtualThreadConfigurator(config.getConfig("virtual-thread-executor"), prerequisites)
 
       case fqcn =>
         val args = List(classOf[Config] -> config, classOf[DispatcherPrerequisites] -> prerequisites)

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -81,7 +81,7 @@ private[akka] class VirtualThreadConfigurator(config: Config, prerequisites: Dis
           createVirtualThreadFactory(prerequisites.dynamicAccess, m.name + "-" + id, Some(m.exceptionHandler))
 
         // Note: daemonic false not allowed for virtual threads, so we ignore that
-        m.contextClassLoader.fold(virtualThreadFactory)(classLoader =>
+        m.contextClassLoader.fold[ThreadFactory](virtualThreadFactory)(classLoader =>
           (r: Runnable) => {
             val virtualThread = virtualThreadFactory.newThread(r)
             virtualThread.setContextClassLoader(classLoader)

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -6,6 +6,7 @@ package akka.dispatch
 
 import akka.actor.DynamicAccess
 import akka.annotation.InternalApi
+import akka.util.JavaVersion
 import com.typesafe.config.Config
 
 import java.util.concurrent.ExecutorService
@@ -17,6 +18,8 @@ import java.util.concurrent.ThreadFactory
  */
 @InternalApi
 private[akka] object VirtualThreadConfigurator {
+
+  def virtualThreadsSupported(): Boolean = JavaVersion.majorVersion >= 21
 
   // Note: since we still support JDK 11 and 17, we need to access the factory method reflectively
   private def createVirtualThreadFactory(

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -4,6 +4,7 @@
 
 package akka.dispatch
 
+import akka.actor.DynamicAccess
 import akka.annotation.InternalApi
 import com.typesafe.config.Config
 
@@ -18,7 +19,7 @@ import java.util.concurrent.ThreadFactory
 private[akka] object VirtualThreadConfigurator {
 
   // Note: since we still support JDK 11 and 17, we need to access the factory method reflectively
-  private def virtualThreadFactory(virtualThreadName: String): ThreadFactory = {
+  private def virtualThreadFactory(dynamicAccess: DynamicAccess, virtualThreadName: String): ThreadFactory = {
     val ofVirtualMethod =
       try {
         classOf[Thread].getMethod("ofVirtual")
@@ -28,7 +29,7 @@ private[akka] object VirtualThreadConfigurator {
       }
     val ofVirtual = ofVirtualMethod.invoke(null)
     // java.lang.ThreadBuilders.VirtualThreadBuilder is package private
-    val ofVirtualInterface = ClassLoader.getSystemClassLoader.loadClass("java.lang.Thread$Builder$OfVirtual")
+    val ofVirtualInterface = dynamicAccess.getClassFor[AnyRef]("java.lang.Thread$Builder$OfVirtual").get
     val ofVirtualWithName =
       if (virtualThreadName.nonEmpty) {
         val nameMethod = ofVirtualInterface.getMethod("name", classOf[String])
@@ -61,8 +62,8 @@ private[akka] class VirtualThreadConfigurator(config: Config, prerequisites: Dis
     val tf = threadFactory match {
       case m: MonitorableThreadFactory =>
         // add the dispatcher id to the thread names
-        virtualThreadFactory(m.name + "-" + id)
-      case _ => virtualThreadFactory("-" + id)
+        virtualThreadFactory(prerequisites.dynamicAccess, m.name + "-" + id)
+      case _ => virtualThreadFactory(prerequisites.dynamicAccess, "-" + id)
     }
     new VirtualThreadExecutorServiceFactory(tf)
   }

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -34,7 +34,6 @@ private[akka] object VirtualThreadConfigurator {
           throw new IllegalStateException("Virtual thread executors only supported on JDK 21 and newer")
       }
     val ofVirtual = ofVirtualMethod.invoke(null)
-    // java.lang.ThreadBuilders.VirtualThreadBuilder is package private
     val ofVirtualInterface = dynamicAccess.getClassFor[AnyRef]("java.lang.Thread$Builder$OfVirtual").get
 
     // thread names

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.dispatch
+
+import akka.annotation.InternalApi
+import com.typesafe.config.Config
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object VirtualThreadConfigurator {
+
+  // Note: since we still support JDK 11 and 17, we need to access the factory method reflectively
+  private def virtualThreadFactory(virtualThreadName: String): ThreadFactory = {
+    val ofVirtualMethod =
+      try {
+        classOf[Thread].getMethod("ofVirtual")
+      } catch {
+        case _: NoSuchMethodError =>
+          throw new IllegalStateException("Virtual thread executors only supported on JDK 21 and newer")
+      }
+    val ofVirtual = ofVirtualMethod.invoke(null)
+    // java.lang.ThreadBuilders.VirtualThreadBuilder is package private
+    val ofVirtualInterface = ClassLoader.getSystemClassLoader.loadClass("java.lang.Thread$Builder$OfVirtual")
+    val ofVirtualWithName =
+      if (virtualThreadName.nonEmpty) {
+        val nameMethod = ofVirtualInterface.getMethod("name", classOf[String])
+        nameMethod.invoke(ofVirtual, virtualThreadName)
+      } else ofVirtual
+    val factoryMethod = ofVirtualInterface.getMethod("factory")
+    factoryMethod.invoke(ofVirtualWithName).asInstanceOf[ThreadFactory]
+  }
+
+  private def threadPerTaskExecutor(threadFactory: ThreadFactory): ExecutorService = {
+    val newThreadPerTaskMethod = classOf[Executors].getMethod("newThreadPerTaskExecutor", classOf[ThreadFactory])
+    newThreadPerTaskMethod.invoke(null, threadFactory).asInstanceOf[ExecutorService]
+  }
+
+  private class VirtualThreadExecutorServiceFactory(tf: ThreadFactory) extends ExecutorServiceFactory {
+    override def createExecutorService: ExecutorService = threadPerTaskExecutor(tf)
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] class VirtualThreadConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
+    extends ExecutorServiceConfigurator(config, prerequisites) {
+  import VirtualThreadConfigurator._
+
+  override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+    val tf = threadFactory match {
+      case m: MonitorableThreadFactory =>
+        // add the dispatcher id to the thread names
+        virtualThreadFactory(m.name + "-" + id)
+      case _ => virtualThreadFactory("-" + id)
+    }
+    new VirtualThreadExecutorServiceFactory(tf)
+  }
+
+}

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorBenchmark.scala
@@ -45,7 +45,7 @@ class ActorBenchmark {
       "akka.actor.JCToolsMailbox"))
   var mailbox = ""
 
-  @Param(Array("fjp-dispatcher")) //  @Param(Array("fjp-dispatcher", "affinity-dispatcher"))
+  @Param(Array("fjp-dispatcher", "virtual-thread-executor")) //  @Param(Array("fjp-dispatcher", "affinity-dispatcher"))
   var dispatcher = ""
 
   implicit var system: ActorSystem = _
@@ -84,6 +84,11 @@ class ActorBenchmark {
             }
             throughput = $tpt
             mailbox-type = "$mailbox"
+         }
+         vt-dispatcher {
+           executor = "virtual-thread-executor"
+           throughput = $tpt
+           mailbox-type = "$mailbox"
          }
        }
       """))

--- a/akka-bench-jmh/src/main/scala/akka/actor/ActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/ActorBenchmark.scala
@@ -45,7 +45,7 @@ class ActorBenchmark {
       "akka.actor.JCToolsMailbox"))
   var mailbox = ""
 
-  @Param(Array("fjp-dispatcher", "virtual-thread-executor")) //  @Param(Array("fjp-dispatcher", "affinity-dispatcher"))
+  @Param(Array("fjp-dispatcher", "vt-dispatcher")) //  @Param(Array("fjp-dispatcher", "affinity-dispatcher"))
   var dispatcher = ""
 
   implicit var system: ActorSystem = _

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -330,6 +330,28 @@ applications.
 
 For a similar discussion specifically about Akka HTTP, refer to @extref[Handling blocking operations in Akka HTTP](akka.http:handling-blocking-operations-in-akka-http-routes.html).
 
+### Solution: Virtual threads dispatcher for blocking operations
+
+If running on Java 21 or later, it is possible to use virtual threads for a blocking dispatcher, configure
+the executor of the dispatcher to be `virtual-thread-executor`.
+
+The virtual thread executor will run every task in a virtual thread, which can let go of the OS-level thread
+when it is waiting for a blocking operation, much like how an async task allows threads to be handed back to
+a thread pool, until some task completes.
+
+Re-configuring the built-in blocking dispatcher to use virtual threads can be done like this:
+
+```ruby
+akka.actor.default-blocking-io-dispatcher {
+  executor = "virtual-thread-executor"
+}
+```
+
+Note that there is a difference in behavior compared to the using a thread pool dispatcher in that there is no limit
+to how many virtual threads can block, for example hitting a service and waiting for a response, 
+while the threadpool executor puts an upper limit (16 by default) on how many threads are actually in flight, 
+once that limit has been reached, additional tasks are queued until a thread becomes available.
+
 ### Available solutions to blocking operations
 
 The non-exhaustive list of adequate solutions to the “blocking problem”

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -335,7 +335,7 @@ For a similar discussion specifically about Akka HTTP, refer to @extref[Handling
 If running on Java 21 or later, it is possible to use virtual threads for a blocking dispatcher, configure
 the executor of the dispatcher to be `virtual-thread-executor`.
 
-The virtual thread executor will run every task in a virtual thread, which can let go of the OS-level thread
+The virtual thread executor will run every task in a virtual thread, which can detach from of the OS-level thread
 when it is waiting for a blocking operation, much like how an async task allows threads to be handed back to
 a thread pool, until some task completes.
 
@@ -347,7 +347,7 @@ akka.actor.default-blocking-io-dispatcher {
 }
 ```
 
-Note that there is a difference in behavior compared to the using a thread pool dispatcher in that there is no limit
+Note that there is a difference in behavior compared to using a thread pool dispatcher in that there is no limit
 to how many virtual threads can block, for example hitting a service and waiting for a response, 
 while the threadpool executor puts an upper limit (16 by default) on how many threads are actually in flight, 
 once that limit has been reached, additional tasks are queued until a thread becomes available.


### PR DESCRIPTION
This adds a new executor config which will make a dispatcher run each scheduled task as a separate, new, virtual thread. This is very useful for blocking logic, for example in futures, but less so for running actors on and has considerable overhead for message intense systems.

Somewhat related issue #31613