### PR TITLE
chore: use JDK11 constructor for ForkJoinPool (support setting maximum spare threads)

### DIFF
--- a/akka-actor/src/main/mima-filters/2.10.x.backwards.excludes/32745-fjp-max-spare-threads.excludes
+++ b/akka-actor/src/main/mima-filters/2.10.x.backwards.excludes/32745-fjp-max-spare-threads.excludes
@@ -1,0 +1,2 @@
+# Internal APIs
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.dispatch.ForkJoinExecutorConfigurator#AkkaForkJoinPool.this")

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -485,9 +485,6 @@ akka {
         # the FJP's overall maximum of 32768 minus the effective parallelism computed
         # above.
         #
-        # FIXME: in a future (at least Akka 2.11.0) version, use a better default (and
-        # perhaps override via property `java.util.concurrent.ForkJoinPool.common.maximumSpares`)
-        #
         # Consider setting this to a lower value if "excessive" dispatcher thread counts
         # are adversely impacting throughput due to context-switching; if no spares are available,
         # threads in the pool will block.

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -600,6 +600,7 @@ akka {
         parallelism-min = 4
         parallelism-factor = 1.0
         parallelism-max = 64
+        maximum-spare-threads = 0
       }
     }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -492,7 +492,6 @@ akka {
         # are adversely impacting throughput due to context-switching; if no spares are available,
         # threads in the pool will block.
         maximum-spare-threads = 32768
-        maximum-spare-threads = ${?java.util.concurrent.ForkJoinPool.common.maximumSpares}
       }
 
       # This will be used if you have set "executor = "thread-pool-executor""

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -475,6 +475,21 @@ akka {
         # Setting to "FIFO" to use queue like peeking mode which "poll" or "LIFO" to use stack
         # like peeking mode which "pop".
         task-peeking-mode = "FIFO"
+
+        # The ForkJoinPool supports ManagedBlocker (used by Scala `blocking {}`)
+        # which allows tasks running in the pool to signal that they might block;
+        # the pool may in response add a worker thread to the pool.  This setting
+        # limits the number of additional worker threads spawned.
+        #
+        # For compatibility with earlier behavior, the default value is 256 and may be
+        # overridden by the property `java.util.concurrent.ForkJoinPool.common.maximumSpares`,
+        # though a direct override in config of this setting takes precedence over that property.
+        #
+        # Consider setting this to a lower value if "excessive" dispatcher thread counts
+        # are adversely impacting throughput due to context-switching; if no spares are available,
+        # threads in the pool will block.
+        maximum-spare-threads = 256
+        maximum-spare-threads = ${?java.util.concurrent.ForkJoinPool.common.maximumSpares}
       }
 
       # This will be used if you have set "executor = "thread-pool-executor""

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -481,14 +481,17 @@ akka {
         # the pool may in response add a worker thread to the pool.  This setting
         # limits the number of additional worker threads spawned.
         #
-        # For compatibility with earlier behavior, the default value is 256 and may be
-        # overridden by the property `java.util.concurrent.ForkJoinPool.common.maximumSpares`,
-        # though a direct override in config of this setting takes precedence over that property.
+        # For compatibility with earlier behavior, the default value is effectively
+        # the FJP's overall maximum of 32768 minus the effective parallelism computed
+        # above.
+        #
+        # FIXME: in a future (at least Akka 2.11.0) version, use a better default (and
+        # perhaps override via property `java.util.concurrent.ForkJoinPool.common.maximumSpares`)
         #
         # Consider setting this to a lower value if "excessive" dispatcher thread counts
         # are adversely impacting throughput due to context-switching; if no spares are available,
         # threads in the pool will block.
-        maximum-spare-threads = 256
+        maximum-spare-threads = 32768
         maximum-spare-threads = ${?java.util.concurrent.ForkJoinPool.common.maximumSpares}
       }
 

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -7,6 +7,7 @@ package akka.dispatch
 import java.util.concurrent.{ ExecutorService, ForkJoinPool, ForkJoinTask, ThreadFactory }
 
 import com.typesafe.config.Config
+import java.util.concurrent.TimeUnit
 
 object ForkJoinExecutorConfigurator {
 
@@ -17,14 +18,25 @@ object ForkJoinExecutorConfigurator {
       parallelism: Int,
       threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
       unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
-      asyncMode: Boolean)
-      extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode)
+      asyncMode: Boolean,
+      maxSpareThreads: Int)
+      extends ForkJoinPool(
+        parallelism,
+        threadFactory,
+        unhandledExceptionHandler,
+        asyncMode,
+        parallelism, // corePoolSize
+        parallelism + maxSpareThreads, // maximumPoolSize
+        1, // minimumRunnable
+        _ => true, // saturate (don't reject execution)
+        60, // how long to allow a thread to be idle (matches default)
+        TimeUnit.SECONDS) // unit for previous
       with LoadMetrics {
     def this(
         parallelism: Int,
         threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
         unhandledExceptionHandler: Thread.UncaughtExceptionHandler) =
-      this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true)
+      this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true, 256)
 
     override def execute(r: Runnable): Unit =
       if (r ne null)
