### PR TITLE
fix: earlier re-registration for shard region when coordinator is leaving/exiting

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -768,7 +768,7 @@ private[akka] class ShardRegion(
           // We only make one attempt to one candidate so as to not flood with registration messages
           // Important since this is level-triggered (any membership change where the coordinator is on a
           // not-up node) while registration is otherwise edge-triggered
-          coordinatorSelection.lastOption.foreach(sendRegistrationMessage)
+          coordinatorSelection.headOption.foreach(sendRegistrationMessage)
 
           if (!timers.isTimerActive(RegisterRetry)) {
             nextRegistrationDelay = initRegistrationDelay

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -789,10 +789,14 @@ private[akka] class ShardRegion(
   def receiveClusterEvent(evt: ClusterDomainEvent): Unit = evt match {
     case MemberUp(m) =>
       addMember(m)
+
     case MemberLeft(m) =>
-      addMember(m)
+      if (m.uniqueAddress != cluster.selfUniqueAddress && matchingCoordinatorRole(m))
+        changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress))
+
     case MemberExited(m) =>
-      addMember(m)
+      if (m.uniqueAddress != cluster.selfUniqueAddress && matchingCoordinatorRole(m))
+        changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress))
 
     case MemberRemoved(m, _) =>
       if (m.uniqueAddress == cluster.selfUniqueAddress)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -763,13 +763,14 @@ private[akka] class ShardRegion(
               typeName,
               notUp)
 
-          // For now, make one attempt to register with the oldest Up member we know about without forgetting
+          // For now, attempt to register with the oldest Up member we know about without forgetting
           // about the current coordinator
-          // We only make one attempt to one candidate so as to not flood with registration messages
+          // We only attempt one candidate so as to not flood with registration messages
           // Important since this is level-triggered (any membership change where the coordinator is on a
           // not-up node) while registration is otherwise edge-triggered
           coordinatorSelection.headOption.foreach(sendRegistrationMessage)
 
+          // in case we're not getting any membership changes for a while...
           if (!timers.isTimerActive(RegisterRetry)) {
             nextRegistrationDelay = initRegistrationDelay
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -805,6 +805,9 @@ private[akka] class ShardRegion(
           after.map(_.address).getOrElse(""))
       coordinator = None
       startRegistration()
+    } else if (coordinator.isEmpty) {
+      // NB: resets registration retry backoff, but the situation has changed
+      startRegistration()
     } else if (coordinatorStatus(membersByAge) != coordinatorStatus(newMembers)) {
       // coordinator status changed
       reRegisterIfCoordinatorNotUp()

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -761,14 +761,14 @@ private[akka] class ShardRegion(
       coordinator = None
       startRegistration()
     } else if (coordinator.nonEmpty) {
-      val coordAddress = coordinator.get.path.address   // safe: guarded by nonEmpty
+      val coordAddress = coordinator.get.path.address // safe: guarded by nonEmpty
       val coordinatorStatus =
         coordinator.flatMap { _ =>
           newMembers.find(_.address == coordAddress).map(_.status)
         }
 
       coordinatorStatus match {
-        case Some(MemberStatus.Up) => ()    // Do nothing
+        case Some(MemberStatus.Up) => () // Do nothing
         case Some(notUp) =>
           if (log.isDebugEnabled)
             log.debug(
@@ -785,10 +785,7 @@ private[akka] class ShardRegion(
 
         case None =>
           // coordinator is on node which has been removed... can this actually happen?
-          log.warning(
-            "{}: Coordinator was on removed node [{}], attempting to re-register",
-            typeName,
-            coordAddress)
+          log.warning("{}: Coordinator was on removed node [{}], attempting to re-register", typeName, coordAddress)
           coordinator = None
           startRegistration()
       }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -793,10 +793,12 @@ private[akka] class ShardRegion(
     case MemberLeft(m) =>
       if (m.uniqueAddress != cluster.selfUniqueAddress && matchingCoordinatorRole(m))
         changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress))
+      else addMember(m)
 
     case MemberExited(m) =>
       if (m.uniqueAddress != cluster.selfUniqueAddress && matchingCoordinatorRole(m))
         changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress))
+      else addMember(m)
 
     case MemberRemoved(m, _) =>
       if (m.uniqueAddress == cluster.selfUniqueAddress)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -769,7 +769,7 @@ private[akka] class ShardRegion(
           // Important since this is level-triggered (any membership change where the coordinator is on a
           // not-up node) while registration is otherwise edge-triggered
           coordinatorSelection.lastOption.foreach(sendRegistrationMessage)
-          
+
           if (!timers.isTimerActive(RegisterRetry)) {
             nextRegistrationDelay = initRegistrationDelay
 

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -391,6 +391,8 @@ object ClusterSingletonManager {
         case MemberRemoved(m, _)        => remove(m)
         case MemberExited(m) if m.uniqueAddress != cluster.selfUniqueAddress =>
           remove(m)
+        case MemberLeft(m) if m.uniqueAddress != cluster.selfUniqueAddress =>
+          remove(m)
         case SelfExiting =>
           remove(cluster.readView.self)
           sender() ! Done // reply to ask

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -391,8 +391,6 @@ object ClusterSingletonManager {
         case MemberRemoved(m, _)        => remove(m)
         case MemberExited(m) if m.uniqueAddress != cluster.selfUniqueAddress =>
           remove(m)
-        case MemberLeft(m) if m.uniqueAddress != cluster.selfUniqueAddress =>
-          remove(m)
         case SelfExiting =>
           remove(cluster.readView.self)
           sender() ! Done // reply to ask


### PR DESCRIPTION
When the coordinator singleton leaves/exits, the singleton is fairly quick to start on the next oldest node.  However, the shard region doesn't try to register with the coordinator until after the previous oldest node has been removed, which can happen some seconds after leaving/exiting.

Among other things, this delays getting shard homes for previously unknown shards: in a rolling restart where the singleton is one of (ideally _the_) last to be stopped, this implies that the node hosting the shard region is comparatively young and may not have requested the homes for that many shards (additionally when there's turnover in cluster membership is more or less exactly when the transition from exiting to removed can be delayed).  This delayed discovery of shard homes will contribute to latency.

This fix recognizes when the last-registered coordinator is on a node which is not up any more and attempts to register with the "heir apparent" coordinator.