### PR TITLE
feat: eager "pre-resolution" of shard homes

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -313,6 +313,12 @@ import akka.util.{ ByteString, Timeout }
     }
   }
 
+  def preResolveShard[M, E](entity: scaladsl.Entity[M, E], shard: String): Unit =
+    classicSharding.preResolveShard(entity.typeKey.name, shard)
+
+  def preResolveShard[M, E](entity: javadsl.Entity[M, E], shard: String): Unit =
+    classicSharding.preResolveShard(entity.typeKey.name, shard)
+
   override lazy val shardState: ActorRef[ClusterShardingQuery] = {
     import akka.actor.typed.scaladsl.adapter._
     val behavior = ShardingState.behavior(classicSharding)

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -313,10 +313,10 @@ import akka.util.{ ByteString, Timeout }
     }
   }
 
-  def preResolveShard[M, E](entity: scaladsl.Entity[M, E], shard: String): Unit =
+  override def preResolveShard[M, E](entity: scaladsl.Entity[M, E], shard: String): Unit =
     classicSharding.preResolveShard(entity.typeKey.name, shard)
 
-  def preResolveShard[M, E](entity: javadsl.Entity[M, E], shard: String): Unit =
+  override def preResolveShard[M, E](entity: javadsl.Entity[M, E], shard: String): Unit =
     classicSharding.preResolveShard(entity.typeKey.name, shard)
 
   override lazy val shardState: ActorRef[ClusterShardingQuery] = {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -225,6 +225,13 @@ abstract class ClusterSharding {
    * The default `ShardAllocationStrategy` is configured by `least-shard-allocation-strategy` properties.
    */
   def defaultShardAllocationStrategy(settings: ClusterShardingSettings): ShardAllocationStrategy
+
+  /**
+   * Direct the shard region or proxy actor for the given entity to resolve the location of the given shard
+   * and cache it.  This may result in the shard being allocated on some node in the cluster.  No message will
+   * be sent to any entity within the shard.
+   */
+  def preResolveShard[M, E](entity: Entity[M, E], shard: String): Unit
 }
 
 object Entity {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -232,6 +232,12 @@ trait ClusterSharding extends Extension { javadslSelf: javadsl.ClusterSharding =
    */
   @InternalApi private[akka] def asJava: javadsl.ClusterSharding = javadslSelf
 
+  /**
+   * Direct the shard region or proxy actor for the given entity to resolve the location of the given shard
+   * and cache it.  This may result in the shard being allocated on some node in the cluster.  No message will
+   * be sent to any entity within the shard.
+   */
+  def preResolveShard[M, E](entity: Entity[M, E], shard: String): Unit
 }
 
 object Entity {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -650,6 +650,16 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
   }
 
   /**
+   * Direct the [[ShardRegion]] actor responsible for the named entity type to resolve the location
+   * of the given shard and cache it.  If the `ShardRegion` already knows the location, it will not do anything,
+   * otherwise it will request the home of the shard, which may result in the shard being allocated on
+   * some node in the cluster.  No message will be sent to any entity within the shard.
+   */
+  def preResolveShard(typeName: String, shard: ShardRegion.ShardId): Unit = {
+    shardRegion(typeName) ! ShardRegion.ResolveShard(shard)
+  }
+
+  /**
    * Retrieve the actor reference of the [[ShardRegion]] actor that will act as a proxy to the
    * named entity type running in another data center. A proxy within the same data center can be accessed
    * with [[#shardRegion]] instead of this method. The entity type must be registered with the


### PR DESCRIPTION
During a rolling restart, shard regions are typically stopped, culminating in (ideally) the shard coordinator stopping and handing off to the next oldest node, as new shard regions start.  While the new shard regions do get the homes of the existing shards en masse from the coordinator at registration, shards which get stopped later only get recreated on demand (assuming remember entities isn't in use, which is not always advisable).

Assuming that the demand to recreate shards arises organically, the process of waiting for the shard coordinator to successfully write to ddata introduces some extra latency into the hot path to service that demand.

Applications can of course synthesize demand, but in the typical case (where the entity to shard mapping is based on hash code of entity ID) finding an entity ID for each shard adds a bit of complexity, especially if the goal is for the entity associated with that ID to not require an attempt to rehydrate from persistence.

This change instead allows cluster nodes to signal their local shard region that a shard home should be located (and if necessary allocated) without sending a message to any entity.