### PR TITLE
feat: Java AbstractShardAllocationStrategy API should return CompletionStage

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -206,6 +206,7 @@ object ShardCoordinator {
   abstract class AbstractShardAllocationStrategy extends ShardAllocationStrategy {
     import java.util.concurrent.CompletableFuture
 
+    @nowarn("cat=deprecation") // calls deprecated allocateShard
     override final def allocateShard(
         requester: ActorRef,
         shardId: ShardId,
@@ -215,6 +216,7 @@ object ShardCoordinator {
       allocateShard(requester, shardId, currentShardAllocations.asJava)
     }
 
+    @nowarn("cat=deprecation") // calls deprecated rebalance
     override final def rebalance(
         currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],
         rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {
@@ -229,7 +231,8 @@ object ShardCoordinator {
      * The default implementation defers to [[allocateNewShard]].  In earlier versions of this API, this
      * Scala Future-returning method was the extension point.
      *
-     * New implementations of this class should prefer to override [[allocateNewShard]].
+     * New implementations of this class should prefer to override [[allocateNewShard]].  This method may be removed
+     * in a future release.
      *
      * @param requester               actor reference to the [[ShardRegion]] that requested the location of the
      *                                shard, can be returned if preference should be given to the node where the shard was first accessed
@@ -239,6 +242,7 @@ object ShardCoordinator {
      * @return a `Future` of the actor ref of the [[ShardRegion]] that is to be responsible for the shard, must be one of
      *         the references included in the `currentShardAllocations` parameter
      */
+    @deprecated("prefer allocateNewShard", "2.10.10")
     def allocateShard(
         requester: ActorRef,
         shardId: String,
@@ -276,7 +280,8 @@ object ShardCoordinator {
      * The default implementation defers to [[rebalanceShards]].  In earlier versions of this API, this
      * Scala Future-returning method was the extension point.
      *
-     * New implementations of this class should prefer to override [[rebalanceShards]].
+     * New implementations of this class should prefer to override [[rebalanceShards]].  This method may be removed in a
+     * future release
      *
      * @param currentShardAllocations all actor refs to `ShardRegion` and their current allocated shards,
      *                                in the order they were allocated
@@ -284,6 +289,7 @@ object ShardCoordinator {
      *                                you should not include these in the returned set
      * @return a `Future` of the shards to be migrated, may be empty to skip rebalance in this round
      */
+    @deprecated("prefer rebalanceShards", "2.10.10")
     def rebalance(
         currentShardAllocations: java.util.Map[ActorRef, immutable.IndexedSeq[String]],
         rebalanceInProgress: java.util.Set[String]): Future[java.util.Set[String]] = {


### PR DESCRIPTION
…and not Scala Future

Since `AbstractShardAllocationStrategy` is Java API, implementations are likely to use Java APIs which generally return `CompletionStage`s; it seems awkward to put the obligation on them to convert a `CompletionStage` into a Scala future.  This is especially suboptimal since the most apparent way someone unfamiliar with Scala futures might implement the conversion is:

```
try {
  var futureResult = javaCS.toCompletableFuture().get();
  return scala.concurrent.Future.successful(futureResult);
} catch (CompletionException ce) {
  return scala.concurrent.Future.failed(ce.getCause());
}
```

This adds CompletionStage-returning methods to the API and documents a suggestion to override the new methods.  Implementations which override only the previous methods will still work (as they would override the forwarding to a future `NotImplementedError`).