### PR TITLE
doc: include reference to lz4 in akka.serialization.jackson.compression

### DIFF
--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -161,6 +161,7 @@ akka.serialization.jackson {
     # Compression algorithm.
     # - off  : no compression
     # - gzip : using common java gzip
+    # - lz4 : using lz4-java
     algorithm = off
 
     # If compression is enabled with the `algorithm` setting the payload is compressed


### PR DESCRIPTION
If looking at the reference config, the availability of lz4 for gzip isn't clear since the only reference is when `jackson-json` overrides `compression`.  The paradox docs do mention this so it's not entirely undocumented.

Semi-related: Jackson's usage of CBOR entails writing field names as values, so for objects that have fieldNamesWhichAreParticularlyLong (not uncommon in Java), CBOR is also rather verbose (and fairly compressible once you start having collections of objects with such field names), so is it worth enabling compression by default in CBOR?