@@ -75,12 +87,13 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
   class ForkJoinExecutorServiceFactory(
       val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
       val parallelism: Int,
-      val asyncMode: Boolean)
+      val asyncMode: Boolean,
+      val maxSpareThreads: Int)
       extends ExecutorServiceFactory {
     def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int) =
-      this(threadFactory, parallelism, asyncMode = true)
+      this(threadFactory, parallelism, asyncMode = true, 256)
     def createExecutorService: ExecutorService =
-      new AkkaForkJoinPool(parallelism, threadFactory, MonitorableThreadFactory.doNothing, asyncMode)
+      new AkkaForkJoinPool(parallelism, threadFactory, MonitorableThreadFactory.doNothing, asyncMode, maxSpareThreads)
   }
 
   final def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
@@ -100,12 +113,15 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
           """"task-peeking-mode" in "fork-join-executor" section could only set to "FIFO" or "LIFO".""")
     }
 
+    val maxSpareThreads = config.getInt("maximum-spare-threads")
+
     new ForkJoinExecutorServiceFactory(
       validate(tf),
       ThreadPoolConfig.scaledPoolSize(
         config.getInt("parallelism-min"),
         config.getDouble("parallelism-factor"),
         config.getInt("parallelism-max")),
-      asyncMode)
+      asyncMode,
+      maxSpareThreads)
   }
 }

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -25,7 +25,7 @@ object ForkJoinExecutorConfigurator {
         threadFactory,
         unhandledExceptionHandler,
         asyncMode,
-        parallelism, // corePoolSize
+        0, // corePoolSize effectively equals Math.max(0, parallelism)
         parallelism + maxSpareThreads, // maximumPoolSize
         1, // minimumRunnable
         _ => true, // saturate (don't reject execution)

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -92,6 +92,10 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
       extends ExecutorServiceFactory {
     def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int) =
       this(threadFactory, parallelism, asyncMode = true, 256)
+
+    def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int, asyncMode: Boolean) =
+      this(threadFactory, parallelism, asyncMode, 256)
+
     def createExecutorService: ExecutorService =
       new AkkaForkJoinPool(parallelism, threadFactory, MonitorableThreadFactory.doNothing, asyncMode, maxSpareThreads)
   }

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -117,12 +117,7 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
           """"task-peeking-mode" in "fork-join-executor" section could only set to "FIFO" or "LIFO".""")
     }
 
-    val maxSpareThreads =
-      if (config.hasPath("maximum-spare-threads")) config.getInt("maximum-spare-threads")
-      else {
-        // old configs for custom dispatchers might not pick up this setting naturally (use the apparent JVM default)
-        256
-      }
+    val maxSpareThreads = config.getInt("maximum-spare-threads")
 
     new ForkJoinExecutorServiceFactory(
       validate(tf),

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -113,7 +113,12 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
           """"task-peeking-mode" in "fork-join-executor" section could only set to "FIFO" or "LIFO".""")
     }
 
