### PR TITLE
fix: Recreate state for EventSourcedBehavior with mutable state

### DIFF
--- a/akka-docs/src/main/paradox/typed/durable-state/persistence.md
+++ b/akka-docs/src/main/paradox/typed/durable-state/persistence.md
@@ -104,6 +104,21 @@ The state is typically defined as an immutable class and a new instance of the s
 You may choose to use a mutable class for the state, and then the command handler may update the state instance, but
 it must still pass the updated state to the `persist` effect.
 
+@@@ div { .group-java }
+
+If the state is mutable, it is important that the `emptyState` method creates a new State instance each time
+it is called to ensure that the state is recreated in case of failure restarts.
+
+@@@
+
+@@@ div { .group-scala }
+
+If the state is mutable, it is important to use the `DurableStateBehavior.withMutableState` factory method that
+takes `emptyStateFactory: () => State` parameter to make sure that the state instance is recreated in case of
+failure restarts.
+
+@@@
+
 More effects are explained in @ref:[Effects and Side Effects](#effects-and-side-effects).
 
 In addition to returning the primary `Effect` for the command, `DurableStateBehavior`s can also 
@@ -206,6 +221,14 @@ Scala
 
 Java
 :  @@snip [PersistentActorCompileOnlyTest.java](/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java) { #commonChainedEffects }
+
+@@@ div { .group-scala }
+
+It is recommended to use an immutable state class. If the state is mutable, it is important to use
+the `DurableStateBehavior.withEnforcedRepliesMutableState` factory method that takes `emptyStateFactory: () => State`
+parameter to make sure that the state instance is recreated in case of failure restarts.
+
+@@@
 
 ### Side effects ordering and guarantees
 

--- a/akka-docs/src/main/paradox/typed/persistence-style.md
+++ b/akka-docs/src/main/paradox/typed/persistence-style.md
@@ -69,6 +69,9 @@ The above examples are using immutable state classes and below is corresponding 
 Java
 :  @@snip [AccountExampleWithNullState.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/AccountExampleWithMutableState.java) { #account-entity }
 
+If the state is mutable, it is important that the `emptyState` method creates a new State instance each time
+it is called to ensure that the state is recreated in case of failure restarts.
+
 ## Leveraging Java 21 features
 
 When building event sourced entities in a project using Java 21 or newer, the @javadoc[EventSourcedOnCommandBehavior](akka.persistence.typed.javadsl.EventSourcedOnCommandBehavior) 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -94,6 +94,17 @@ Note that the concrete class does not contain any fields with state like a regul
 lost when the actor is stopped or restarted. Updates to the State are always performed in the eventHandler 
 based on the events.
 
+If the state is mutable, it is important that the `emptyState` method creates a new State instance each time
+it is called to ensure that the state is recreated in case of failure restarts.
+
+@@@
+
+@@@ div { .group-scala }
+
+It is recommended to use an immutable state class. If the state is mutable, it is important to use
+the `EventSourcedBehavior.withMutableState` factory method that takes `emptyStateFactory: () => State` parameter
+to make sure that the state instance is recreated in case of failure restarts.
+
 @@@
 
 Next we'll discuss each of these in detail.
@@ -452,6 +463,14 @@ is not used, but then there will be no compilation errors if the reply decision 
 
 Note that the `noReply` is a way of making conscious decision that a reply shouldn't be sent for a specific
 command or the reply will be sent later, perhaps after some asynchronous interaction with other actors or services.
+
+@@@ div { .group-scala }
+
+It is recommended to use an immutable state class. If the state is mutable, it is important to use
+the `EventSourcedBehavior.withEnforcedRepliesMutableState` factory method that takes `emptyStateFactory: () => State`
+parameter to make sure that the state instance is recreated in case of failure restarts.
+
+@@@
 
 ## Serialization
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
@@ -54,7 +54,7 @@ private[akka] object Unpersistent {
       findEventSourcedBehavior(behavior, context).fold {
         throw new AssertionError("Did not find the expected EventSourcedBehavior")
       } { esBehavior =>
-        val (initialState, initialSequenceNr) = fromStateAndSequenceNr.getOrElse(esBehavior.emptyState -> 0L)
+        val (initialState, initialSequenceNr) = fromStateAndSequenceNr.getOrElse(esBehavior.emptyState() -> 0L)
         new WrappedEventSourcedBehavior(context, esBehavior, initialState, initialSequenceNr, onEvent, onSnapshot)
       }
     }

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/Unpersistent.scala
@@ -79,7 +79,7 @@ private[akka] object Unpersistent {
       findDurableStateBehavior(behavior, context).fold {
         throw new AssertionError("Did not find the expected DurableStateBehavior")
       } { dsBehavior =>
-        val initialState = fromState.getOrElse(dsBehavior.emptyState)
+        val initialState = fromState.getOrElse(dsBehavior.emptyState())
         new WrappedDurableStateBehavior(context, dsBehavior, initialState, onPersist)
       }
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -103,7 +103,7 @@ private[akka] object EventSourcedBehaviorImpl {
 @InternalApi
 private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     persistenceId: PersistenceId,
-    emptyState: State,
+    emptyState: () => State,
     commandHandler: EventSourcedBehavior.CommandHandler[Command, Event, State],
     eventHandler: EventSourcedBehavior.EventHandler[State, Event],
     loggerClass: Class[_],
@@ -208,7 +208,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
           val eventSourcedSetup = new BehaviorSetup(
             ctx.asInstanceOf[ActorContext[InternalProtocol]],
             persistenceId,
-            emptyState,
+            emptyState(),
             commandHandler,
             eventHandler,
             WriterIdentity.newIdentity(),

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -61,6 +61,9 @@ abstract class EventSourcedBehavior[Command, Event, State] private[akka] (
    * This object will be passed into this behaviors handlers, until a new state replaces it.
    *
    * Also known as "zero state" or "neutral state".
+   *
+   * If the state is mutable, it is important that this creates a new State instance each time it is called
+   * to ensure that the state is recreated in case of failure restarts.
    */
   protected def emptyState: State
 
@@ -230,7 +233,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[akka] (
     val eventHandlerInstance = eventHandler()
     var behavior = new internal.EventSourcedBehaviorImpl[Command, Event, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       (state, cmd) => commandHandlerInstance(state, cmd).asInstanceOf[EffectImpl[Event, State]],
       eventHandlerInstance(_, _),
       getClass)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedOnCommandBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedOnCommandBehavior.scala
@@ -67,6 +67,9 @@ abstract class EventSourcedOnCommandBehavior[Command, Event, State](
    * This object will be passed into this behaviors handlers, until a new state replaces it.
    *
    * Also known as "zero state" or "neutral state".
+   *
+   * If the state is mutable, it is important that this creates a new State instance each time it is called
+   * to ensure that the state is recreated in case of failure restarts.
    */
   protected def emptyState: State
 
@@ -217,7 +220,7 @@ abstract class EventSourcedOnCommandBehavior[Command, Event, State](
 
     var behavior = new internal.EventSourcedBehaviorImpl[Command, Event, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       (state, cmd) => this.onCommand(state, cmd).asInstanceOf[EffectImpl[Event, State]],
       this.onEvent,
       getClass)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedOnCommandWithReplyBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedOnCommandWithReplyBehavior.scala
@@ -69,6 +69,9 @@ abstract class EventSourcedOnCommandWithReplyBehavior[Command, Event, State](
    * This object will be passed into this behaviors handlers, until a new state replaces it.
    *
    * Also known as "zero state" or "neutral state".
+   *
+   * If the state is mutable, it is important that this creates a new State instance each time it is called
+   * to ensure that the state is recreated in case of failure restarts.
    */
   protected def emptyState: State
 
@@ -219,7 +222,7 @@ abstract class EventSourcedOnCommandWithReplyBehavior[Command, Event, State](
 
     var behavior = new internal.EventSourcedBehaviorImpl[Command, Event, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       (state, cmd) => this.onCommand(state, cmd).asInstanceOf[EffectImpl[Event, State]],
       this.onEvent,
       getClass)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -44,7 +44,7 @@ private[akka] object DurableStateBehaviorImpl {
 @InternalApi
 private[akka] final case class DurableStateBehaviorImpl[Command, State](
     persistenceId: PersistenceId,
-    emptyState: State,
+    emptyState: () => State,
     commandHandler: DurableStateBehavior.CommandHandler[Command, State],
     loggerClass: Class[_],
     durableStateStorePluginId: Option[String] = None,
@@ -101,7 +101,7 @@ private[akka] final case class DurableStateBehaviorImpl[Command, State](
           val durableStateSetup = new BehaviorSetup(
             ctx.asInstanceOf[ActorContext[InternalProtocol]],
             persistenceId,
-            emptyState,
+            emptyState(),
             commandHandler,
             actualSignalHandler,
             tag,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -64,6 +64,9 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
    * This object will be passed into this behaviors handlers, until a new state replaces it.
    *
    * Also known as "zero state" or "neutral state".
+   *
+   * If the state is mutable, it is important that this creates a new State instance each time it is called
+   * to ensure that the state is recreated in case of failure restarts.
    */
   protected def emptyState: State
 
@@ -137,7 +140,7 @@ abstract class DurableStateBehavior[Command, State] private[akka] (
 
     val behavior = new internal.DurableStateBehaviorImpl[Command, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       (state, cmd) => commandHandler()(state, cmd).asInstanceOf[EffectImpl[State]],
       getClass).withTag(tag).snapshotAdapter(snapshotAdapter()).withDurableStateStorePluginId(durableStateStorePluginId)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateOnCommandBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateOnCommandBehavior.scala
@@ -131,7 +131,7 @@ abstract class DurableStateOnCommandBehavior[Command, State] private[akka] (
 
     val behavior = new internal.DurableStateBehaviorImpl[Command, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       onCommand(_, _).asInstanceOf[EffectImpl[State]],
       getClass).withTag(tag).snapshotAdapter(snapshotAdapter()).withDurableStateStorePluginId(durableStateStorePluginId)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateOnCommandWithReplyBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateOnCommandWithReplyBehavior.scala
@@ -133,7 +133,7 @@ abstract class DurableStateOnCommandWithReplyBehavior[Command, State] private[ak
 
     val behavior = new internal.DurableStateBehaviorImpl[Command, State](
       persistenceId,
-      emptyState,
+      () => emptyState,
       onCommand(_, _).asInstanceOf[EffectImpl[State]],
       getClass).withTag(tag).snapshotAdapter(snapshotAdapter()).withDurableStateStorePluginId(durableStateStorePluginId)
 


### PR DESCRIPTION
* in case of failure restarts the state instance must be recreated if the state is mutable
* no changes in javadsl, but emptyState method is called also for restarts, inside Behavior.setup
* added factory methods for mutable state in scaladsl, but with Scala it should be more natural to use immutable state
