### PR TITLE
chore: remove deprecated sonatypeOssRepo

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -87,7 +87,7 @@ object AkkaBuild {
     else Seq.empty,
     // should we be allowed to use artifacts from sonatype snapshots
     if (System.getProperty("akka.build.useSnapshotSonatypeResolver", "false").toBoolean)
-      resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+      resolvers += Resolver.sonatypeCentralSnapshots
     else Seq.empty,
     pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
   )

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -85,10 +85,6 @@ object AkkaBuild {
     if (System.getProperty("akka.build.useLocalMavenResolver", "false").toBoolean)
       resolvers += mavenLocalResolver
     else Seq.empty,
-    // should we be allowed to use artifacts from sonatype snapshots
-    if (System.getProperty("akka.build.useSnapshotSonatypeResolver", "false").toBoolean)
-      resolvers += Resolver.sonatypeCentralSnapshots
-    else Seq.empty,
     pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
   )
 


### PR DESCRIPTION
That repo will be shut down in a few days, replaced with (per the annotation in sbt) `Resolver.sonatypeCentralSnapshots`