### PR TITLE
feat: optionally gossip to all when leaving if sufficiently old

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -142,6 +142,29 @@ akka {
     # discard incoming gossip messages if not handled within this duration
     gossip-time-to-live = 2s
 
+    # experimental optimization: gossip to all when leaving if one of the oldest in a role
+    # this is intended to speed up singleton (including shard coordinator, if using cluster sharding)
+    # handoff and discovery in normal operation.
+    #
+    # negative (current default) disables this optimization
+    #
+    # if non-negative, when this node leaves the cluster, it will check if it has a role in
+    # which it is one of the oldest 'gossip-all-when-leaving-and-oldest-n' + lg(nr-of-members-with-role + 1)
+    # if so, it will gossip to all members of the cluster
+    #
+    # for example, if set to 1
+    #   members with role      gossip to all if one of the oldest __ members with role
+    #   1, 2                   2
+    #   3, 4, 5, 6             3
+    #   7 ... 14               4
+    #   15 ... 30              5
+    #   31 ... 62              6
+    #   63 ... 126             7
+    #
+    # by gossiping to all, we attempt to minimize the time to achieve consensus that this member is leaving
+    # and thus cannot be expected to host singletons for a role
+    gossip-all-when-leaving-and-oldest-n = -1
+
     # how often should the leader perform maintenance tasks?
     leader-actions-interval = 1s
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -107,6 +107,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
   val GossipTimeToLive: FiniteDuration = {
     cc.getMillisDuration("gossip-time-to-live")
   }.requiring(_ > Duration.Zero, "gossip-time-to-live must be > 0")
+  val GossipAllWhenLeavingAndOldestN: Int = cc.getInt("gossip-all-when-leaving-and-oldest-n")
   val LeaderActionsInterval: FiniteDuration = cc.getMillisDuration("leader-actions-interval")
   val UnreachableNodesReaperInterval: FiniteDuration = cc.getMillisDuration("unreachable-nodes-reaper-interval")
   val PublishStatsInterval: Duration = {


### PR DESCRIPTION
sketch of an idea:

When singleton (by extension sharding and sharding daemon process) is in use, the oldest node in the cluster (resp. a role) takes on extra importance and only slightly less important are nodes which could plausibly become the oldest if a "reasonable number" of nodes left the cluster.  In the interest of smoothing the transition from an oldest node to its "legitimate heir", it's thus desirable to disseminate membership changes involving the oldest node and nodes in the immediate "line of succession" as quickly as possible.

Toward that end, this PR proposes to propagate the gossip that a node is leaving to all nodes (all meaning, in line with the deprecation of multi-DC, "all in the same DC") if it is sufficiently close to being the oldest node for at least one role.  "Sufficiently close" means one of the oldest `log2(1 + number_of_members) + extra`, where `extra` is tunable (e.g. based on the typical number of nodes added/removed in a rolling update).