### PR TITLE
fix: cancel delayed restart when remembering entities and eagerly restarting

### DIFF
--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -44,12 +44,10 @@ jobs:
           mkdir ~/.sbt
           printf "%s" "$CLOUDSMITH_MACHINE_AKKA_CREDS" > ~/.sbt/.credentials
 
-      - name: Get creds test
-        id: creds_test
-        run: echo "version=$(cat ~/.sbt/.credentials)" >> $GITHUB_OUTPUT
-        
-      - name: Creds test output
-        run: echo ${{ steps.creds_test.outputs.version }}
+      - name: Output SBT credentials
+        run: |
+          echo "Contents of ~/.sbt/.credentials:"
+          cat ~/.sbt/.credentials
 
       - name: Code style check
         run: |-

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -44,10 +44,11 @@ jobs:
           mkdir ~/.sbt
           printf "%s" "$CLOUDSMITH_MACHINE_AKKA_CREDS" > ~/.sbt/.credentials
 
-      - name: Output SBT credentials
+      - name: Use multiline output
         run: |
-          echo "Contents of ~/.sbt/.credentials:"
-          cat ~/.sbt/.credentials
+          FILE_CONTENT=$(cat ~/.sbt/.credentials)
+          echo "Here's the content of my file:"
+          echo "$FILE_CONTENT"
 
       - name: Code style check
         run: |-

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -44,12 +44,6 @@ jobs:
           mkdir ~/.sbt
           printf "%s" "$CLOUDSMITH_MACHINE_AKKA_CREDS" > ~/.sbt/.credentials
 
-      - name: Use multiline output
-        run: |
-          FILE_CONTENT=$(cat ~/.sbt/.credentials)
-          echo "Here's the content of my file:"
-          echo "$FILE_CONTENT"
-
       - name: Code style check
         run: |-
           cp .jvmopts-ci .jvmopts

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -44,6 +44,13 @@ jobs:
           mkdir ~/.sbt
           printf "%s" "$CLOUDSMITH_MACHINE_AKKA_CREDS" > ~/.sbt/.credentials
 
+      - name: Get creds test
+        id: creds_test
+        run: echo "version=$(cat ~/.sbt/.credentials)" >> $GITHUB_OUTPUT
+        
+      - name: Creds test output
+        run: echo ${{ steps.creds_test.outputs.version }}
+
       - name: Code style check
         run: |-
           cp .jvmopts-ci .jvmopts

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -404,7 +404,7 @@ class RememberEntitiesFailureSpec
 
       var sharding: ActorRef = null
       val probe = TestProbe()
-      implicit val sender = probe.ref
+      implicit val sender: ActorRef = probe.ref
 
       val spawnProbe = TestProbe()
       val props = Props[EntityActor] {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -54,6 +54,9 @@ object RememberEntitiesFailureSpec {
         context.stop(self)
       case "graceful-stop" =>
         context.parent ! ShardRegion.Passivate("stop")
+      case "incarnation" =>
+        // Don't do this at home, kids...
+        sender() ! self
       case msg => sender() ! msg
     }
   }
@@ -394,6 +397,55 @@ class RememberEntitiesFailureSpec
 
         system.stop(sharding)
       }
