### PR TITLE
tests: Try to avoid race in EventSourcedBehaviorRetentionSpec

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -593,6 +593,12 @@ class EventSourcedBehaviorRetentionSpec
       eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 8
       deleteSnapshotSignalProbe.expectDeleteSnapshotCompleted(6)
 
+      // Work around race condition: Wait here for delete to complete (how is it not complete when we saw the signal?) or else the new snapshot
+      // is deferred.
+      // Observed in logs:
+      // "Skipping retention at seqNr [16] because previous retention has not completed yet. Next retention will cover skipped retention."
+      Thread.sleep(50)
+
       persistentActor ! Increment // 15
       persistentActor ! Increment // 16
       snapshotSignalProbe.expectSnapshotCompleted(16) // every-2 through criteria


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #32340

Not 100% sure about this, could also be an actual bug lurking here - if you said snapshot every 2, shouldn't that always happen? In this case it seems like it is skipped because the result of a delete not having come in yet.
