### PR TITLE
chore: Keep actor ref with backpressure around until last ack arrives

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
@@ -84,7 +84,7 @@ import akka.stream.stage._
       }
 
       override def onUpstreamFinish(): Unit = {
-        if (buffer.isEmpty) finish()
+        if (buffer.isEmpty && acknowledgementReceived) finish()
         else completeReceived = true
       }
 


### PR DESCRIPTION
Avoids annoying dead letter logs when stream completes with empty buffer.