### PR TITLE
fix: remove noisy warning log from stale region detection

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1159,7 +1159,6 @@ abstract class ShardCoordinator(
         // If the node is alive, the watch is simply re-established (no-op).
         state.regions.keys.foreach { ref =>
           if (!ref.path.address.hasLocalScope) {
-            log.warning("{}: Stale region detection, re-watching region [{}]", typeName, ref)
             context.unwatch(ref)
             context.watch(ref)
           }


### PR DESCRIPTION
Remove `log.warning` that fired for every re-watched region on each stale region detection tick, not just for actually stale ones