### PR TITLE
feat: Add LatestEventTimestampQuery

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
@@ -48,7 +48,8 @@ final class EventsBySliceFirehoseQuery(delegate: scaladsl.EventsBySliceFirehoseQ
     with EventsBySliceQuery
     with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
-    with LoadEventQuery {
+    with LoadEventQuery
+    with LatestEventTimestampQuery {
 
   override def sliceForPersistenceId(persistenceId: String): Int =
     delegate.sliceForPersistenceId(persistenceId)
@@ -81,5 +82,11 @@ final class EventsBySliceFirehoseQuery(delegate: scaladsl.EventsBySliceFirehoseQ
 
   override def loadEnvelope[Event](persistenceId: String, sequenceNr: Long): CompletionStage[EventEnvelope[Event]] =
     delegate.loadEnvelope[Event](persistenceId, sequenceNr).asJava
+
+  override def latestEventTimestamp(
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int): CompletionStage[Optional[Instant]] =
+    delegate.latestEventTimestamp(entityType, minSlice, maxSlice).map(_.toJava)(ExecutionContext.parasitic).asJava
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/LatestEventTimestampQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/LatestEventTimestampQuery.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.javadsl
+
+import java.time.Instant
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import akka.persistence.query.javadsl.ReadJournal
+
+/**
+ * Retrieve the latest timestamp for an entity type and slice range.
+ */
+trait LatestEventTimestampQuery extends ReadJournal {
+
+  def latestEventTimestamp(entityType: String, minSlice: Int, maxSlice: Int): CompletionStage[Optional[Instant]]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/LatestEventTimestampQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/LatestEventTimestampQuery.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.scaladsl
+
+import java.time.Instant
+
+import scala.concurrent.Future
+
+import akka.persistence.query.scaladsl.ReadJournal
+
+/**
+ * Retrieve the latest timestamp for an entity type and slice range.
+ */
+trait LatestEventTimestampQuery extends ReadJournal {
+
+  def latestEventTimestamp(entityType: String, minSlice: Int, maxSlice: Int): Future[Option[Instant]]
+
+}


### PR DESCRIPTION
* Retrieve the latest timestamp for an entity type and slice range.
* Primary purpose is for observability.

