### PR TITLE
doc: Java configuration block in "Extending Akka"

### DIFF
--- a/akka-docs/src/main/paradox/typed/extending.md
+++ b/akka-docs/src/main/paradox/typed/extending.md
@@ -68,13 +68,13 @@ Scala
 :  @@snip [ExtensionDocSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala) { #config }
 
 Java
-:  @@@ vars
-   ```ruby
-   akka.actor.typed {
-     extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
-   }
-   ```
-   @@@
+:  @@@vars
+```ruby
+akka.actor.typed {
+  extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
+}
+```
+@@@
      
 
 

--- a/akka-docs/src/main/paradox/typed/extending.md
+++ b/akka-docs/src/main/paradox/typed/extending.md
@@ -68,12 +68,13 @@ Scala
 :  @@snip [ExtensionDocSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala) { #config }
 
 Java
-:  @@ vars
+:  @@@ vars
    ```ruby
    akka.actor.typed {
      extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
    }
    ```
+   @@@
      
 
 

--- a/akka-docs/src/main/paradox/typed/extending.md
+++ b/akka-docs/src/main/paradox/typed/extending.md
@@ -68,7 +68,8 @@ Scala
 :  @@snip [ExtensionDocSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala) { #config }
 
 Java
-:   ```
+:  @@ vars
+   ```
    akka.actor.typed {
      extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
    }

--- a/akka-docs/src/main/paradox/typed/extending.md
+++ b/akka-docs/src/main/paradox/typed/extending.md
@@ -69,7 +69,7 @@ Scala
 
 Java
 :  @@ vars
-   ```
+   ```ruby
    akka.actor.typed {
      extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
    }

--- a/akka-docs/src/main/paradox/typed/extending.md
+++ b/akka-docs/src/main/paradox/typed/extending.md
@@ -68,7 +68,7 @@ Scala
 :  @@snip [ExtensionDocSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala) { #config }
 
 Java
-:   ```ruby
+:   ```
    akka.actor.typed {
      extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"]
    }


### PR DESCRIPTION
Kind of weird that this renders as

```
ruby akka.actor.typed { extensions = ["jdocs.akka.extensions.ExtensionDocTest$DatabaseConnectionPool$Id"] }
```

I assume it's some breaking change in paradox that crept in, but in lieu of actually tracking that down, giving up syntax coloring in exchange for having something copy-pasteable seems like the next best thing for now.