### PR TITLE
Update lz4-java dependency version to 1.10.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,7 @@ object Dependencies {
     val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonCoreVersion // ApacheV2
     val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonCoreVersion // ApacheV2
     val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonCoreVersion // ApacheV2
-    val lz4Java = "at.yawk.lz4" % "lz4-java" % "1.10.0" // ApacheV2
+    val lz4Java = "at.yawk.lz4" % "lz4-java" % "1.10.2" // ApacheV2
 
     val logback = "ch.qos.logback" % "logback-classic" % logbackVersion // EPL 1.0
   }


### PR DESCRIPTION
Version 1.10.1 contains a fix to CVE-2025-66566!, but 1.10.2 is the latest one

