### PR TITLE
fix: Java Integer in ShardRegionStats

### DIFF
--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingStatsSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingStatsSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.cluster.sharding.typed
 
+import java.util.stream.Collectors
+
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 
@@ -94,6 +96,14 @@ abstract class ClusterShardingStatsSpec
       stats.regions.size shouldEqual 3 // 3 nodes
       stats.regions.values.flatMap(_.stats.values).sum shouldEqual 2 // number of entities
       stats.regions.values.forall(_.failed.isEmpty) shouldBe true
+
+      // javadsl
+      stats
+        .getRegions()
+        .values()
+        .stream()
+        .flatMap(_.getStats().values().stream())
+        .collect(Collectors.summingInt((i: Integer) => i.intValue())) shouldEqual 2
 
       enterBarrier("done")
     }

--- a/akka-cluster-sharding/src/main/mima-filters/2.10.8.backwards.excludes/32743-unstash-by-shard.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.10.8.backwards.excludes/32743-unstash-by-shard.excludes
@@ -1,0 +1,2 @@
+# Java Integer vs Scala Int in ShardRegionStats
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.sharding.ShardRegion#ShardRegionStats.getStats")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -318,9 +318,9 @@ object ShardRegion {
     /**
      * Java API
      */
-    def getStats(): java.util.Map[ShardId, Int] = {
+    def getStats(): java.util.Map[ShardId, Integer] = {
       import scala.jdk.CollectionConverters._
-      stats.asJava
+      stats.map { case (k, v) => k -> Integer.valueOf(v) }.asJava
     }
 
     /** Java API */


### PR DESCRIPTION
* Was Map of Scala Int, which is not usable
* Might look like an incompatible change, but since it could not have been used as it was it should be fine to change

