### PR TITLE
fix: Don't use Java serialization for cluster metrics

### DIFF
--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -260,13 +260,15 @@ private[metrics] trait MetricNumericConverter {
    * May involve rounding or truncation.
    */
   def convertNumber(from: Any): Either[Long, Double] = from match {
-    case n: Int        => Left(n)
-    case n: Long       => Left(n)
-    case n: Double     => Right(n)
-    case n: Float      => Right(n)
-    case n: BigInt     => Left(n.longValue)
-    case n: BigDecimal => Right(n.doubleValue)
-    case x             => throw new IllegalArgumentException(s"Not a number [$x]")
+    case n: Int                  => Left(n)
+    case n: Long                 => Left(n)
+    case n: Double               => Right(n)
+    case n: Float                => Right(n)
+    case n: BigInt               => Left(n.longValue)
+    case n: java.math.BigInteger => Left(n.longValue)
+    case n: BigDecimal           => Right(n.doubleValue)
+    case n: java.math.BigDecimal => Right(n.doubleValue)
+    case x                       => throw new IllegalArgumentException(s"Not a number [$x]")
   }
 
 }

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.cluster.metrics.protobuf
 
+import java.math.BigInteger
+
 import akka.actor.{ Address, ExtendedActorSystem }
 import akka.cluster.MemberStatus
 import akka.cluster.TestMember
@@ -52,7 +54,10 @@ class MessageSerializerSpec extends AkkaSpec("""
               Metric("bar2", Float.MaxValue, None),
               Metric("bar3", Int.MaxValue, None),
               Metric("bar4", Long.MaxValue, None),
-              Metric("bar5", BigInt(Long.MaxValue), None)))))
+              Metric("bar5", BigInt(Long.MaxValue), None),
+              Metric("bar6", new BigInteger(s"${Long.MaxValue}"), None),
+              Metric("bar7", BigDecimal.exact(s"${Long.MaxValue}.0"), None),
+              Metric("bar8", new java.math.BigDecimal(s"${Long.MaxValue}.0"), None)))))
 
       checkSerialization(MetricsGossipEnvelope(a1.address, metricsGossip, true))
 


### PR DESCRIPTION
* it was possibly used for BigDecimal and BigInteger
* might result in serialization errors during rolling update, but that should heal as soon as the rollout is completed
