### PR TITLE
avoid double DownIndirectlyConnected when indirectly-connected is between independently-known unreachable

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/sbr/TestAddresses.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/sbr/TestAddresses.scala
@@ -46,6 +46,8 @@ object TestAddresses {
     new Member(UniqueAddress(addressA.copy(host = Some("f")), 0L), 5, Up, Set(defaultDcRole), Version.Zero)
   val memberG =
     new Member(UniqueAddress(addressA.copy(host = Some("g")), 0L), 6, Up, Set(defaultDcRole), Version.Zero)
+  val memberH =
+    new Member(UniqueAddress(addressA.copy(host = Some("h")), 0L), 7, Up, Set(defaultDcRole), Version.Zero)
 
   val memberAWeaklyUp = new Member(memberA.uniqueAddress, Int.MaxValue, WeaklyUp, memberA.roles, Version.Zero)
   val memberBWeaklyUp = new Member(memberB.uniqueAddress, Int.MaxValue, WeaklyUp, memberB.roles, Version.Zero)


### PR DESCRIPTION
Scenario:

* A marks B unreachable, gossips the observation
* clean partition putting A & B on minority side
* all nodes in majority side mark A & B unreachable
* A and B have not yet seen latest gossip from majority side
* A may or may not mark B reachable again: in any case A is unable to gossip the reachability change to the majority side

Thus A is indirectly connected (both a subject and observer of unreachability) but B is not.  SBR resolution will be `DownIndirectlyConnected` (adding A to the downing decision) and then consider a secondary decision.

In considering that decision, unreachability edges between nodes where both are in the set of observers and subjects are removed, as are all edges where both of "the subject has seen the latest gossip" and "observer has observed a subject which had seen the latest gossip" are true.  If indirectly connected nodes remain, the decision effectively becomes `DownAll`.  These nodes can only be indirectly connected by the first criterion (intersection between observers and subjects): the definition of the second criterion (unreachable but seen latest gossip) is always removed (as any observers of that subject are also indirectly connected by the second criterion).

In this scenario, the SBR on the other side from A & B will `DownAll`: all nodes on either side of the partition after this are either crashed or downed.

The double-down-indirectly-connected is safe, but it seems to be literal overkill.