### PR TITLE
fix: Avoid start of ShardedDaemonProcess for old revision

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessCoordinator.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessCoordinator.scala
@@ -306,11 +306,16 @@ private final class ShardedDaemonProcessCoordinator private (
       case ShardStopped(shard) =>
         val newShardsStillRunning = shardsStillRunning - shard
         if (newShardsStillRunning.isEmpty) {
+          context.log.info(
+            "{}: All shards stopped. Continue rescaling of Sharded Daemon Process to [{}] processes, rev [{}]",
+            daemonProcessName,
+            state.numberOfProcesses,
+            state.revision)
           timers.cancel(ShardStopTimeout)
           rescalingComplete(state, request)
         } else waitForShardsStopping(state, request, previousNumberOfProcesses, newShardsStillRunning)
       case ShardStopTimeout =>
-        context.log.debug("{}: Stopping shards timed out after [{}] retrying", daemonProcessName, stopShardsTimeout)
+        context.log.info("{}: Stopping shards timed out after [{}] retrying", daemonProcessName, stopShardsTimeout)
         stopAllShards(state, request, previousNumberOfProcesses)
     }
   }


### PR DESCRIPTION
* when rescaling the revision is bumped, and all previous processes are stopped
* if a keep-alive message is in flight that can trigger a new start of a process that belongs to the previous revision, because the revision check was using local read consistency
* change to use same consistency as the ShardedDaemonProcessCoordinator