-    val maxSpareThreads = config.getInt("maximum-spare-threads")
+    val maxSpareThreads =
+      if (config.hasPath("maximum-spare-threads")) config.getInt("maximum-spare-threads")
+      else {
+        // old configs for custom dispatchers might not pick up this setting naturally (use the apparent JVM default)
+        256
+      }
 
     new ForkJoinExecutorServiceFactory(
       validate(tf),

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -125,10 +125,11 @@ The `parallelism-max` for the `fork-join-executor` does not set the upper bound 
 allocated by the ForkJoinPool. It is a setting specifically talking about the number of *hot*
 threads the pool will keep running in order to reduce the latency of handling a new incoming task.  Threads may use
 `ManagedBlocker` (used by (among others) @scala[`Await` and `blocking {}`]@java[`CompletableFuture::get` and `CompletableFuture::join`])
-to signal the pool that it might be desirable to add a thread.  Prior to Akka 2.10.7, dispatchers with a `fork-join-executor`
-did not meaningfully bound the number of the additional threads which might be added.  From Akka 2.10.7 onwards, the
-default if `maximum-spare-threads` is not set in config is "no meaningful bound", but a limit can be set.  A future (at
-least 2.11) version of Akka may change this default behavior.
+to signal the pool that it might be desirable to add a thread (note that @ref:[this is not really a solution[(#non-solution-)).
+Prior to Akka 2.10.7, dispatchers with a `fork-join-executor` did not meaningfully bound the number of the additional threads which might
+be added.  From Akka 2.10.7 onwards, the default if `maximum-spare-threads` is not set in config is "no meaningful bound", but a limit
+can be set.  A future (at least 2.11) version of Akka may change this default behavior.
+
 You can read more about parallelism in the JDK's [ForkJoinPool documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ForkJoinPool.html).
 
 @@@

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -123,8 +123,13 @@ section and the `default-dispatcher` section of the @ref:[configuration](../gene
 
 The `parallelism-max` for the `fork-join-executor` does not set the upper bound on the total number of threads
 allocated by the ForkJoinPool. It is a setting specifically talking about the number of *hot*
-threads the pool will keep running in order to reduce the latency of handling a new incoming task.
-You can read more about parallelism in the JDK's [ForkJoinPool documentation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ForkJoinPool.html).
+threads the pool will keep running in order to reduce the latency of handling a new incoming task.  Threads may use
+`ManagedBlocker` (used by (among others) @scala[`Await` and `blocking {}`]@java[`CompletableFuture::get` and `CompletableFuture::join`])
+to signal the pool that it might be desirable to add a thread.  Prior to Akka 2.10.7, dispatchers with a `fork-join-executor`
+did not meaningfully bound the number of the additional threads which might be added.  From Akka 2.10.7 onwards, the
+default if `maximum-spare-threads` is not set in config is "no meaningful bound", but a limit can be set.  A future (at
+least 2.11) version of Akka may change this default behavior.
+You can read more about parallelism in the JDK's [ForkJoinPool documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ForkJoinPool.html).
 
 @@@
 
@@ -282,6 +287,20 @@ executes can still be a problem, since this dispatcher is by default used for al
 unless you @ref:[set up a separate dispatcher for the actor](../dispatchers.md#setting-the-dispatcher-for-an-actor).
 
 @@@
+
+### Non-solution: @scala[`blocking {}`]@java[`ManagedBlocker`]
+
+It may be tempting, if running on a `fork-join-executor`, to signal blocking to the underlying thread pool and allow the
+pool to dynamically add a worker thread when about to block.  Constructs like @scala[`Await`]@java[the `get()` and `join()`
+methods of `CompletableFuture`] will signal the thread pool in this way.  In the very short term, while the thread which
+signaled the pool is blocked, this does keep the dispatcher responsive.  The problem with this approach is that the "spare"
+thread will not be stopped until it has been idle for some period of time (the default is 1 minute): in the mean time, this
+will likely mean that the spare thread will be running even after the blocked thread has become unblocked.  During this
+period, it is further likely that there will be more runnable threads than available processors to run them, which will
+generally mean more context switches by the OS kernel and decreased application throughput with unpredictable latencies.
+Assuming the system remains under load, these spare threads will be kept busy and not become idle; even a relatively
+infrequent use of this mechanism under load may eventually exhaust the ability to add threads, resulting in a crash
+"out of the blue".
 
 ### Solution: Dedicated dispatcher for blocking operations
 

--- a/akka-docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -60,6 +60,8 @@ object DispatcherDocSpec {
         parallelism-factor = 2.0
         # Max number of threads to cap factor-based parallelism number to
         parallelism-max = 10
+        # Max number of additional threads to spawn by ManagedBlocker
+        maximum-spare-threads = 16
       }
       # Throughput defines the maximum number of messages to be
       # processed per actor before the thread jumps to the next actor.


### PR DESCRIPTION
Scala code (via `BlockContext` so `Await`/`blocking`) and Java code (via `ManagedBlocker`) can signal a ForkJoinPool that it might be useful to add a worker thread to compensate for the present worker being blocked.  For the common pool, the number of additional workers can be bounded by a JVM property (default value is 256); ~it is unclear whether this property also applies~ this property does not apply to application constructed FJPs like the default dispatcher (~or whether~ the effective maximum spare threads for a dispatcher is 2^15 - parallelism).  JDK11 adds a constructor which allows setting this maximum (among a few other settings).

Regardless of whether the default behavior of the currently-used constructor takes a limit from the property, it seems useful to expose this setting in config.  The default chosen is 256 to match the property's default (which is doubtless better than the previous de facto "no limit" ~if~ the current behavior is not to consult the property!).  In addition to overriding via config, the value of the JDK property for the common pool may also be used (as the default dispatcher is the Akka analogue to the common pool).

The priority for setting values for this setting for the default dispatcher (inherited by user-defined dispatchers) is:
* explicit JVM property `akka.actor.default-dispatcher.fork-join-executor.maximum-spare-threads`
* `akka.actor.default-dispatcher.fork-join-executor.maximum-spare-threads` in config (can be overridden by the usual config methods)
* ~JVM property `java.util.concurrent.ForkJoinPool.common.maximumSpares`~

The internal dispatcher is hardcoded to have zero spares: there shouldn't be anything that blocks in that dispatcher.