### PR TITLE
Revert "feat: Include counter in virtual thread name"

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
@@ -65,7 +65,7 @@ class VirtualThreadDispatcherSpec extends AnyWordSpec with Matchers {
           })
           val info = threadIsVirtualProbe.expectMsgType[ThreadInfo]
           info.virtual shouldBe true
-          info.name should endWith("my-vt-dispatcher-0")
+          info.name should endWith("my-vt-dispatcher")
         } finally {
           TestKit.shutdownActorSystem(system)
         }
@@ -91,7 +91,7 @@ class VirtualThreadDispatcherSpec extends AnyWordSpec with Matchers {
           echo.tell("give-me-info", responseProbe.ref)
           val info = responseProbe.expectMsgType[ThreadInfo]
           info.virtual shouldBe true
-          info.name should include("akka.actor.default-dispatcher")
+          info.name should endWith("akka.actor.default-dispatcher")
         } finally {
           TestKit.shutdownActorSystem(system)
         }

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -39,8 +39,8 @@ private[akka] object VirtualThreadConfigurator {
     // thread names
     val ofVirtualWithName =
       if (virtualThreadName.nonEmpty) {
-        val nameMethod = ofVirtualInterface.getMethod("name", classOf[String], classOf[Long])
-        nameMethod.invoke(ofVirtual, virtualThreadName + "-", 0L)
+        val nameMethod = ofVirtualInterface.getMethod("name", classOf[String])
+        nameMethod.invoke(ofVirtual, virtualThreadName)
       } else ofVirtual
 
     // uncaught exception handler


### PR DESCRIPTION
Reverts akka/akka#32783

I realized this wasn't such a good idea after all, there is a new VT created per task executed on the dispatcher, which means a new string per task, let's leave it as it was. Thread.currentThread.threadId anyway provides a unique identifier for debugging.