+    }
+
+    "neither restart entity nor crash when entity passivates after being eagerly restarted" in {
+      val shardingSettings = ClusterShardingSettings(system).withRememberEntities(true)
+
+      var sharding: ActorRef = null
+      val probe = TestProbe()
+      implicit val sender = probe.ref
+
+      val spawnProbe = TestProbe()
+      val props = Props[EntityActor] {
+        spawnProbe.ref.tell("spawned", ActorRef.noSender)
+        new EntityActor()
+      }
+
+      within(1.second) {
+        sharding = ClusterSharding(system).start(
+          "failStartPassivate",
+          props,
+          shardingSettings,
+          extractEntityId,
+          extractShardId,
+          ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 1, relativeLimit = 0.1),
+          "graceful-stop")
+
+        sharding ! EntityEnvelope(1, "incarnation")
+        spawnProbe.expectMsg("spawned")
+        var currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
+
+        probe.watch(currentIncarnation)
+        currentIncarnation ! "stop"
+        probe.expectTerminated(currentIncarnation)
+        // The restart timer is active
+        currentIncarnation = null
+
+        // restart the entity early
+        sharding ! EntityEnvelope(1, "incarnation")
+        spawnProbe.expectMsg("spawned")
+        sharding ! EntityEnvelope(1, "graceful-stop")
+        currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
+
+        probe.watch(currentIncarnation)
+        probe.expectTerminated(currentIncarnation)
+        // entity is now passivated
+
+        probe.watch(sharding)
+      }
+      spawnProbe.expectNoMessage(1.second)
+      probe.expectNoMessage(1.second)
     }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -412,38 +412,36 @@ class RememberEntitiesFailureSpec
         new EntityActor()
       }
 
-      within(1.second) {
-        sharding = ClusterSharding(system).start(
-          "failStartPassivate",
-          props,
-          shardingSettings,
-          extractEntityId,
-          extractShardId,
-          ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 1, relativeLimit = 0.1),
-          "graceful-stop")
+      sharding = ClusterSharding(system).start(
+        "failStartPassivate",
+        props,
+        shardingSettings,
+        extractEntityId,
+        extractShardId,
+        ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 1, relativeLimit = 0.1),
+        "graceful-stop")
 
-        sharding ! EntityEnvelope(1, "incarnation")
-        spawnProbe.expectMsg("spawned")
-        var currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
+      sharding ! EntityEnvelope(1, "incarnation")
+      spawnProbe.expectMsg("spawned")
+      var currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
 
-        probe.watch(currentIncarnation)
-        currentIncarnation ! "stop"
-        probe.expectTerminated(currentIncarnation)
-        // The restart timer is active
-        currentIncarnation = null
+      probe.watch(currentIncarnation)
+      currentIncarnation ! "stop"
+      probe.expectTerminated(currentIncarnation)
+      // The restart timer is active
+      currentIncarnation = null
 
-        // restart the entity early
-        sharding ! EntityEnvelope(1, "incarnation")
-        spawnProbe.expectMsg("spawned")
-        sharding ! EntityEnvelope(1, "graceful-stop")
-        currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
+      // restart the entity early
+      sharding ! EntityEnvelope(1, "incarnation")
+      spawnProbe.expectMsg("spawned")
+      sharding ! EntityEnvelope(1, "graceful-stop")
+      currentIncarnation = probe.receiveN(1).head.asInstanceOf[ActorRef]
 
-        probe.watch(currentIncarnation)
-        probe.expectTerminated(currentIncarnation)
-        // entity is now passivated
+      probe.watch(currentIncarnation)
+      probe.expectTerminated(currentIncarnation)
+      // entity is now passivated
 
-        probe.watch(sharding)
-      }
+      probe.watch(sharding)
       spawnProbe.expectNoMessage(1.second)
       probe.expectNoMessage(1.second)
     }


### PR DESCRIPTION
When remembering entities and an entity stops (read: "is observed to stop by the shard") before the shard sends the stop message (e.g. `PoisonPill`), the shard puts the entity into a `WaitingForRestart` state and schedules a `RestartTerminatedEntity` for the future.

In the meantime, a message for the entity will eagerly restart the entity: upon restart, that entity may now elect to passivate.  If it does, that entity's state in the shard and remember entities store is now "passivated".  If this happens before the `RestartTerminatedEntity` is handled, the shard is unsure about the correct course and stops the shard (stopping all active entities in said shard).

This change fixes that condition by considering the `RestartTerminatedEntity` superseded by the eager restart (as the restart is no longer needed) and thus cancels the `RestartTerminatedEntity`.