### PR TITLE
feat: add self-healing mechanism for the shard state

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.10.16.backwards.excludes/self-healing.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.10.16.backwards.excludes/self-healing.excludes
@@ -1,0 +1,4 @@
+# Self-healing settings added to ClusterShardingSettings constructor
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ClusterShardingSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ClusterShardingSettings.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ClusterShardingSettings.copy$default$*")

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -466,6 +466,39 @@ akka.cluster.sharding {
     # coordinator for that entity type.
     disabled-after = 10s
   }
+
+  # Self-healing configuration for automatic shard state cleanup when cluster coordination is impaired.
+  # When enabled, shards allocated to regions that have been unreachable beyond a configurable threshold
+  # will be automatically deallocated, enabling graceful degradation and recovery.
+  self-healing {
+    # Enable/disable the self-healing mechanism.
+    # When enabled, shards from regions that have been unreachable beyond the
+    # stale-region-timeout will be automatically deallocated and can be reallocated
+    # to healthy regions.
+    enabled = off
+
+    # Time threshold after which an unreachable region's shards are considered stale
+    # and will be deallocated. This should be longer than expected network hiccups
+    # but shorter than manual intervention time.
+    # Recommended: At least 2x the failure-detector acceptable-heartbeat-pause (default 3s).
+    stale-region-timeout = 30s
+
+    # How often to check for stale regions.
+    # This interval controls the resolution of the timeout detection.
+    # Smaller values detect staleness faster but add more CPU overhead.
+    check-interval = 5s
+
+    # Grace period after coordinator startup before self-healing activates.
+    # This prevents premature cleanup during cluster formation when nodes
+    # may be temporarily unreachable as they join.
+    startup-grace-period = 60s
+
+    # Whether to only log warnings instead of actually deallocating shards.
+    # Useful for testing/monitoring the self-healing behavior before enabling
+    # full automatic cleanup. When enabled, logs what would be deallocated
+    # without actually performing the deallocation.
+    dry-run = off
+  }
 }
 # //#sharding-ext-config
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingCoordinatorSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingCoordinatorSpec.scala
@@ -1,0 +1,506 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.io.File
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.testkit.{ AkkaSpec, EventFilter, TestProbe, WithLogCapturing }
+
+object SelfHealingCoordinatorSpec {
+
+  val baseConfig = ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.actor.provider = "cluster"
+    akka.remote.artery.canonical.hostname = "127.0.0.1"
+    akka.remote.artery.canonical.port = 0
+    akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+    akka.cluster.jmx.enabled = off
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingCoordinatorSpec/sharding-ddata"
+      map-size = 10 MiB
+    }
+  """)
+
+  val enabledConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = off
+    }
+  """).withFallback(baseConfig)
+
+  val disabledConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = off
+    }
+  """).withFallback(baseConfig)
+
+  val dryRunConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = on
+    }
+  """).withFallback(baseConfig)
+
+  val longGracePeriodConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 60s
+      dry-run = off
+    }
+  """).withFallback(baseConfig)
+
+  val zeroGracePeriodConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 0s
+      dry-run = off
+    }
+  """).withFallback(baseConfig)
+
+  val shardTypeName = "TestEntity"
+  val numberOfShards = 10
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: String => (msg, msg)
+    case _           => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: String                 => (math.abs(msg.hashCode) % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (math.abs(id.hashCode) % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class TestEntity extends Actor {
+    override def receive: Receive = {
+      case msg => sender() ! s"received: $msg"
+    }
+  }
+}
+
+// === Timer Scheduling Tests ===
+
+class SelfHealingCoordinatorTimerEnabledSpec
+    extends AkkaSpec(SelfHealingCoordinatorSpec.enabledConfig)
+    with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing timer when enabled" must {
+
+    "schedule SelfHealingTick timer at check-interval" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      // Starting sharding will start the coordinator which schedules the timer
+      // We verify the timer is running by checking logs
+      EventFilter.info(pattern = "Self-healing enabled with.*", occurrences = 1).intercept {
+        startSharding(system)
+      }
+    }
+  }
+}
+
+class SelfHealingCoordinatorTimerDisabledSpec
+    extends AkkaSpec(SelfHealingCoordinatorSpec.disabledConfig)
+    with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing timer when disabled" must {
+
+    "not schedule SelfHealingTick timer" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      // When disabled, the self-healing enabled log should NOT appear
+      EventFilter.info(pattern = "Self-healing enabled with.*", occurrences = 0).intercept {
+        startSharding(system)
+        // Give some time for logs that shouldn't appear
+        Thread.sleep(500)
+      }
+    }
+  }
+}
+
+// === Grace Period Tests ===
+
+class SelfHealingCoordinatorGracePeriodSpec
+    extends AkkaSpec(SelfHealingCoordinatorSpec.longGracePeriodConfig)
+    with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing during grace period" must {
+
+    "skip self-healing check and log debug message" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create an entity to ensure sharding is active
+      region.tell("test-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity")
+
+      // Since grace period is 60s, self-healing should be skipped
+      // and debug log should appear (at least one occurrence with 500ms intervals)
+      EventFilter.debug(pattern = ".*Self-healing skipped.*within startup grace period.*").intercept {
+        // Wait for at least one tick (500ms check interval)
+        Thread.sleep(1000)
+      }
+    }
+  }
+}
+
+class SelfHealingCoordinatorZeroGracePeriodSpec
+    extends AkkaSpec(SelfHealingCoordinatorSpec.zeroGracePeriodConfig)
+    with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with zero grace period" must {
+
+    "activate immediately without grace period delay" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create an entity to ensure sharding is active
+      region.tell("test-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity")
+
+      // With zero grace period, the "skipped" message should NOT appear
+      // (unless there are no unreachable regions to process)
+      EventFilter.debug(pattern = ".*Self-healing skipped.*within startup grace period.*", occurrences = 0).intercept {
+        // Wait for ticks to run
+        Thread.sleep(1500)
+      }
+    }
+  }
+}
+
+// === Dry Run Mode Tests ===
+
+class SelfHealingCoordinatorDryRunSpec extends AkkaSpec(SelfHealingCoordinatorSpec.dryRunConfig) with WithLogCapturing {
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  "Self-healing in dry-run mode" must {
+
+    "be configured with dryRun=true" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.dryRun shouldBe true
+    }
+  }
+}
+
+// === Main Coordinator Spec - Multi-node simulation ===
+
+class SelfHealingCoordinatorSpec extends AkkaSpec(SelfHealingCoordinatorSpec.enabledConfig) with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing coordinator" must {
+
+    "have self-healing enabled with correct configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 2.seconds
+      settings.selfHealingSettings.checkInterval shouldBe 500.millis
+      settings.selfHealingSettings.startupGracePeriod shouldBe 1.second
+      settings.selfHealingSettings.dryRun shouldBe false
+    }
+
+    "initialize cluster and start sharding successfully" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Send messages to create entities
+      region.tell("entity-1", probe.ref)
+      probe.expectMsg(5.seconds, "received: entity-1")
+
+      region.tell("entity-2", probe.ref)
+      probe.expectMsg(5.seconds, "received: entity-2")
+    }
+
+    "track shards correctly" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create multiple entities across different shards
+      (1 to 5).foreach { i =>
+        region.tell(s"entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: entity-$i")
+      }
+
+      // Verify shards are allocated
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+    }
+  }
+}
+
+// === Multi-ActorSystem Tests for Unreachability ===
+
+class SelfHealingCoordinatorMultiNodeSpec
+    extends AkkaSpec(SelfHealingCoordinatorSpec.enabledConfig)
+    with WithLogCapturing {
+
+  import SelfHealingCoordinatorSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  // Create second actor system for multi-node testing
+  val sys2Config = ConfigFactory.parseString("""
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingCoordinatorSpec2/sharding-ddata"
+    }
+  """).withFallback(SelfHealingCoordinatorSpec.enabledConfig)
+
+  lazy val sys2: ActorSystem = ActorSystem(system.name, sys2Config)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+    val sys2Storage = new File("target/SelfHealingCoordinatorSpec2")
+    if (sys2Storage.exists) FileUtils.deleteQuietly(sys2Storage)
+  }
+
+  override protected def beforeTermination(): Unit = {
+    if (sys2 != null && !sys2.whenTerminated.isCompleted) {
+      shutdown(sys2)
+    }
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+    val sys2Storage = new File("target/SelfHealingCoordinatorSpec2")
+    if (sys2Storage.exists) FileUtils.deleteQuietly(sys2Storage)
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing coordinator with multiple nodes" must {
+
+    "form cluster with two nodes" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+
+      within(15.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+          Cluster(sys2).state.members.size shouldEqual 2
+          Cluster(sys2).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+    }
+
+    "distribute shards across nodes" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(15.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      startSharding(sys2) // Start on second node as well
+
+      val probe = TestProbe()
+
+      // Create entities to distribute shards
+      (1 to 10).foreach { i =>
+        region1.tell(s"entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: entity-$i")
+      }
+
+      // Verify shards exist
+      region1.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+    }
+
+    "handle member registration and clear self-healing tracking" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(15.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      val region2 = startSharding(sys2)
+
+      val probe = TestProbe()
+
+      // Create some entities
+      region1.tell("test-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity")
+
+      // Verify normal operation continues
+      region2.tell("another-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: another-entity")
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingEdgeCasesSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingEdgeCasesSpec.scala
@@ -1,0 +1,660 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.io.File
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.testkit.{ AkkaSpec, EventFilter, TestProbe, WithLogCapturing }
+
+object SelfHealingEdgeCasesSpec {
+
+  val baseConfig = ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.actor.provider = "cluster"
+    akka.remote.artery.canonical.hostname = "127.0.0.1"
+    akka.remote.artery.canonical.port = 0
+    akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+    akka.cluster.jmx.enabled = off
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingEdgeCasesSpec/sharding-ddata"
+      map-size = 10 MiB
+    }
+  """)
+
+  // Very short timeout configuration
+  val veryShortTimeoutConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 100ms
+      check-interval = 50ms
+      startup-grace-period = 100ms
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingVeryShortTimeoutSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  // Very long grace period
+  val veryLongGracePeriodConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 10m
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingLongGracePeriodSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  // Zero grace period
+  val zeroGracePeriodConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 0s
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingZeroGracePeriodSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  // High check interval
+  val highCheckIntervalConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 60s
+      startup-grace-period = 1s
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingHighCheckIntervalSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  // Single node configuration
+  val singleNodeConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingSingleNodeSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  // Standard configuration for most tests
+  val standardConfig = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = off
+    }
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingEdgeCasesStandardSpec/sharding-ddata"
+    }
+  """).withFallback(baseConfig)
+
+  val shardTypeName = "EdgeCaseEntity"
+  val numberOfShards = 10
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: String => (msg, msg)
+    case _           => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: String                 => (math.abs(msg.hashCode) % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (math.abs(id.hashCode) % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class TestEntity extends Actor {
+    override def receive: Receive = {
+      case msg => sender() ! s"received: $msg"
+    }
+  }
+}
+
+// === Very Short Timeout Tests ===
+
+class SelfHealingVeryShortTimeoutSpec
+    extends AkkaSpec(SelfHealingEdgeCasesSpec.veryShortTimeoutConfig)
+    with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with very short timeout (100ms)" must {
+
+    "have correct configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 100.millis
+      settings.selfHealingSettings.checkInterval shouldBe 50.millis
+      settings.selfHealingSettings.startupGracePeriod shouldBe 100.millis
+    }
+
+    "operate normally with very short timeouts" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Normal operation should work even with aggressive timeouts
+      region.tell("short-timeout-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: short-timeout-entity")
+    }
+
+    "handle rapid check intervals without issues" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create multiple entities to exercise the system
+      (1 to 10).foreach { i =>
+        region.tell(s"rapid-entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: rapid-entity-$i")
+      }
+
+      // Wait for several check cycles to complete
+      Thread.sleep(500)
+
+      // System should still be operational
+      region.tell("after-cycles-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: after-cycles-entity")
+    }
+  }
+}
+
+// === Very Long Grace Period Tests ===
+
+class SelfHealingVeryLongGracePeriodSpec
+    extends AkkaSpec(SelfHealingEdgeCasesSpec.veryLongGracePeriodConfig)
+    with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with very long grace period (10 minutes)" must {
+
+    "have correct configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.startupGracePeriod shouldBe 10.minutes
+    }
+
+    "skip self-healing during the long grace period" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("long-grace-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: long-grace-entity")
+
+      // Verify that grace period skip message appears (at least one with 500ms intervals)
+      EventFilter.debug(pattern = ".*Self-healing skipped.*within startup grace period.*").intercept {
+        Thread.sleep(1000)
+      }
+    }
+
+    "still allow normal sharding operations during grace period" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      (1 to 10).foreach { i =>
+        region.tell(s"grace-entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: grace-entity-$i")
+      }
+    }
+  }
+}
+
+// === Zero Grace Period Tests ===
+
+class SelfHealingZeroGracePeriodSpec
+    extends AkkaSpec(SelfHealingEdgeCasesSpec.zeroGracePeriodConfig)
+    with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with zero grace period" must {
+
+    "have correct configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.startupGracePeriod shouldBe Duration.Zero
+    }
+
+    "activate immediately without waiting" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("zero-grace-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: zero-grace-entity")
+
+      // Should NOT see the "skipped - within startup grace period" message
+      EventFilter.debug(pattern = ".*Self-healing skipped.*within startup grace period.*", occurrences = 0).intercept {
+        Thread.sleep(1000)
+      }
+    }
+  }
+}
+
+// === High Check Interval Tests ===
+
+class SelfHealingHighCheckIntervalSpec
+    extends AkkaSpec(SelfHealingEdgeCasesSpec.highCheckIntervalConfig)
+    with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with high check interval (60 seconds)" must {
+
+    "have correct configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.checkInterval shouldBe 60.seconds
+    }
+
+    "operate normally with infrequent checks" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("high-interval-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: high-interval-entity")
+    }
+  }
+}
+
+// === Single Node (Empty Cluster) Tests ===
+
+class SelfHealingSingleNodeSpec extends AkkaSpec(SelfHealingEdgeCasesSpec.singleNodeConfig) with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing on single node (no other regions to heal)" must {
+
+    "operate without errors when there are no other regions" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create entities on single node
+      (1 to 10).foreach { i =>
+        region.tell(s"single-node-entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: single-node-entity-$i")
+      }
+
+      // Wait for self-healing checks to run (should be no-ops)
+      Thread.sleep(2000)
+
+      // System should still be operational
+      region.tell("after-checks-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: after-checks-entity")
+    }
+
+    "not emit any self-healing warnings in single-node mode" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("test-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity")
+
+      // No self-healing warnings should appear (no unreachable regions)
+      EventFilter.warning(pattern = ".*Self-healing.*deallocat.*", occurrences = 0).intercept {
+        Thread.sleep(3000) // Wait longer than stale-region-timeout
+      }
+    }
+  }
+}
+
+// === Standard Edge Cases Tests ===
+
+class SelfHealingEdgeCasesSpec extends AkkaSpec(SelfHealingEdgeCasesSpec.standardConfig) with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile,
+    new File("target/SelfHealingEdgeCasesSpec2"))
+
+  lazy val sys2Config = ConfigFactory.parseString("""
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingEdgeCasesSpec2/sharding-ddata"
+    }
+  """).withFallback(standardConfig)
+
+  lazy val sys2: ActorSystem = ActorSystem(system.name, sys2Config)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def beforeTermination(): Unit = {
+    if (sys2 != null && !sys2.whenTerminated.isCompleted) {
+      shutdown(sys2)
+    }
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing edge cases" must {
+
+    "have standard configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 2.seconds
+      settings.selfHealingSettings.checkInterval shouldBe 500.millis
+      settings.selfHealingSettings.startupGracePeriod shouldBe 1.second
+      settings.selfHealingSettings.dryRun shouldBe false
+    }
+
+    "handle rapid entity creation without issues" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Rapid entity creation
+      (1 to 100).foreach { i =>
+        region.tell(s"rapid-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: rapid-$i")
+      }
+    }
+
+    "handle entities spread across all shards" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create entities that hit all shards (using sequential IDs)
+      (0 until numberOfShards).foreach { shardId =>
+        // Find an entity ID that maps to this shard
+        val entityId = s"shard-$shardId-entity"
+        region.tell(entityId, probe.ref)
+        probe.expectMsg(5.seconds, s"received: $entityId")
+      }
+
+      // Verify all shards have entities
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+    }
+
+    "handle graceful cluster operations" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      startSharding(sys2) // Start on second node
+      val probe1 = TestProbe()(system)
+
+      // Create entities
+      (1 to 10).foreach { i =>
+        region1.tell(s"graceful-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: graceful-$i")
+      }
+
+      // Have node 2 leave gracefully
+      Cluster(sys2).leave(Cluster(sys2).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 1
+        }
+      }
+
+      // Verify entities still accessible after graceful leave
+      region1.tell("graceful-1", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: graceful-1")
+    }
+
+    "handle multiple entity accesses during self-healing check cycles" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Wait for grace period to pass
+      Thread.sleep(1500)
+
+      // Now perform multiple operations during active self-healing check cycles
+      (1 to 50).foreach { i =>
+        region.tell(s"during-checks-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: during-checks-$i")
+        if (i % 10 == 0) Thread.sleep(100) // Allow check cycles to run
+      }
+    }
+  }
+}
+
+// === Concurrent Operations Tests ===
+
+class SelfHealingConcurrentOperationsSpec
+    extends AkkaSpec(SelfHealingEdgeCasesSpec.standardConfig)
+    with WithLogCapturing {
+
+  import SelfHealingEdgeCasesSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with concurrent operations" must {
+
+    "handle concurrent message sending" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+
+      // Create multiple probes for concurrent access
+      val probes = (1 to 5).map(_ => TestProbe())
+
+      // Send messages concurrently
+      probes.zipWithIndex.foreach {
+        case (probe, idx) =>
+          region.tell(s"concurrent-$idx", probe.ref)
+      }
+
+      // All should succeed
+      probes.zipWithIndex.foreach {
+        case (probe, idx) =>
+          probe.expectMsg(10.seconds, s"received: concurrent-$idx")
+      }
+    }
+
+    "handle rapid sequential access to same entity" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Rapid access to same entity
+      (1 to 50).foreach { _ =>
+        region.tell("same-entity", probe.ref)
+        probe.expectMsg(5.seconds, "received: same-entity")
+      }
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingIntegrationSpec.scala
@@ -1,0 +1,462 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.io.File
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.testkit.{ AkkaSpec, TestProbe, WithLogCapturing }
+
+object SelfHealingIntegrationSpec {
+
+  val config = ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.actor.provider = "cluster"
+    akka.remote.artery.canonical.hostname = "127.0.0.1"
+    akka.remote.artery.canonical.port = 0
+    akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+    akka.cluster.testkit.auto-down-unreachable-after = 5s
+    akka.cluster.jmx.enabled = off
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingIntegrationSpec/sharding-ddata"
+      map-size = 10 MiB
+    }
+
+    # Enable self-healing with short timeouts for testing
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 3s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = off
+    }
+  """)
+
+  val configDryRun = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing.dry-run = on
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingIntegrationDryRunSpec/sharding-ddata"
+    }
+  """).withFallback(config)
+
+  val shardTypeName = "IntegrationTestEntity"
+  val numberOfShards = 10
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: String => (msg, msg)
+    case _           => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: String                 => (math.abs(msg.hashCode) % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (math.abs(id.hashCode) % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class TestEntity extends Actor {
+    override def receive: Receive = {
+      case msg => sender() ! s"received: $msg"
+    }
+  }
+
+  def configForNode(nodeNum: Int): com.typesafe.config.Config = {
+    ConfigFactory.parseString(s"""
+      akka.cluster.sharding.distributed-data.durable.lmdb {
+        dir = "target/SelfHealingIntegrationSpec$nodeNum/sharding-ddata"
+      }
+    """).withFallback(config)
+  }
+}
+
+class SelfHealingIntegrationSpec extends AkkaSpec(SelfHealingIntegrationSpec.config) with WithLogCapturing {
+
+  import SelfHealingIntegrationSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile,
+    new File("target/SelfHealingIntegrationSpec2"),
+    new File("target/SelfHealingIntegrationSpec3"))
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing integration" must {
+
+    "form cluster with self-healing enabled and verify configuration" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 3.seconds
+      settings.selfHealingSettings.checkInterval shouldBe 500.millis
+      settings.selfHealingSettings.startupGracePeriod shouldBe 1.second
+      settings.selfHealingSettings.dryRun shouldBe false
+    }
+
+    "start single-node cluster and allocate shards" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create entities across multiple shards
+      (1 to 10).foreach { i =>
+        region.tell(s"entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: entity-$i")
+      }
+
+      // Verify shards are allocated
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+      state.shards.size should be > 0
+    }
+
+    "route messages correctly after cluster formation" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Send messages to same entity multiple times
+      region.tell("consistent-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: consistent-entity")
+
+      region.tell("consistent-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: consistent-entity")
+
+      // Different entities
+      region.tell("another-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: another-entity")
+    }
+  }
+}
+
+class SelfHealingIntegrationMultiNodeSpec extends AkkaSpec(SelfHealingIntegrationSpec.config) with WithLogCapturing {
+
+  import SelfHealingIntegrationSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile,
+    new File("target/SelfHealingIntegrationSpec2"))
+
+  // Create second actor system
+  lazy val sys2: ActorSystem = ActorSystem(system.name, configForNode(2))
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def beforeTermination(): Unit = {
+    if (sys2 != null && !sys2.whenTerminated.isCompleted) {
+      shutdown(sys2)
+    }
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with multiple nodes" must {
+
+    "form two-node cluster with self-healing enabled" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+          Cluster(sys2).state.members.size shouldEqual 2
+          Cluster(sys2).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      // Verify self-healing is enabled on both nodes
+      ClusterShardingSettings(system).selfHealingSettings.enabled shouldBe true
+      ClusterShardingSettings(sys2).selfHealingSettings.enabled shouldBe true
+    }
+
+    "allocate shards across both nodes" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      val region2 = startSharding(sys2)
+
+      val probe1 = TestProbe()(system)
+      val probe2 = TestProbe()(sys2)
+
+      // Create multiple entities to spread across shards
+      (1 to 20).foreach { i =>
+        region1.tell(s"entity-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: entity-$i")
+      }
+
+      // Verify from the other node
+      region2.tell("cross-node-test", probe2.ref)
+      probe2.expectMsg(10.seconds, "received: cross-node-test")
+    }
+
+    "continue operation when second node joins after sharding started" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      // Start sharding on first node
+      val region1 = startSharding(system)
+      val probe1 = TestProbe()(system)
+
+      // Create some entities
+      (1 to 5).foreach { i =>
+        region1.tell(s"early-entity-$i", probe1.ref)
+        probe1.expectMsg(5.seconds, s"received: early-entity-$i")
+      }
+
+      // Now join second node
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      // Start sharding on second node
+      val region2 = startSharding(sys2)
+      val probe2 = TestProbe()(sys2)
+
+      // Verify existing entities still work
+      region1.tell("early-entity-1", probe1.ref)
+      probe1.expectMsg(5.seconds, "received: early-entity-1")
+
+      // Verify new entities work from both nodes
+      region2.tell("late-entity", probe2.ref)
+      probe2.expectMsg(10.seconds, "received: late-entity")
+    }
+  }
+}
+
+class SelfHealingIntegrationThreeNodeSpec extends AkkaSpec(SelfHealingIntegrationSpec.config) with WithLogCapturing {
+
+  import SelfHealingIntegrationSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile,
+    new File("target/SelfHealingIntegrationSpec2"),
+    new File("target/SelfHealingIntegrationSpec3"))
+
+  lazy val sys2: ActorSystem = ActorSystem(system.name, configForNode(2))
+  lazy val sys3: ActorSystem = ActorSystem(system.name, configForNode(3))
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def beforeTermination(): Unit = {
+    if (sys2 != null && !sys2.whenTerminated.isCompleted) shutdown(sys2)
+    if (sys3 != null && !sys3.whenTerminated.isCompleted) shutdown(sys3)
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with three nodes" must {
+
+    "form three-node cluster successfully" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      Cluster(sys3).join(Cluster(system).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 3
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+    }
+
+    "distribute shards across three nodes and handle messaging" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      Cluster(sys3).join(Cluster(system).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 3
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      val region2 = startSharding(sys2)
+      val region3 = startSharding(sys3)
+
+      val probe1 = TestProbe()(system)
+      val probe2 = TestProbe()(sys2)
+      val probe3 = TestProbe()(sys3)
+
+      // Create entities from different nodes
+      (1 to 10).foreach { i =>
+        region1.tell(s"from-node1-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: from-node1-$i")
+      }
+
+      (1 to 10).foreach { i =>
+        region2.tell(s"from-node2-$i", probe2.ref)
+        probe2.expectMsg(10.seconds, s"received: from-node2-$i")
+      }
+
+      (1 to 10).foreach { i =>
+        region3.tell(s"from-node3-$i", probe3.ref)
+        probe3.expectMsg(10.seconds, s"received: from-node3-$i")
+      }
+
+      // Cross-node access
+      region1.tell("from-node2-1", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: from-node2-1")
+    }
+
+    "handle node leaving gracefully" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      Cluster(sys3).join(Cluster(system).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 3
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      startSharding(sys2) // Start on second node
+      startSharding(sys3) // Start on third node
+
+      val probe1 = TestProbe()(system)
+
+      // Create some entities
+      (1 to 5).foreach { i =>
+        region1.tell(s"entity-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: entity-$i")
+      }
+
+      // Have node 3 leave gracefully
+      Cluster(sys3).leave(Cluster(sys3).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+        }
+      }
+
+      // Verify remaining nodes still work
+      region1.tell("after-leave-entity", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: after-leave-entity")
+    }
+  }
+}
+
+class SelfHealingIntegrationDryRunSpec extends AkkaSpec(SelfHealingIntegrationSpec.configDryRun) with WithLogCapturing {
+
+  import SelfHealingIntegrationSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing in dry-run mode integration" must {
+
+    "be configured with dry-run enabled" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.dryRun shouldBe true
+    }
+
+    "still allow normal sharding operations" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("dry-run-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: dry-run-entity")
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingSettingsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingSettingsSpec.scala
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import akka.actor.ActorSystem
+import akka.cluster.sharding.ClusterShardingSettings.SelfHealingSettings
+import akka.testkit.{ AkkaSpec, TestKit }
+
+class SelfHealingSettingsSpec extends AnyWordSpec with Matchers {
+
+  def settings(conf: String): ClusterShardingSettings = {
+    val config = ConfigFactory.parseString(conf).withFallback(AkkaSpec.testConf)
+    val system = ActorSystem("SelfHealingSettingsSpec", config)
+    val clusterShardingSettings = ClusterShardingSettings(system)
+    TestKit.shutdownActorSystem(system)
+    clusterShardingSettings
+  }
+
+  val defaultSettings: ClusterShardingSettings = settings(conf = "")
+
+  "SelfHealingSettings" must {
+
+    // === Default Values Tests ===
+
+    "be disabled by default" in {
+      defaultSettings.selfHealingSettings.enabled shouldBe false
+    }
+
+    "have correct default values when disabled" in {
+      val sh = defaultSettings.selfHealingSettings
+      sh.staleRegionTimeout shouldBe 30.seconds
+      sh.checkInterval shouldBe 5.seconds
+      sh.startupGracePeriod shouldBe 60.seconds
+      sh.dryRun shouldBe false
+    }
+
+    // === HOCON Configuration Tests ===
+
+    "allow enabling self-healing via config" in {
+      settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+        }
+      """).selfHealingSettings.enabled shouldBe true
+    }
+
+    "allow configuring stale-region-timeout" in {
+      settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+          stale-region-timeout = 45s
+        }
+      """).selfHealingSettings.staleRegionTimeout shouldBe 45.seconds
+    }
+
+    "allow configuring check-interval" in {
+      settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+          check-interval = 10s
+        }
+      """).selfHealingSettings.checkInterval shouldBe 10.seconds
+    }
+
+    "allow configuring startup-grace-period" in {
+      settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+          startup-grace-period = 120s
+        }
+      """).selfHealingSettings.startupGracePeriod shouldBe 120.seconds
+    }
+
+    "allow configuring dry-run mode" in {
+      settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+          dry-run = on
+        }
+      """).selfHealingSettings.dryRun shouldBe true
+    }
+
+    "allow configuring all settings together" in {
+      val sh = settings("""
+        akka.cluster.sharding.self-healing {
+          enabled = on
+          stale-region-timeout = 60s
+          check-interval = 10s
+          startup-grace-period = 90s
+          dry-run = on
+        }
+      """).selfHealingSettings
+
+      sh.enabled shouldBe true
+      sh.staleRegionTimeout shouldBe 60.seconds
+      sh.checkInterval shouldBe 10.seconds
+      sh.startupGracePeriod shouldBe 90.seconds
+      sh.dryRun shouldBe true
+    }
+
+    // === Programmatic Configuration Tests ===
+
+    "provide a disabled instance via SelfHealingSettings.disabled" in {
+      val sh = SelfHealingSettings.disabled
+      sh.enabled shouldBe false
+      sh.staleRegionTimeout shouldBe 30.seconds
+      sh.checkInterval shouldBe 5.seconds
+      sh.startupGracePeriod shouldBe 60.seconds
+      sh.dryRun shouldBe false
+    }
+
+    "support programmatic configuration via withEnabled" in {
+      val sh = SelfHealingSettings.disabled.withEnabled(true)
+      sh.enabled shouldBe true
+    }
+
+    "support programmatic configuration via withStaleRegionTimeout" in {
+      val sh = SelfHealingSettings.disabled.withStaleRegionTimeout(45.seconds)
+      sh.staleRegionTimeout shouldBe 45.seconds
+    }
+
+    "support programmatic configuration via withCheckInterval" in {
+      val sh = SelfHealingSettings.disabled.withCheckInterval(15.seconds)
+      sh.checkInterval shouldBe 15.seconds
+    }
+
+    "support programmatic configuration via withStartupGracePeriod" in {
+      val sh = SelfHealingSettings.disabled.withStartupGracePeriod(90.seconds)
+      sh.startupGracePeriod shouldBe 90.seconds
+    }
+
+    "support programmatic configuration via withDryRun" in {
+      val sh = SelfHealingSettings.disabled.withDryRun(true)
+      sh.dryRun shouldBe true
+    }
+
+    "support chaining multiple programmatic configurations" in {
+      val sh = SelfHealingSettings.disabled
+        .withEnabled(true)
+        .withStaleRegionTimeout(45.seconds)
+        .withCheckInterval(10.seconds)
+        .withStartupGracePeriod(120.seconds)
+        .withDryRun(true)
+
+      sh.enabled shouldBe true
+      sh.staleRegionTimeout shouldBe 45.seconds
+      sh.checkInterval shouldBe 10.seconds
+      sh.startupGracePeriod shouldBe 120.seconds
+      sh.dryRun shouldBe true
+    }
+
+    // === Java Duration Support Tests ===
+
+    "support Java Duration for programmatic configuration" in {
+      val sh = SelfHealingSettings.disabled
+        .withStaleRegionTimeout(java.time.Duration.ofSeconds(45))
+        .withCheckInterval(java.time.Duration.ofSeconds(10))
+        .withStartupGracePeriod(java.time.Duration.ofMinutes(2))
+
+      sh.staleRegionTimeout shouldBe 45.seconds
+      sh.checkInterval shouldBe 10.seconds
+      sh.startupGracePeriod shouldBe 2.minutes
+    }
+
+    "support Java Duration for stale-region-timeout" in {
+      val sh = SelfHealingSettings.disabled.withStaleRegionTimeout(java.time.Duration.ofMinutes(1))
+      sh.staleRegionTimeout shouldBe 1.minute
+    }
+
+    "support Java Duration for check-interval" in {
+      val sh = SelfHealingSettings.disabled.withCheckInterval(java.time.Duration.ofMillis(500))
+      sh.checkInterval shouldBe 500.millis
+    }
+
+    "support Java Duration for startup-grace-period" in {
+      val sh = SelfHealingSettings.disabled.withStartupGracePeriod(java.time.Duration.ofSeconds(30))
+      sh.startupGracePeriod shouldBe 30.seconds
+    }
+
+    // === Validation Tests ===
+
+    "reject stale-region-timeout <= 0" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        SelfHealingSettings.disabled.withStaleRegionTimeout(Duration.Zero)
+      }
+    }
+
+    "reject negative stale-region-timeout" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        SelfHealingSettings.disabled.withStaleRegionTimeout(-1.second)
+      }
+    }
+
+    "reject check-interval <= 0" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        SelfHealingSettings.disabled.withCheckInterval(Duration.Zero)
+      }
+    }
+
+    "reject negative check-interval" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        SelfHealingSettings.disabled.withCheckInterval(-1.second)
+      }
+    }
+
+    "reject startup-grace-period < 0" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        SelfHealingSettings.disabled.withStartupGracePeriod(-1.second)
+      }
+    }
+
+    "allow startup-grace-period = 0" in {
+      val sh = SelfHealingSettings.disabled.withStartupGracePeriod(Duration.Zero)
+      sh.startupGracePeriod shouldBe Duration.Zero
+    }
+
+    // === toString Tests ===
+
+    "provide meaningful toString" in {
+      val sh = SelfHealingSettings.disabled
+      sh.toString should include("enabled=false")
+      sh.toString should include("staleRegionTimeout=")
+      sh.toString should include("dryRun=false")
+    }
+
+    "include all fields in toString for enabled settings" in {
+      val sh = SelfHealingSettings.disabled
+        .withEnabled(true)
+        .withStaleRegionTimeout(45.seconds)
+        .withCheckInterval(10.seconds)
+        .withStartupGracePeriod(90.seconds)
+        .withDryRun(true)
+
+      val str = sh.toString
+      str should include("enabled=true")
+      str should include("staleRegionTimeout=")
+      str should include("checkInterval=")
+      str should include("startupGracePeriod=")
+      str should include("dryRun=true")
+    }
+
+    // === ClusterShardingSettings Integration Tests ===
+
+    "be accessible from ClusterShardingSettings via withSelfHealingSettings" in {
+      val customSelfHealing = SelfHealingSettings.disabled.withEnabled(true).withStaleRegionTimeout(45.seconds)
+
+      val shardingSettings = defaultSettings.withSelfHealingSettings(customSelfHealing)
+      shardingSettings.selfHealingSettings.enabled shouldBe true
+      shardingSettings.selfHealingSettings.staleRegionTimeout shouldBe 45.seconds
+    }
+
+    "preserve other settings when updating selfHealingSettings" in {
+      val customSelfHealing = SelfHealingSettings.disabled.withEnabled(true)
+      val originalSettings = defaultSettings
+      val updatedSettings = originalSettings.withSelfHealingSettings(customSelfHealing)
+
+      // Self-healing should be updated
+      updatedSettings.selfHealingSettings.enabled shouldBe true
+
+      // Other settings should remain unchanged
+      updatedSettings.role shouldBe originalSettings.role
+      updatedSettings.rememberEntities shouldBe originalSettings.rememberEntities
+    }
+
+    "return new instance when using withSelfHealingSettings" in {
+      val customSelfHealing = SelfHealingSettings.disabled.withEnabled(true)
+      val original = defaultSettings
+      val updated = original.withSelfHealingSettings(customSelfHealing)
+
+      original.selfHealingSettings.enabled shouldBe false
+      updated.selfHealingSettings.enabled shouldBe true
+      original should not be theSameInstanceAs(updated)
+    }
+
+    "return new instance when using programmatic with* methods" in {
+      val original = SelfHealingSettings.disabled
+      val updated = original.withEnabled(true)
+
+      original.enabled shouldBe false
+      updated.enabled shouldBe true
+      original should not be theSameInstanceAs(updated)
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SelfHealingSpec.scala
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.io.File
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.testkit.{ AkkaSpec, EventFilter, TestProbe, WithLogCapturing }
+
+object SelfHealingSpec {
+  val commonConfig = ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.actor.provider = "cluster"
+    akka.remote.artery.canonical.hostname = "127.0.0.1"
+    akka.remote.artery.canonical.port = 0
+    akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+    akka.cluster.testkit.auto-down-unreachable-after = 5s
+    akka.cluster.jmx.enabled = off
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingSpec/sharding-ddata"
+      map-size = 10 MiB
+    }
+  """)
+
+  val config = ConfigFactory.parseString("""
+    # Enable self-healing with short timeouts for testing
+    akka.cluster.sharding.self-healing {
+      enabled = on
+      stale-region-timeout = 2s
+      check-interval = 500ms
+      startup-grace-period = 1s
+      dry-run = off
+    }
+  """).withFallback(commonConfig)
+
+  val configDryRun = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing.dry-run = on
+  """).withFallback(config)
+
+  val configDisabled = ConfigFactory.parseString("""
+    akka.cluster.sharding.self-healing.enabled = off
+  """).withFallback(commonConfig)
+
+  val shardTypeName = "TestEntity"
+  val numberOfShards = 10
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: String => (msg, msg)
+    case _           => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: String                 => (math.abs(msg.hashCode) % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (math.abs(id.hashCode) % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class TestEntity extends Actor {
+    override def receive: Receive = {
+      case msg => sender() ! s"received: $msg"
+    }
+  }
+}
+
+class SelfHealingSpec extends AkkaSpec(SelfHealingSpec.config) with WithLogCapturing {
+
+  import SelfHealingSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing mechanism" must {
+
+    "be enabled when configured" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 2.seconds
+      settings.selfHealingSettings.checkInterval shouldBe 500.millis
+      settings.selfHealingSettings.startupGracePeriod shouldBe 1.second
+    }
+
+    "initialize cluster and sharding successfully with self-healing enabled" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Send a message to create an entity
+      region.tell("test-entity-1", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity-1")
+
+      // Verify the shard is allocated
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+    }
+
+    "allocate shards across multiple entities" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create multiple entities
+      (1 to 10).foreach { i =>
+        region.tell(s"entity-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: entity-$i")
+      }
+
+      // Verify shards are allocated
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards.size should be > 0
+    }
+
+    "route messages to correct entities consistently" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Send message to same entity multiple times
+      region.tell("consistent-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: consistent-entity")
+
+      region.tell("consistent-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: consistent-entity")
+
+      region.tell("consistent-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: consistent-entity")
+    }
+
+  }
+}
+
+class SelfHealingDryRunSpec extends AkkaSpec(SelfHealingSpec.configDryRun) with WithLogCapturing {
+
+  import SelfHealingSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing dry-run mode" must {
+
+    "be enabled when configured" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe true
+      settings.selfHealingSettings.dryRun shouldBe true
+    }
+
+    "allow normal sharding operations in dry-run mode" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      region.tell("dry-run-entity", probe.ref)
+      probe.expectMsg(5.seconds, "received: dry-run-entity")
+    }
+
+    "not deallocate shards in dry-run mode" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Create entities
+      (1 to 5).foreach { i =>
+        region.tell(s"dry-run-$i", probe.ref)
+        probe.expectMsg(5.seconds, s"received: dry-run-$i")
+      }
+
+      // Verify all entities are still accessible
+      region.tell(ShardRegion.GetShardRegionState, probe.ref)
+      val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState](5.seconds)
+      state.shards should not be empty
+    }
+  }
+}
+
+class SelfHealingDisabledSpec extends AkkaSpec(SelfHealingSpec.configDisabled) with WithLogCapturing {
+
+  import SelfHealingSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing when disabled" must {
+
+    "not be enabled" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.enabled shouldBe false
+    }
+
+    "still allow normal sharding operations" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      val region = startSharding(system)
+      val probe = TestProbe()
+
+      // Send a message to create an entity
+      region.tell("test-entity-disabled", probe.ref)
+      probe.expectMsg(5.seconds, "received: test-entity-disabled")
+    }
+
+    "not log self-healing enabled message on startup" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+
+      // When disabled, no self-healing log should appear
+      EventFilter.info(pattern = ".*Self-healing enabled.*", occurrences = 0).intercept {
+        startSharding(system)
+        // Give some time for logs to appear (they shouldn't)
+        Thread.sleep(500)
+      }
+    }
+
+    "have correct default values when disabled" in {
+      val settings = ClusterShardingSettings(system)
+      settings.selfHealingSettings.staleRegionTimeout shouldBe 30.seconds
+      settings.selfHealingSettings.checkInterval shouldBe 5.seconds
+      settings.selfHealingSettings.startupGracePeriod shouldBe 60.seconds
+      settings.selfHealingSettings.dryRun shouldBe false
+    }
+  }
+}
+
+// === Multi-Node Self-Healing Test ===
+
+class SelfHealingMultiNodeSpec extends AkkaSpec(SelfHealingSpec.config) with WithLogCapturing {
+
+  import SelfHealingSpec._
+
+  val storageLocations = List(
+    new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile,
+    new File("target/SelfHealingSpec2"))
+
+  val sys2Config = ConfigFactory.parseString("""
+    akka.cluster.sharding.distributed-data.durable.lmdb {
+      dir = "target/SelfHealingSpec2/sharding-ddata"
+    }
+  """).withFallback(config)
+
+  lazy val sys2: ActorSystem = ActorSystem(system.name, sys2Config)
+
+  override protected def atStartup(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  override protected def beforeTermination(): Unit = {
+    if (sys2 != null && !sys2.whenTerminated.isCompleted) {
+      shutdown(sys2)
+    }
+  }
+
+  override protected def afterTermination(): Unit = {
+    storageLocations.foreach(dir => if (dir.exists) FileUtils.deleteQuietly(dir))
+  }
+
+  def startSharding(sys: ActorSystem): ActorRef = {
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[TestEntity](),
+      ClusterShardingSettings(sys),
+      extractEntityId,
+      extractShardId)
+  }
+
+  "Self-healing with multiple nodes" must {
+
+    "form a two-node cluster with self-healing enabled" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+          Cluster(sys2).state.members.size shouldEqual 2
+        }
+      }
+    }
+
+    "distribute shards across nodes" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      val region2 = startSharding(sys2)
+
+      val probe1 = TestProbe()(system)
+      val probe2 = TestProbe()(sys2)
+
+      // Create entities from both nodes
+      (1 to 10).foreach { i =>
+        region1.tell(s"from-node1-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: from-node1-$i")
+      }
+
+      (1 to 10).foreach { i =>
+        region2.tell(s"from-node2-$i", probe2.ref)
+        probe2.expectMsg(10.seconds, s"received: from-node2-$i")
+      }
+    }
+
+    "route messages correctly between nodes" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      val region2 = startSharding(sys2)
+
+      val probe1 = TestProbe()(system)
+
+      // Create entity from node 1
+      region1.tell("cross-node-entity", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: cross-node-entity")
+
+      // Access same entity from node 2
+      val probe2 = TestProbe()(sys2)
+      region2.tell("cross-node-entity", probe2.ref)
+      probe2.expectMsg(10.seconds, "received: cross-node-entity")
+    }
+
+    "continue operation after graceful node leave" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 10.seconds)
+
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(20.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 2
+          Cluster(system).state.members.forall(_.status == MemberStatus.Up) shouldBe true
+        }
+      }
+
+      val region1 = startSharding(system)
+      startSharding(sys2) // Start on second node as well
+
+      val probe1 = TestProbe()(system)
+
+      // Create some entities
+      (1 to 5).foreach { i =>
+        region1.tell(s"before-leave-$i", probe1.ref)
+        probe1.expectMsg(10.seconds, s"received: before-leave-$i")
+      }
+
+      // Have node 2 leave gracefully
+      Cluster(sys2).leave(Cluster(sys2).selfAddress)
+
+      within(30.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.size shouldEqual 1
+        }
+      }
+
+      // Verify entities still accessible from remaining node
+      region1.tell("before-leave-1", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: before-leave-1")
+
+      // Create new entities
+      region1.tell("after-leave-entity", probe1.ref)
+      probe1.expectMsg(10.seconds, "received: after-leave-entity")
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR introduces a self-healing mechanism to Akka Cluster Sharding that automatically detects and removes stale shard state when cluster coordination is impaired. This feature allows shards hosted on unreachable regions to be recovered and reallocated without waiting for the node to be fully downed or removed from the cluster.

### Problem
When a node hosting shard regions becomes unreachable (but not yet downed), shards remain assigned to that region. Messages destined for those shards are buffered indefinitely until the node is manually downed or handled by a Split Brain Resolver. This latency significantly degrades system availability during network partitions or partial failures.

### Changes
- Reachability Tracking: The ShardCoordinator now tracks when regions become unreachable via UnreachableMember events.
- Periodic Cleanup: A periodic check (SelfHealingTick) identifies regions that have been unreachable for longer than a configured threshold.
- Safe Deallocation: Shards on stale regions are proactively deallocated (triggering ShardHomeDeallocated), allowing them to be reallocated to reachable nodes.
- Configuration: Added akka.cluster.sharding.self-healing settings to control the behavior.

```conf
akka.cluster.sharding.self-healing {
  enabled = off              # Opt-in
  stale-region-timeout = 30s # Threshold for stale regions
  check-interval = 5s        # Frequency of checks
  startup-grace-period = 60s # Grace period on coordinator startup
  dry-run = off              # Log-only mode for safety testing
}
```