### PR TITLE
fix: Shard crashes in some situation with ES remember entity store

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -835,9 +835,9 @@ private[akka] class Shard(
         stash()
       case NoState =>
         if (entities.pendingRememberedEntitiesExist()) {
-          // hold off until current write completes
+          // No actor running and write in progress for some other entity id (can only happen with remember entities enabled)
           log.debug("{}: Request to start entity [{}] postponed, remember entity write in progress", typeName, entityId)
-          stash()
+          entities.rememberingStart(entityId, ackTo = ackTo)
         } else {
           // started manually from the outside, or the shard id extractor was changed since the entity was remembered
           // we need to store that it was started

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesShardStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesShardStore.scala
@@ -88,7 +88,7 @@ private[akka] final class EventSourcedRememberEntitiesShardStore(
   private val maxUpdatesPerWrite = context.system.settings.config
     .getInt("akka.cluster.sharding.event-sourced-remember-entities-store.max-updates-per-write")
 
-  log.debug("Starting up EventSourcedRememberEntitiesStore")
+  log.debug("Starting up EventSourcedRememberEntitiesStore [{}], using journal [{}]", persistenceId, journalPluginId)
   private var state = State()
   override def persistenceId = s"/sharding/${typeName}Shard/$shardId"
   override def journalPluginId: String = settings.journalPluginId

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesShardStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesShardStore.scala
@@ -90,6 +90,8 @@ private[akka] final class EventSourcedRememberEntitiesShardStore(
 
   log.debug("Starting up EventSourcedRememberEntitiesStore [{}], using journal [{}]", persistenceId, journalPluginId)
   private var state = State()
+  private val verboseDebug = context.system.settings.config.getBoolean("akka.cluster.sharding.verbose-debug-logging")
+
   override def persistenceId = s"/sharding/${typeName}Shard/$shardId"
   override def journalPluginId: String = settings.journalPluginId
   override def snapshotPluginId: String = settings.snapshotPluginId
@@ -105,6 +107,9 @@ private[akka] final class EventSourcedRememberEntitiesShardStore(
   override def receiveCommand: Receive = {
 
     case RememberEntitiesShardStore.Update(started, stopped) =>
+      if (verboseDebug)
+        log.debug("ES remember entities store asked to store started [{}] and stopped [{}]", started, stopped)
+
       val events =
         (if (started.nonEmpty) createEntityEvents(started, EntitiesStarted.apply _, maxUpdatesPerWrite) else Nil) :::
         (if (stopped.nonEmpty) createEntityEvents(stopped, EntitiesStopped.apply _, maxUpdatesPerWrite) else Nil)
@@ -114,6 +119,8 @@ private[akka] final class EventSourcedRememberEntitiesShardStore(
         left -= 1
         saveSnap = saveSnap || isSnapshotNeeded
         if (left == 0) {
+          if (verboseDebug)
+            log.debug("Persisting remembered entities update done, started [{}], stopped [{}]", started, stopped)
           sender() ! RememberEntitiesShardStore.UpdateDone(started, stopped)
           state = state.copy(state.entities.union(started).diff(stopped))
           if (saveSnap) {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2018-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.Shard.GetShardStats
+import akka.cluster.sharding.Shard.ShardStats
+import akka.cluster.sharding.ShardRegion.StartEntity
+import akka.cluster.sharding.ShardRegion.StartEntityAck
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore
+import akka.cluster.sharding.internal.RememberEntitiesShardStore
+import akka.testkit.AkkaSpec
+import akka.testkit.EventFilter
+import akka.testkit.ImplicitSender
+import akka.testkit.WithLogCapturing
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.util.UUID
+import scala.concurrent.duration._
+
+object RememberEntitiesAndStartEntityEsSpec {
+  class EntityActor extends Actor {
+    override def receive: Receive = {
+      case "give-me-shard" => sender() ! context.parent
+      case msg             => sender() ! msg
+    }
+  }
+
+  case class EntityEnvelope(entityId: Int, msg: Any)
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case EntityEnvelope(id, payload) => (id.toString, payload)
+    case msg                         => throw new IllegalArgumentException(s"Unknown message type ${msg.getClass.getName}")
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case EntityEnvelope(id, _) => (id % 10).toString
+    case StartEntity(id)       => (id.toInt % 10).toString
+    case _                     => throw new IllegalArgumentException()
+  }
+
+  val config = ConfigFactory.parseString(s"""
+      akka.loglevel=DEBUG
+      akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+      akka.actor.provider = cluster
+      akka.remote.artery.canonical.port = 0
+      akka.cluster.sharding.verbose-debug-logging = on
+      akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+      # no leaks between test runs thank you
+      akka.cluster.sharding.distributed-data.durable.keys = []
+      akka.cluster.sharding.remember-entities-store=eventsourced
+      # small batches to cover batching
+      akka.cluster.sharding.event-sourced-remember-entities-store.max-updates-per-write=3
+      akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+      akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+      akka.persistence.snapshot-store.local.dir = "target/${classOf[RememberEntitiesAndStartEntityEsSpec].getName}-${UUID
+                                              .randomUUID()
+                                              .toString}"
+    """.stripMargin)
+}
+
+// this test covers remember entities + StartEntity
+class RememberEntitiesAndStartEntityEsSpec
+    extends AkkaSpec(RememberEntitiesAndStartEntityEsSpec.config)
+    with AnyWordSpecLike
+    with ImplicitSender
+    with WithLogCapturing {
+
+  import RememberEntitiesAndStartEntityEsSpec._
+
+  override def atStartup(): Unit = {
+    // Form a one node cluster
+    val cluster = Cluster(system)
+    cluster.join(cluster.selfAddress)
+    awaitAssert(cluster.readView.members.count(_.status == MemberStatus.Up) should ===(1))
+  }
+
+  "Sharding" must {
+
+    "remember entities started with StartEntity" in {
+      val typeName = "startEntity"
+      val shardingSettings = ClusterShardingSettings(system).withRememberEntities(true)
+      val sharding =
+        ClusterSharding(system).start(typeName, Props[EntityActor](), shardingSettings, extractEntityId, extractShardId)
+
+      sharding ! StartEntity("1")
+      expectMsg(StartEntityAck("1", "1"))
+      val shard = lastSender
+
+      watch(shard)
+      shard ! PoisonPill
+      expectTerminated(shard)
+
+      // trigger shard start by messaging other actor in it
+      system.log.info("Starting shard again")
+      // race condition between this message and region getting the termination message, we may need to retry
+      val secondShardIncarnation = awaitAssert {
+        sharding ! EntityEnvelope(11, "give-me-shard")
+        expectMsgType[ActorRef](1.second) // short timeout, retry via awaitAssert
+      }
+
+      awaitAssert {
+        secondShardIncarnation ! GetShardStats
+        // the remembered 1 and 11 which we just triggered start of
+        expectMsg(1.second, ShardStats("1", 2)) // short timeout, retry via awaitAssert
+      }
+
+      EventFilter
+        .error(
+          start = "Unknown message type akka.cluster.sharding.internal.RememberEntitiesShardStore$UpdateDone",
+          occurrences = 0)
+        .intercept {
+          // start another bunch of entities (without waiting for each to complete before starting the next)
+          for (i <- 2 to 5) {
+            // mix a few StartEntity and regular startups
+            if (i % 2 == 0)
+              sharding ! StartEntity((i * 10 + 1).toString)
+            else
+              sharding ! EntityEnvelope(i * 10 + 1, "give-me-shard")
+          }
+          Thread.sleep(100)
+          for (i <- 6 to 9) {
+            // mix a few StartEntity and regular startups
+            if (i % 2 == 0)
+              sharding ! StartEntity((i * 10 + 1).toString)
+            else
+              sharding ! EntityEnvelope(i * 10 + 1, "give-me-shard")
+          }
+        }
+
+      // all started without error
+      receiveN(8)
+
+      awaitAssert {
+        secondShardIncarnation ! GetShardStats
+        // the new remembered 8 and previous 1 and 11 which we just triggered start of
+        expectMsg(1.second, ShardStats("1", 10)) // short timeout, retry via awaitAssert
+      }
+
+      Thread.sleep(200)
+
+      // check what is persisted
+
+      val store = system.actorOf(
+        EventSourcedRememberEntitiesShardStore.props(typeName, new ShardRegion.ShardId("1"), shardingSettings),
+        "dummyStore")
+      store ! RememberEntitiesShardStore.GetEntities
+      val remembered = expectMsgType[RememberEntitiesShardStore.RememberedEntities]
+      remembered.entities shouldEqual Set("1", "11", "21", "31", "41", "51", "61", "71", "81", "91")
+    }
+  }
+
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
@@ -38,7 +38,7 @@ object RememberEntitiesAndStartEntityEsSpec {
 
   val extractEntityId: ShardRegion.ExtractEntityId = {
     case EntityEnvelope(id, payload) => (id.toString, payload)
-    case msg                         => throw new IllegalArgumentException(s"Unknown message type ${msg.getClass.getName}")
+    case msg                         => throw new IllegalArgumentException(s"Unknown message type ${msg.getClass.getName} ($msg)")
   }
 
   val extractShardId: ShardRegion.ExtractShardId = {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
@@ -16,7 +16,6 @@ import akka.cluster.sharding.ShardRegion.StartEntity
 import akka.cluster.sharding.ShardRegion.StartEntityAck
 import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore
 import akka.cluster.sharding.internal.RememberEntitiesShardStore
-import akka.persistence.journal.inmem.InmemJournal
 import akka.testkit.AkkaSpec
 import akka.testkit.EventFilter
 import akka.testkit.ImplicitSender
@@ -153,6 +152,7 @@ class RememberEntitiesAndStartEntityEsSpec
       store ! RememberEntitiesShardStore.GetEntities
       val remembered = expectMsgType[RememberEntitiesShardStore.RememberedEntities]
       remembered.entities shouldEqual Set("1", "11", "21", "31", "41", "51", "61", "71", "81", "91")
+      fail()
     }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntityEsSpec.scala
@@ -152,7 +152,6 @@ class RememberEntitiesAndStartEntityEsSpec
       store ! RememberEntitiesShardStore.GetEntities
       val remembered = expectMsgType[RememberEntitiesShardStore.RememberedEntities]
       remembered.entities shouldEqual Set("1", "11", "21", "31", "41", "51", "61", "71", "81", "91")
-      fail()
     }
   }
 


### PR DESCRIPTION
Mixed entity starts from regular entity messages and StartEntity commands could lead to the shard crashing when using the eventsourced remember entities store.