### PR TITLE
chore: bump akka-http to 10.7.1 in akka-sample-sharding-scala

### DIFF
--- a/samples/akka-sample-sharding-scala/build.sbt
+++ b/samples/akka-sample-sharding-scala/build.sbt
@@ -1,6 +1,6 @@
 val AkkaVersion = "2.10.6"
-val AkkaHttpVersion = "10.6.3"
-val AkkaDiagnostics = "2.1.1"
+val AkkaHttpVersion = "10.7.1"
+val AkkaDiagnostics = "2.2.1"
 val LogbackVersion = "1.5.18"
 
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")


### PR DESCRIPTION
Needed to make the sample work again.