### PR TITLE
fix: disable batching for vt executor

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/VirtualThreadDispatcherSpec.scala
@@ -154,10 +154,10 @@ class VirtualThreadDispatcherSpec extends AnyWordSpec with Matchers {
             threadInfoProbe.ref ! (("parent before", currentThreadId()))
             Future {
               threadInfoProbe.ref ! (("child before", currentThreadId()))
-              Thread.sleep(200)
+              Thread.sleep(300)
               threadInfoProbe.ref ! (("child after", currentThreadId()))
             }
-            Thread.sleep(20)
+            Thread.sleep(100)
             threadInfoProbe.ref ! (("parent after", currentThreadId()))
           }
           val all = threadInfoProbe.receiveN(4)

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -39,6 +39,8 @@ class Dispatcher(
 
   import configurator.prerequisites._
 
+  private val batchingEnabled = executorServiceFactoryProvider.isInstanceOf[NoBatchingExecutorFactoryProvider]
+
   private class LazyExecutorServiceDelegate(factory: ExecutorServiceFactory) extends ExecutorServiceDelegate {
     lazy val executor: ExecutorService = factory.createExecutorService
     def copy(): LazyExecutorServiceDelegate = new LazyExecutorServiceDelegate(factory)
@@ -140,6 +142,10 @@ class Dispatcher(
       } else false
     } else false
   }
+
+  override def batchable(runnable: Runnable): Boolean =
+    if (batchingEnabled) super.batchable(runnable)
+    else false
 
   override val toString: String = Logging.simpleName(this) + "[" + id + "]"
 }

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -39,7 +39,7 @@ class Dispatcher(
 
   import configurator.prerequisites._
 
-  private val batchingEnabled = executorServiceFactoryProvider.isInstanceOf[NoBatchingExecutorFactoryProvider]
+  private val batchingEnabled = !executorServiceFactoryProvider.isInstanceOf[NoBatchingExecutorFactoryProvider]
 
   private class LazyExecutorServiceDelegate(factory: ExecutorServiceFactory) extends ExecutorServiceDelegate {
     lazy val executor: ExecutorService = factory.createExecutorService

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -66,6 +66,11 @@ trait ExecutorServiceFactoryProvider {
 }
 
 /**
+ * Marker trait to disable dispatcher batching for a given executor
+ */
+trait NoBatchingExecutorFactoryProvider {}
+
+/**
  * A small configuration DSL to create ThreadPoolExecutors that can be provided as an ExecutorServiceFactoryProvider to Dispatcher
  */
 final case class ThreadPoolConfig(

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -60,9 +60,7 @@ private[akka] object VirtualThreadConfigurator {
     newThreadPerTaskMethod.invoke(null, threadFactory).asInstanceOf[ExecutorService]
   }
 
-  private class VirtualThreadExecutorServiceFactory(tf: ThreadFactory)
-      extends ExecutorServiceFactory
-      with NoBatchingExecutorFactoryProvider {
+  private class VirtualThreadExecutorServiceFactory(tf: ThreadFactory) extends ExecutorServiceFactory {
     override def createExecutorService: ExecutorService = threadPerTaskExecutor(tf)
   }
 
@@ -73,7 +71,8 @@ private[akka] object VirtualThreadConfigurator {
  */
 @InternalApi
 private[akka] class VirtualThreadConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-    extends ExecutorServiceConfigurator(config, prerequisites) {
+    extends ExecutorServiceConfigurator(config, prerequisites)
+    with NoBatchingExecutorFactoryProvider {
   import VirtualThreadConfigurator._
 
   override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {

--- a/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/VirtualThreadConfigurator.scala
@@ -60,7 +60,9 @@ private[akka] object VirtualThreadConfigurator {
     newThreadPerTaskMethod.invoke(null, threadFactory).asInstanceOf[ExecutorService]
   }
 
-  private class VirtualThreadExecutorServiceFactory(tf: ThreadFactory) extends ExecutorServiceFactory {
+  private class VirtualThreadExecutorServiceFactory(tf: ThreadFactory)
+      extends ExecutorServiceFactory
+      with NoBatchingExecutorFactoryProvider {
     override def createExecutorService: ExecutorService = threadPerTaskExecutor(tf)
   }
 


### PR DESCRIPTION
This fixes that batching in the dispatcher would cause new tasks scheduled from a virtual thread to be batched and run in the same virtual thread rather than immediately start in a separate virtual thread.