### PR TITLE
Prioritized `Terminated` Message Handling in Akka Cluster Sharding Coordinator

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -254,14 +254,14 @@ class ActorWithStashSpec extends AkkaSpec with DefaultTimeout with BeforeAndAfte
     }
 
     "drop self.tell(Terminated) because terminatedQueued was already cleared" in {
-      val actor = system.actorOf(Props(new SelfTellTerminatedActor(testActor)))
+      system.actorOf(Props(new SelfTellTerminatedActor(testActor)))
       expectMsg("first")
       // The re-sent Terminated via self.tell is dropped — "second" never arrives
       expectNoMessage(3.seconds)
     }
 
     "re-deliver stashAtHead Terminated because unstashAll re-adds to terminatedQueued" in {
-      val actor = system.actorOf(Props(new StashAtHeadRedeliveryActor(testActor)))
+      system.actorOf(Props(new StashAtHeadRedeliveryActor(testActor)))
       expectMsg("first")
       // Unlike self.tell, stashAtHead/unstashAll goes through enqueueFirst which
       // calls terminatedQueuedFor. So the Terminated IS re-delivered.

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -88,6 +88,53 @@ object ActorWithStashSpec {
   }
 
   /**
+   * Proves that self.tell(Terminated) is silently dropped by DeathWatch.
+   * On first delivery, DeathWatch removes the ref from terminatedQueued.
+   * The re-sent Terminated finds nothing in terminatedQueued and is ignored.
+   */
+  class SelfTellTerminatedActor(probe: ActorRef) extends Actor {
+    val watched = context.watch(context.actorOf(Props[WatchedActor]()))
+    var alreadyReceived = false
+
+    context.stop(watched)
+
+    def receive = {
+      case t @ Terminated(`watched`) =>
+        if (!alreadyReceived) {
+          alreadyReceived = true
+          probe ! "first"
+          self.tell(t, ActorRef.noSender)
+        } else {
+          probe ! "second"
+        }
+    }
+  }
+
+  /**
+   * Counterpart to SelfTellTerminatedActor that uses stashAtHead/unstashAll instead of self.tell.
+   * The stash mechanism calls enqueueFirst which re-adds the ref to terminatedQueued,
+   * so the Terminated is delivered again. Probe receives "first" AND "second".
+   */
+  class StashAtHeadRedeliveryActor(probe: ActorRef) extends Actor with Stash {
+    val watched = context.watch(context.actorOf(Props[WatchedActor]()))
+    var alreadyReceived = false
+
+    context.stop(watched)
+
+    def receive = {
+      case Terminated(`watched`) =>
+        if (!alreadyReceived) {
+          alreadyReceived = true
+          probe ! "first"
+          stashAtHead()
+          unstashAll()
+        } else {
+          probe ! "second"
+        }
+    }
+  }
+
+  /**
    * Proves that stashAtHead() delivers Terminated before normally-stashed messages.
    * Receives "normal" -> stash() (appended to tail), then Terminated -> stashAtHead()
    * (prepended to head). After unstashAll(), Terminated is processed first.
@@ -204,6 +251,21 @@ class ActorWithStashSpec extends AkkaSpec with DefaultTimeout with BeforeAndAfte
       system.actorOf(Props(classOf[TerminatedMessageStashingActor], testActor))
       expectMsg("terminated")
       expectMsg("terminated")
+    }
+
+    "drop self.tell(Terminated) because terminatedQueued was already cleared" in {
+      val actor = system.actorOf(Props(new SelfTellTerminatedActor(testActor)))
+      expectMsg("first")
+      // The re-sent Terminated via self.tell is dropped — "second" never arrives
+      expectNoMessage(3.seconds)
+    }
+
+    "re-deliver stashAtHead Terminated because unstashAll re-adds to terminatedQueued" in {
+      val actor = system.actorOf(Props(new StashAtHeadRedeliveryActor(testActor)))
+      expectMsg("first")
+      // Unlike self.tell, stashAtHead/unstashAll goes through enqueueFirst which
+      // calls terminatedQueuedFor. So the Terminated IS re-delivered.
+      expectMsg("second")
     }
 
     "deliver stashAtHead messages before normally-stashed messages after unstashAll" in {

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -188,6 +188,7 @@ private[akka] trait StashSupport {
    * This allows priority handling of certain messages (e.g., `Terminated`)
    * while still going through the stash mechanism's correct `terminatedQueuedFor` handling.
    */
+  @InternalApi
   private[akka] def stashAtHead(): Unit = {
     val currMsg = actorCell.currentMessage
     if (theStash.nonEmpty && (currMsg eq theStash.head))

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -181,6 +181,24 @@ private[akka] trait StashSupport {
   }
 
   /**
+   * INTERNAL API.
+   *
+   * Adds the current message to the head of the actor's stash (instead of the tail).
+   * When `unstashAll()` is called, messages at the head are processed first.
+   * This allows priority handling of certain messages (e.g., `Terminated`)
+   * while still going through the stash mechanism's correct `terminatedQueuedFor` handling.
+   */
+  private[akka] def stashAtHead(): Unit = {
+    val currMsg = actorCell.currentMessage
+    if (theStash.nonEmpty && (currMsg eq theStash.head))
+      throw new IllegalStateException(s"Can't stash the same message $currMsg more than once")
+    if (capacity <= 0 || theStash.size < capacity) theStash = currMsg +: theStash
+    else
+      throw new StashOverflowException(
+        s"Couldn't enqueue message ${currMsg.message.getClass.getName} from ${currMsg.sender} to stash of $self")
+  }
+
+  /**
    * Prepends `others` to this stash. This method is optimized for a large stash and
    * small `others`.
    */

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1893,6 +1893,12 @@ private[akka] class DDataShardCoordinator(
       if (!handleGetShardHome(shard))
         stashGetShardHomeRequest(sender(), g) // must wait for update that is in progress
 
+    case Terminated(ref) if state.regions.get(ref).fold(0)(_.size) > 0 =>
+      // Stash at head so Terminated is processed before any other message.
+      // This ensures region termination is handled with priority
+      // while still going through the stash mechanism's correct terminatedQueuedFor handling.
+      stashAtHead()
+
     case ShardCoordinator.Internal.Terminate =>
       log.debug("{}: The ShardCoordinator received termination message while waiting for update", typeName)
       terminating = true

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DDataCoordinatorTerminatedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DDataCoordinatorTerminatedSpec.scala
@@ -274,7 +274,7 @@ class DDataCoordinatorTerminatedSpec extends AkkaSpec(DDataCoordinatorTerminated
       Set(evt1.region, evt2.region) should ===(Set(regionA.ref, regionB.ref))
     }
 
-    "handle Terminated for region with zero shards via normal stash" in
+    "handle Terminated for region with zero shards via stashAtHead" in
     withFixture(regionCount = 2) { (f, regions) =>
       val Fixture(coordinator, replicatorProbe, strategy) = f
       val regionA = regions(0)
@@ -289,7 +289,7 @@ class DDataCoordinatorTerminatedSpec extends AkkaSpec(DDataCoordinatorTerminated
       coordinator.tell(GetShardHome("s2"), s2Probe.ref)
       val pendingUpdate = interceptNextUpdate(replicatorProbe)
 
-      // Kill regionB (0 shards) -> stashed at tail (not head)
+      // Kill regionB (0 shards) -> stashed at head (known region)
       stopAndWaitForTerminated(regionB.ref)
 
       // Complete s2 -> Terminated(regionB) unstashed

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DDataCoordinatorTerminatedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DDataCoordinatorTerminatedSpec.scala
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor._
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.ddata.LWWRegister
+import akka.cluster.ddata.LWWRegisterKey
+import akka.cluster.ddata.Replicator._
+import akka.cluster.sharding.ShardCoordinator.Internal._
+import akka.cluster.sharding.ShardRegion.ShardId
+import akka.testkit._
+
+object DDataCoordinatorTerminatedSpec {
+  val config = ConfigFactory.parseString("""
+    akka.actor.provider = cluster
+    akka.remote.artery.canonical.port = 0
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.updating-state-timeout = 60s
+    akka.cluster.sharding.rebalance-interval = 120s
+    akka.cluster.sharding.shard-start-timeout = 120s
+    akka.cluster.min-nr-of-members = 1
+  """)
+
+  /**
+   * Simple allocation strategy that routes to a configurable target region.
+   * Falls back to picking the region with fewest shards.
+   */
+  class TestAllocationStrategy extends ShardCoordinator.ShardAllocationStrategy {
+    @volatile var targetRegion: Option[ActorRef] = None
+
+    override def allocateShard(
+        requester: ActorRef,
+        shardId: ShardId,
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]): Future[ActorRef] =
+      Future.successful(targetRegion.getOrElse(currentShardAllocations.minBy(_._2.size)._1))
+
+    override def rebalance(
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
+        rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] =
+      Future.successful(Set.empty)
+  }
+}
+
+/**
+ * Integration tests for DDataShardCoordinator's Terminated handling.
+ *
+ * Each test uses a mock ddata replicator (TestProbe) for full control over when
+ * ddata updates complete, allowing precise simulation of Terminated messages
+ * arriving during the waitingForUpdate state.
+ */
+class DDataCoordinatorTerminatedSpec extends AkkaSpec(DDataCoordinatorTerminatedSpec.config) with WithLogCapturing {
+
+  import DDataCoordinatorTerminatedSpec._
+
+  private type CoordinatorUpdate = Update[LWWRegister[State]]
+
+  private case class Fixture(coordinator: ActorRef, replicatorProbe: TestProbe, strategy: TestAllocationStrategy)
+
+  private var testCounter = 0
+
+  private def nextTypeName(): String = {
+    testCounter += 1
+    s"TestEntity$testCounter"
+  }
+
+  override def atStartup(): Unit = {
+    val cluster = Cluster(system)
+    cluster.join(cluster.selfAddress)
+    awaitAssert {
+      cluster.readView.members.count(_.status == MemberStatus.Up) should ===(1)
+    }
+  }
+
+  /**
+   * Create a coordinator with `regionCount` registered regions, run the test
+   * body, and stop the coordinator on exit.
+   */
+  private def withFixture(regionCount: Int)(body: (Fixture, IndexedSeq[TestProbe]) => Unit): Unit = {
+    val typeName = nextTypeName()
+    val strategy = new TestAllocationStrategy
+    val replicatorProbe = TestProbe()
+    val coordinator = system.actorOf(
+      ShardCoordinator.props(
+        typeName,
+        ClusterShardingSettings(system),
+        strategy,
+        replicatorProbe.ref,
+        majorityMinCap = 0,
+        rememberEntitiesStoreProvider = None))
+
+    // Bootstrap: respond to the initial ddata Get with empty state
+    replicatorProbe.expectMsgType[Get[_]](5.seconds)
+    replicatorProbe.reply(NotFound(LWWRegisterKey[State](s"${typeName}CoordinatorState"), None))
+    replicatorProbe.expectNoMessage(100.millis)
+
+    val regions = (1 to regionCount).map { _ =>
+      val region = TestProbe()
+      coordinator.tell(Register(region.ref), region.ref)
+      completeNextUpdate(replicatorProbe)
+      region.expectMsgType[RegisterAck](5.seconds)
+      region
+    }
+
+    try body(Fixture(coordinator, replicatorProbe, strategy), regions)
+    finally system.stop(coordinator)
+  }
+
+  /** Complete the next pending ddata Update and return the raw event. */
+  private def completeNextUpdate(replicatorProbe: TestProbe): DomainEvent = {
+    val update = replicatorProbe.expectMsgType[CoordinatorUpdate](5.seconds)
+    val evt = update.request.get.asInstanceOf[DomainEvent]
+    replicatorProbe.reply(UpdateSuccess(update.key, update.request))
+    evt
+  }
+
+  /** Complete the next pending ddata Update, assert the event type, and return it typed. */
+  private def completeNextUpdateExpecting[T <: DomainEvent: ClassTag](replicatorProbe: TestProbe): T = {
+    val evt = completeNextUpdate(replicatorProbe)
+    evt shouldBe a[T]
+    evt.asInstanceOf[T]
+  }
+
+  /** Wait for the next ddata Update without completing it. */
+  private def interceptNextUpdate(replicatorProbe: TestProbe): CoordinatorUpdate =
+    replicatorProbe.expectMsgType[CoordinatorUpdate](5.seconds)
+
+  /** Complete a previously intercepted Update. */
+  private def completeInterceptedUpdate(replicatorProbe: TestProbe, update: CoordinatorUpdate): Unit =
+    replicatorProbe.reply(UpdateSuccess(update.key, update.request))
+
+  /** Allocate a shard and complete the ddata update. */
+  private def allocateShard(coordinator: ActorRef, shardId: String, replicatorProbe: TestProbe): ShardHome = {
+    val probe = TestProbe()
+    coordinator.tell(GetShardHome(shardId), probe.ref)
+    completeNextUpdate(replicatorProbe)
+    probe.expectMsgType[ShardHome](5.seconds)
+  }
+
+  /** Stop an actor and wait for its Terminated to be dispatched to the coordinator. */
+  private def stopAndWaitForTerminated(ref: ActorRef): Unit = {
+    watch(ref)
+    system.stop(ref)
+    expectTerminated(ref, 5.seconds)
+    Thread.sleep(200) // allow DeathWatch to deliver Terminated to coordinator
+  }
+
+  /**
+   * Construct a ShardCoordinator.RebalanceDone message via reflection
+   * (it is private to the ShardCoordinator object).
+   */
+  private def createRebalanceDone(shard: String, ok: Boolean): Any = {
+    val clazz = Class.forName("akka.cluster.sharding.ShardCoordinator$RebalanceDone")
+    val ctor = clazz.getDeclaredConstructors.head
+    ctor.setAccessible(true)
+    ctor.newInstance(shard, java.lang.Boolean.valueOf(ok))
+  }
+
+  "DDataShardCoordinator Terminated handling" must {
+
+    "process Terminated during ddata update -- not silently dropped" in
+    withFixture(regionCount = 2) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+
+      // Allocate s1, s2 on regionA
+      strategy.targetRegion = Some(regionA.ref)
+      allocateShard(coordinator, "s1", replicatorProbe)
+      allocateShard(coordinator, "s2", replicatorProbe)
+
+      // Start s3 allocation on regionB -- enter waitingForUpdate
+      strategy.targetRegion = Some(regionB.ref)
+      val s3Probe = TestProbe()
+      coordinator.tell(GetShardHome("s3"), s3Probe.ref)
+      val pendingUpdate = interceptNextUpdate(replicatorProbe)
+
+      // Kill regionA while coordinator is busy with ddata
+      stopAndWaitForTerminated(regionA.ref)
+
+      // Complete s3 -> coordinator unstashes Terminated(regionA)
+      completeInterceptedUpdate(replicatorProbe, pendingUpdate)
+      s3Probe.expectMsgType[ShardHome](5.seconds)
+
+      val terminated = completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+      terminated.region should ===(regionA.ref)
+
+      // Verify s1 is re-allocated to regionB (not stuck on dead regionA)
+      strategy.targetRegion = Some(regionB.ref)
+      val verifyProbe = TestProbe()
+      coordinator.tell(GetShardHome("s1"), verifyProbe.ref)
+      val alloc = completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      alloc.region should ===(regionB.ref)
+      verifyProbe.expectMsgType[ShardHome](5.seconds).ref should ===(regionB.ref)
+    }
+
+    "give Terminated priority over stashed RebalanceDone during waitingForUpdate" in
+    withFixture(regionCount = 2) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+
+      // Allocate s1, s2 on regionA
+      strategy.targetRegion = Some(regionA.ref)
+      allocateShard(coordinator, "s1", replicatorProbe)
+      allocateShard(coordinator, "s2", replicatorProbe)
+
+      // Start s3 allocation on regionB -- enter waitingForUpdate
+      strategy.targetRegion = Some(regionB.ref)
+      val s3Probe = TestProbe()
+      coordinator.tell(GetShardHome("s3"), s3Probe.ref)
+      val pendingUpdate = interceptNextUpdate(replicatorProbe)
+
+      // RebalanceDone("s2") during waitingForUpdate -> stashed at tail
+      coordinator.tell(createRebalanceDone("s2", true), ActorRef.noSender)
+      // Kill regionA -> Terminated stashed at head (before RebalanceDone)
+      stopAndWaitForTerminated(regionA.ref)
+
+      // Complete s3 -> unstash: Terminated first, then RebalanceDone
+      completeInterceptedUpdate(replicatorProbe, pendingUpdate)
+      s3Probe.expectMsgType[ShardHome](5.seconds)
+
+      // Terminated(regionA) processed first -- removes s2 from state
+      val terminated = completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+      terminated.region should ===(regionA.ref)
+
+      // RebalanceDone("s2") finds s2 already gone -> no redundant ddata write
+      replicatorProbe.expectNoMessage(500.millis)
+    }
+
+    "handle multiple Terminated messages during a single waitingForUpdate" in
+    withFixture(regionCount = 3) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+      val regionC = regions(2)
+
+      // Allocate s1, s2 on regionA; s3, s4 on regionB
+      strategy.targetRegion = Some(regionA.ref)
+      allocateShard(coordinator, "s1", replicatorProbe)
+      allocateShard(coordinator, "s2", replicatorProbe)
+      strategy.targetRegion = Some(regionB.ref)
+      allocateShard(coordinator, "s3", replicatorProbe)
+      allocateShard(coordinator, "s4", replicatorProbe)
+
+      // Start s5 allocation on regionC -- enter waitingForUpdate
+      strategy.targetRegion = Some(regionC.ref)
+      val s5Probe = TestProbe()
+      coordinator.tell(GetShardHome("s5"), s5Probe.ref)
+      val pendingUpdate = interceptNextUpdate(replicatorProbe)
+
+      // Kill both regionA and regionB during waitingForUpdate
+      stopAndWaitForTerminated(regionA.ref)
+      stopAndWaitForTerminated(regionB.ref)
+
+      // Complete s5 -> both Terminated messages unstashed
+      completeInterceptedUpdate(replicatorProbe, pendingUpdate)
+      s5Probe.expectMsgType[ShardHome](5.seconds)
+
+      // Both regions should be terminated -- neither was lost
+      val evt1 = completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+      val evt2 = completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+      Set(evt1.region, evt2.region) should ===(Set(regionA.ref, regionB.ref))
+    }
+
+    "handle Terminated for region with zero shards via normal stash" in
+    withFixture(regionCount = 2) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+
+      // Allocate s1 on regionA only -- regionB has zero shards
+      strategy.targetRegion = Some(regionA.ref)
+      allocateShard(coordinator, "s1", replicatorProbe)
+
+      // Start s2 allocation on regionA -- enter waitingForUpdate
+      val s2Probe = TestProbe()
+      coordinator.tell(GetShardHome("s2"), s2Probe.ref)
+      val pendingUpdate = interceptNextUpdate(replicatorProbe)
+
+      // Kill regionB (0 shards) -> stashed at tail (not head)
+      stopAndWaitForTerminated(regionB.ref)
+
+      // Complete s2 -> Terminated(regionB) unstashed
+      completeInterceptedUpdate(replicatorProbe, pendingUpdate)
+      s2Probe.expectMsgType[ShardHome](5.seconds)
+
+      val terminated = completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+      terminated.region should ===(regionB.ref)
+
+      // regionA and its shards are unaffected
+      val verifyProbe = TestProbe()
+      coordinator.tell(GetShardHome("s1"), verifyProbe.ref)
+      verifyProbe.expectMsgType[ShardHome](5.seconds).ref should ===(regionA.ref)
+    }
+
+    "process messages normally when no Terminated arrives during waitingForUpdate" in
+    withFixture(regionCount = 1) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+
+      strategy.targetRegion = Some(regionA.ref)
+      allocateShard(coordinator, "s1", replicatorProbe)
+
+      // Start s2 allocation -- enter waitingForUpdate
+      val s2Probe = TestProbe()
+      coordinator.tell(GetShardHome("s2"), s2Probe.ref)
+      val pendingUpdate = interceptNextUpdate(replicatorProbe)
+
+      // Send GetShardHome("s3") while in waitingForUpdate -> stashed separately
+      val s3Probe = TestProbe()
+      coordinator.tell(GetShardHome("s3"), s3Probe.ref)
+
+      // Complete s2 -> s3 unstashed and allocated
+      completeInterceptedUpdate(replicatorProbe, pendingUpdate)
+      s2Probe.expectMsgType[ShardHome](5.seconds)
+
+      val alloc = completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      alloc.shard should ===("s3")
+      s3Probe.expectMsgType[ShardHome](5.seconds)
+
+      // Verify s1 is still correctly allocated
+      val verifyProbe = TestProbe()
+      coordinator.tell(GetShardHome("s1"), verifyProbe.ref)
+      val response = verifyProbe.expectMsgType[ShardHome](5.seconds)
+      response.shard should ===("s1")
+      response.ref should ===(regionA.ref)
+    }
+  }
+}


### PR DESCRIPTION
- Add `stashAtHead()` method to StashSupport to allow prepending of messages.
- Use `stashAtHead()` for Terminated Messages in ShardCoordinator