### PR TITLE
bump: Jackson 2.18.3

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,8 +3,8 @@ pullRequests.frequency = "@monthly"
 
 updates.pin  = [
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.2." }
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.17." }
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.17." }
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.18." }
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.18." }
   // Aeron 1.46 and onwards is JDK 17+ only and we still support JDK 11 so can't bump
   { groupId = "io.aeron", artifactId = "aeron-client", version = "1.44."}
   { groupId = "io.aeron", artifactId = "aeron-driver", version = "1.44."}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val logbackVersion = "1.5.18"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"
-  val jacksonCoreVersion = "2.17.3" // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
+  val jacksonCoreVersion = "2.18.3" // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
   val jacksonDatabindVersion = jacksonCoreVersion // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
 
   // Also update URLs in link-validator.conf


### PR DESCRIPTION
* seems to be compatible with 2.17 so will be bumped in patch of Akka

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.18
