### PR TITLE
feat: SnapshotRecovered signal in typed EventSourcedBehavior

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
@@ -25,6 +25,7 @@ import scala.jdk.CollectionConverters._
 
 import akka.persistence.CompositeMetadata
 import akka.persistence.typed.internal.EventSourcedBehaviorImpl.WithMetadataAccessible
+import akka.persistence.typed.SnapshotRecovered
 
 /**
  * INTERNAL API
@@ -116,6 +117,7 @@ private[akka] object Unpersistent {
     private def sendSignal(signal: EventSourcedSignal): Unit =
       signalHandler.applyOrElse(state -> signal, doNothing)
 
+    sendSignal(SnapshotRecovered(snapshotMetadata()))
     sendSignal(RecoveryCompleted)
 
     override def onMessage(cmd: Command): Behavior[Command] = {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
@@ -18,6 +18,12 @@ import akka.annotation.InternalApi
 @DoNotInherit
 sealed trait EventSourcedSignal extends Signal
 
+final case class SnapshotRecovered(metadata: SnapshotMetadata) extends EventSourcedSignal {
+
+  /** Java API */
+  def getMetadata(): SnapshotMetadata = metadata
+}
+
 @DoNotInherit sealed abstract class RecoveryCompleted extends EventSourcedSignal
 case object RecoveryCompleted extends RecoveryCompleted {
   def instance: RecoveryCompleted = this

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -13,6 +13,7 @@ import akka.persistence.SnapshotProtocol.LoadSnapshotFailed
 import akka.persistence.SnapshotProtocol.LoadSnapshotResult
 import akka.persistence.typed.{ RecoveryFailed, ReplicaId }
 import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState }
+import akka.persistence.typed.SnapshotRecovered
 
 /**
  * INTERNAL API
@@ -168,6 +169,11 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
       }
 
       setup.internalLogger.debug("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
+      snapshot.foreach { snap =>
+        import akka.persistence.typed.{ SnapshotMetadata => TypedSnapshotMetadata }
+
+        setup.onSignal(state, SnapshotRecovered(TypedSnapshotMetadata.fromClassic(snap.metadata)), catchAndLog = true)
+      }
 
       setup.cancelRecoveryTimer()
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -169,16 +169,16 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
       }
 
       setup.internalLogger.debug("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
-      snapshot.foreach { snap =>
-        import akka.persistence.typed.{ SnapshotMetadata => TypedSnapshotMetadata }
-
-        setup.onSignal(state, SnapshotRecovered(TypedSnapshotMetadata.fromClassic(snap.metadata)), catchAndLog = true)
-      }
 
       setup.cancelRecoveryTimer()
 
       setup.currentSequenceNumber = seqNr
       setup.currentMetadata = metadata
+      snapshot.foreach { snap =>
+        import akka.persistence.typed.{ SnapshotMetadata => TypedSnapshotMetadata }
+
+        setup.onSignal(state, SnapshotRecovered(TypedSnapshotMetadata.fromClassic(snap.metadata)), catchAndLog = true)
+      }
 
       ReplayingEvents[C, E, S](
         setup,


### PR DESCRIPTION
In classic persistence, a `PersistentActor` knows about the snapshot retrieved, if any, by receiving (via `receiveRecover` a `SnapshotOffer`).  This can be useful for targeted observability (e.g. tracking latency for recoveries involving certain important states).

This introduces similar functionality for typed `EventSourcedBehavior`s, via a signal analogous to `RecoveryCompleted`.
