### PR TITLE
chore: cluster tools API doc link

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -199,11 +199,11 @@ project-info {
     ]
     api-docs: [
       {
-        url: ${project-info.scaladoc}"cluster/tools/index.html"
+        url: ${project-info.scaladoc}"cluster/index.html"
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"cluster/tools/package-summary.html"
+        url: ${project-info.javadoc}"cluster/package-summary.html"
         text: "API (Javadoc)"
       }
     ]


### PR DESCRIPTION
The link checker has been complaining for a while now...

The cluster tools don't live in the `akka.cluster.tools` package thus pointing to https://doc.akka.io/api/akka-core/2.10.8/akka/cluster/index.html instead.

```
## HTTP failure response
https://doc.akka.io/api/akka-core/2.10.8/akka/cluster/tools/index.html status 404 Not Found
 - cluster-singleton.html
 - distributed-pub-sub.html

https://doc.akka.io/japi/akka-core/2.10.8/akka/cluster/tools/package-summary.html status 404 Not Found
 - cluster-singleton.html
 - distributed-pub-sub.html
```