### PR TITLE
perf: Only do rebalance roundtrip to regions known to know shard

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -822,6 +822,11 @@ abstract class ShardCoordinator(
   var preparingForShutdown = false
   // rebalanceInProgress for the ShardId keys, pending GetShardHome requests by the ActorRef values
   var rebalanceInProgress = Map.empty[ShardId, Set[ActorRef]]
+  // Tracks which regions/proxies have received ShardHome for each shard.
+  // Only populated for shards freshly allocated by THIS coordinator instance after allRegionsRegistered,
+  // so after a coordinator failover, recovered shards are absent and fall back to full fan-out.
+  // Used to scope BeginHandOff to only regions that have the shard location cached.
+  var shardSubscribers = Map.empty[ShardId, Set[ActorRef]]
   var rebalanceWorkers: Set[ActorRef] = Set.empty
   var unAckedHostShards = Map.empty[ShardId, Cancellable]
   // regions that have requested handoff, for graceful shutdown
@@ -1043,11 +1048,13 @@ abstract class ShardCoordinator(
             update(ShardHomeDeallocated(shard)) { evt =>
               log.debug("{}: Shard [{}] deallocated after", typeName, shard)
               state = state.updated(evt)
+              shardSubscribers -= shard
               clearRebalanceInProgress(shard)
               allocateShardHomesForRememberEntities()
               self.tell(GetShardHome(shard), ignoreRef)
             }
           } else {
+            shardSubscribers -= shard
             clearRebalanceInProgress(shard)
           }
 
@@ -1217,6 +1224,16 @@ abstract class ShardCoordinator(
     }
   }
 
+  // Only adds the subscriber if we are already tracking this shard (i.e. it was freshly allocated
+  // by this coordinator instance). Shards recovered from state are absent from shardSubscribers and
+  // continue to use the full BeginHandOff fan-out as a safe fallback.
+  private def recordShardSubscriber(shard: ShardId, subscriber: ActorRef): Unit =
+    shardSubscribers.get(shard) match {
+      case Some(current) =>
+        shardSubscribers = shardSubscribers.updated(shard, current + subscriber)
+      case None =>
+    }
+
   private def deferGetShardHomeRequest(shard: ShardId, from: ActorRef): Unit = {
     log.debug(
       "{}: GetShardHome [{}] request from [{}] deferred, because rebalance is in progress for this shard. " +
@@ -1258,6 +1275,7 @@ abstract class ShardCoordinator(
               else map.updated(regionRef, shardId :: Nil)
           }
           ref ! ShardHomes(shardsSubMap)
+          shardsSubMap.values.foreach(_.foreach(recordShardSubscriber(_, ref)))
         }
     }
   }
@@ -1287,8 +1305,10 @@ abstract class ShardCoordinator(
               typeName,
               shard,
               shardRegionRef)
-          else
+          else {
             sender() ! ShardHome(shard, shardRegionRef)
+            recordShardSubscriber(shard, sender())
+          }
 
           unstashOneGetShardHomeRequest() // continue unstashing
           true
@@ -1372,10 +1392,15 @@ abstract class ShardCoordinator(
 
   def regionTerminated(ref: ActorRef): Unit = {
     rebalanceWorkers.foreach(_ ! RebalanceWorker.ShardRegionTerminated(ref))
+    state.regions.get(ref) match {
+      case Some(shards) => shards.foreach(shardSubscribers -= _)
+      case None         =>
+    }
+    shardSubscribers = shardSubscribers.transform((_, subs) => subs - ref)
     if (state.regions.contains(ref)) {
       if (log.isDebugEnabled) {
         log.debug(
-          "{}: ShardRegion terminated{}: [{}] {}",
+          "{}: ShardRegion terminated{}: [{}]",
           typeName,
           if (gracefulShutdownInProgress.contains(ref)) " (gracefully)" else "",
           ref)
@@ -1403,6 +1428,7 @@ abstract class ShardCoordinator(
 
   def regionProxyTerminated(ref: ActorRef): Unit = {
     rebalanceWorkers.foreach(_ ! RebalanceWorker.ShardRegionTerminated(ref))
+    shardSubscribers = shardSubscribers.transform((_, subs) => subs - ref)
     if (state.regionProxies.contains(ref)) {
       log.debug("{}: ShardRegion proxy terminated: [{}]", typeName, ref)
       update(ShardRegionProxyTerminated(ref)) { evt =>
@@ -1433,7 +1459,9 @@ abstract class ShardCoordinator(
       deferGetShardHomeRequest(shard, getShardHomeSender)
     } else {
       state.shards.get(shard) match {
-        case Some(ref) => getShardHomeSender ! ShardHome(shard, ref)
+        case Some(ref) =>
+          getShardHomeSender ! ShardHome(shard, ref)
+          recordShardSubscriber(shard, getShardHomeSender)
         case None =>
           if (state.regions.contains(region) && !gracefulShutdownInProgress(region) && !regionTerminationInProgress
                 .contains(region)) {
@@ -1448,6 +1476,8 @@ abstract class ShardCoordinator(
 
               sendHostShardMsg(evt.shard, evt.region)
               getShardHomeSender ! ShardHome(evt.shard, evt.region)
+              if (allRegionsRegistered)
+                shardSubscribers = shardSubscribers.updated(evt.shard, Set(getShardHomeSender))
               unstashGetShardHomeRequestsForShard(evt.shard)
             }
           } else {
@@ -1493,7 +1523,7 @@ abstract class ShardCoordinator(
           shard,
           from,
           handOffTimeout,
-          state.regions.keySet.union(state.regionProxies),
+          shardSubscribers.getOrElse(shard, state.regions.keySet.union(state.regionProxies)),
           isRebalance = isRebalance).withDispatcher(context.props.dispatcher))
     }
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1227,12 +1227,15 @@ abstract class ShardCoordinator(
   // Only adds the subscriber if we are already tracking this shard (i.e. it was freshly allocated
   // by this coordinator instance). Shards recovered from state are absent from shardSubscribers and
   // continue to use the full BeginHandOff fan-out as a safe fallback.
+  // ignoreRef is never tracked: it is used for internal self-tells and discards all messages,
+  // so including it as a subscriber would cause BeginHandOff to go nowhere and the handoff to time out.
   private def recordShardSubscriber(shard: ShardId, subscriber: ActorRef): Unit =
-    shardSubscribers.get(shard) match {
-      case Some(current) =>
-        shardSubscribers = shardSubscribers.updated(shard, current + subscriber)
-      case None =>
-    }
+    if (subscriber != ignoreRef)
+      shardSubscribers.get(shard) match {
+        case Some(current) =>
+          shardSubscribers = shardSubscribers.updated(shard, current + subscriber)
+        case None =>
+      }
 
   private def deferGetShardHomeRequest(shard: ShardId, from: ActorRef): Unit = {
     log.debug(
@@ -1476,7 +1479,7 @@ abstract class ShardCoordinator(
 
               sendHostShardMsg(evt.shard, evt.region)
               getShardHomeSender ! ShardHome(evt.shard, evt.region)
-              if (allRegionsRegistered)
+              if (allRegionsRegistered && getShardHomeSender != ignoreRef)
                 shardSubscribers = shardSubscribers.updated(evt.shard, Set(getShardHomeSender))
               unstashGetShardHomeRequestsForShard(evt.shard)
             }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSubscriberOptimizationSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSubscriberOptimizationSpec.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor._
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.ddata.LWWRegister
+import akka.cluster.ddata.LWWRegisterKey
+import akka.cluster.ddata.Replicator._
+import akka.cluster.sharding.ShardCoordinator.Internal._
+import akka.cluster.sharding.ShardRegion.ShardId
+import akka.testkit._
+
+object ShardSubscriberOptimizationSpec {
+  val config = ConfigFactory.parseString("""
+    akka.actor.provider = cluster
+    akka.remote.artery.canonical.port = 0
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.cluster.sharding.verbose-debug-logging = on
+    akka.cluster.sharding.updating-state-timeout = 60s
+    akka.cluster.sharding.rebalance-interval = 120s
+    akka.cluster.sharding.shard-start-timeout = 120s
+    akka.cluster.sharding.handoff-timeout = 10s
+    akka.cluster.min-nr-of-members = 1
+  """)
+
+  class TestAllocationStrategy extends ShardCoordinator.ShardAllocationStrategy {
+    @volatile var targetRegion: Option[ActorRef] = None
+
+    override def allocateShard(
+        requester: ActorRef,
+        shardId: ShardId,
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]): Future[ActorRef] =
+      Future.successful(targetRegion.getOrElse(currentShardAllocations.minBy(_._2.size)._1))
+
+    override def rebalance(
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
+        rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] =
+      Future.successful(Set.empty)
+  }
+
+  case class Fixture(coordinator: ActorRef, replicatorProbe: TestProbe, strategy: TestAllocationStrategy)
+}
+
+/**
+ * Tests for the shardSubscribers optimization: BeginHandOff is sent to only
+ * the regions that have the shard's location cached, rather than broadcasting
+ * to every region in the cluster.
+ */
+class ShardSubscriberOptimizationSpec extends AkkaSpec(ShardSubscriberOptimizationSpec.config) with WithLogCapturing {
+
+  import ShardSubscriberOptimizationSpec._
+
+  private type CoordinatorUpdate = Update[LWWRegister[State]]
+  private var testCounter = 0
+
+  private def nextTypeName(): String = {
+    testCounter += 1
+    s"TestEntity$testCounter"
+  }
+
+  override def atStartup(): Unit = {
+    val cluster = Cluster(system)
+    cluster.join(cluster.selfAddress)
+    awaitAssert {
+      cluster.readView.members.count(_.status == MemberStatus.Up) should ===(1)
+    }
+  }
+
+  private def withFixture(regionCount: Int)(body: (Fixture, IndexedSeq[TestProbe]) => Unit): Unit = {
+    val typeName = nextTypeName()
+    val strategy = new TestAllocationStrategy
+    val replicatorProbe = TestProbe()
+    val coordinator = system.actorOf(
+      ShardCoordinator.props(
+        typeName,
+        ClusterShardingSettings(system),
+        strategy,
+        replicatorProbe.ref,
+        majorityMinCap = 0,
+        rememberEntitiesStoreProvider = None))
+
+    // fake initial state from replicator
+    replicatorProbe.expectMsgType[Get[_]](5.seconds)
+    replicatorProbe.reply(NotFound(LWWRegisterKey[State](s"${typeName}CoordinatorState"), None))
+    replicatorProbe.expectNoMessage(100.millis)
+
+    val regions = (1 to regionCount).map { _ =>
+      val region = TestProbe()
+      coordinator.tell(Register(region.ref), region.ref)
+      completeNextUpdate(replicatorProbe)
+      region.expectMsgType[RegisterAck](5.seconds)
+      region
+    }
+
+    try body(Fixture(coordinator, replicatorProbe, strategy), regions)
+    finally system.stop(coordinator)
+  }
+
+  private def completeNextUpdate(replicatorProbe: TestProbe): DomainEvent = {
+    val update = replicatorProbe.expectMsgType[CoordinatorUpdate](5.seconds)
+    val evt = update.request.get.asInstanceOf[DomainEvent]
+    replicatorProbe.reply(UpdateSuccess(update.key, update.request))
+    evt
+  }
+
+  private def completeNextUpdateExpecting[T <: DomainEvent: ClassTag](replicatorProbe: TestProbe): T = {
+    val evt = completeNextUpdate(replicatorProbe)
+    evt shouldBe a[T]
+    evt.asInstanceOf[T]
+  }
+
+  "shardSubscribers optimization" must {
+
+    "scope BeginHandOff to only regions that have requested the shard location" in
+    withFixture(regionCount = 3) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+      val regionC = regions(2)
+
+      // s1 allocated to regionA; regionB is the requester and becomes a subscriber
+      strategy.targetRegion = Some(regionA.ref)
+      coordinator.tell(GetShardHome("s1"), regionB.ref)
+      completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      regionB.expectMsgType[ShardHome](5.seconds)
+
+      // regionC never requests GetShardHome for s1
+
+      // Initiate graceful shutdown of regionA — triggers BeginHandOff fan-out
+      coordinator.tell(GracefulShutdownReq(regionA.ref), regionA.ref)
+
+      // Only regionB (a subscriber) should receive BeginHandOff; regionC should not
+      regionB.expectMsg(3.seconds, BeginHandOff("s1"))
+      regionC.expectNoMessage(500.millis)
+    }
+
+    "include a region that learns the shard location via informAboutCurrentShards on registration" in
+    withFixture(regionCount = 2) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+
+      // s1 allocated to regionA; regionB becomes a subscriber via the initial request
+      strategy.targetRegion = Some(regionA.ref)
+      coordinator.tell(GetShardHome("s1"), regionB.ref)
+      completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      regionB.expectMsgType[ShardHome](5.seconds)
+
+      // regionC registers after s1 is allocated: the coordinator sends it ShardHomes
+      // (via informAboutCurrentShards), which should add it to the subscriber set
+      val regionC = TestProbe()
+      coordinator.tell(Register(regionC.ref), regionC.ref)
+      // informAboutCurrentShards fires before the DData update, so ShardHomes arrives first
+      regionC.expectMsgType[ShardHomes](5.seconds)
+      completeNextUpdateExpecting[ShardRegionRegistered](replicatorProbe)
+      regionC.expectMsgType[RegisterAck](5.seconds)
+
+      // Initiate graceful shutdown of regionA
+      coordinator.tell(GracefulShutdownReq(regionA.ref), regionA.ref)
+
+      // Both regionB (GetShardHome subscriber) and regionC (informAboutCurrentShards subscriber)
+      // should receive BeginHandOff
+      regionB.expectMsg(3.seconds, BeginHandOff("s1"))
+      regionC.expectMsg(3.seconds, BeginHandOff("s1"))
+    }
+
+    "deliver BeginHandOff to a second region that requests the shard location after initial allocation" in
+    withFixture(regionCount = 3) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+      val regionC = regions(2)
+
+      // s1 allocated to regionA via regionB's request
+      strategy.targetRegion = Some(regionA.ref)
+      coordinator.tell(GetShardHome("s1"), regionB.ref)
+      completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      regionB.expectMsgType[ShardHome](5.seconds)
+
+      // regionC also requests the location later — already allocated, no DData update needed
+      coordinator.tell(GetShardHome("s1"), regionC.ref)
+      regionC.expectMsg(3.seconds, ShardHome("s1", regionA.ref))
+
+      // Initiate graceful shutdown of regionA
+      coordinator.tell(GracefulShutdownReq(regionA.ref), regionA.ref)
+
+      // Both B and C are subscribers and should receive BeginHandOff
+      regionB.expectMsg(3.seconds, BeginHandOff("s1"))
+      regionC.expectMsg(3.seconds, BeginHandOff("s1"))
+    }
+
+    "prune a terminated region from subscriber sets before BeginHandOff fan-out" in
+    withFixture(regionCount = 3) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+      val regionC = regions(2)
+
+      // Both regionB and regionC subscribe to s1
+      strategy.targetRegion = Some(regionA.ref)
+      coordinator.tell(GetShardHome("s1"), regionB.ref)
+      completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+      regionB.expectMsgType[ShardHome](5.seconds)
+
+      coordinator.tell(GetShardHome("s1"), regionC.ref)
+      regionC.expectMsg(3.seconds, ShardHome("s1", regionA.ref))
+
+      // regionC terminates, coordinator should prune it from shardSubscribers
+      watch(regionC.ref)
+      system.stop(regionC.ref)
+      expectTerminated(regionC.ref, 5.seconds)
+      Thread.sleep(200) // allow DeathWatch to deliver Terminated to coordinator
+      completeNextUpdateExpecting[ShardRegionTerminated](replicatorProbe)
+
+      // Initiate graceful shutdown of regionA
+      coordinator.tell(GracefulShutdownReq(regionA.ref), regionA.ref)
+
+      // regionB (still alive subscriber) receives BeginHandOff
+      regionB.expectMsg(3.seconds, BeginHandOff("s1"))
+      // The handoff proceeds to completion without stalling on the dead regionC:
+      // regionB acks, HandOff goes to regionA, which replies ShardStopped
+      regionB.reply(BeginHandOffAck("s1"))
+      regionA.fishForMessage(3.seconds, "HandOff") { case HandOff("s1") => true; case _ => false }
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSubscriberOptimizationSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSubscriberOptimizationSpec.scala
@@ -11,6 +11,7 @@ import scala.reflect.ClassTag
 import com.typesafe.config.ConfigFactory
 
 import akka.actor._
+import akka.actor.ExtendedActorSystem
 import akka.cluster.Cluster
 import akka.cluster.MemberStatus
 import akka.cluster.ddata.LWWRegister
@@ -232,6 +233,34 @@ class ShardSubscriberOptimizationSpec extends AkkaSpec(ShardSubscriberOptimizati
       // regionB acks, HandOff goes to regionA, which replies ShardStopped
       regionB.reply(BeginHandOffAck("s1"))
       regionA.fishForMessage(3.seconds, "HandOff") { case HandOff("s1") => true; case _ => false }
+    }
+
+    // Regression test: shards allocated via the coordinator's internal ignoreRef self-tells
+    // (rememberEntities, regionTerminated recovery, post-handoff re-allocation) must not get
+    // ignoreRef added as a subscriber.  If they did, BeginHandOff would be sent only to ignoreRef,
+    // which discards the message, causing the handoff to time out and entities never to stop.
+    "fall back to full BeginHandOff fan-out for shards allocated via ignoreRef self-tells" in
+    withFixture(regionCount = 2) { (f, regions) =>
+      val Fixture(coordinator, replicatorProbe, strategy) = f
+      val regionA = regions(0)
+      val regionB = regions(1)
+
+      // Simulate an internal coordinator self-tell (as done by allocateShardHomesForRememberEntities,
+      // regionTerminated recovery, etc.) by using the same ignoreRef the coordinator uses internally.
+      // The shard must NOT end up tracked with ignoreRef as its only subscriber.
+      val ignoreRef = system.asInstanceOf[ExtendedActorSystem].provider.ignoreRef
+      strategy.targetRegion = Some(regionA.ref)
+      coordinator.tell(GetShardHome("s1"), ignoreRef)
+      completeNextUpdateExpecting[ShardHomeAllocated](replicatorProbe)
+
+      // Trigger graceful shutdown of regionA
+      coordinator.tell(GracefulShutdownReq(regionA.ref), regionA.ref)
+
+      // Both regions must receive BeginHandOff — the full fan-out fallback applies because
+      // the shard was allocated with ignoreRef and is therefore not in shardSubscribers.
+      // regionA also receives HostShard during allocation, so fish past it.
+      regionA.fishForMessage(3.seconds, "BeginHandOff(s1)") { case BeginHandOff("s1") => true; case _ => false }
+      regionB.expectMsg(3.seconds, BeginHandOff("s1"))
     }
   }
 }


### PR DESCRIPTION
Trying out an idea for shard rebalance optimization.

By keeping track of what region knows about a shard location, we only need to do the BeginHandOff/BeginHandOffAck roundtrip from the rebalance worker to the regions that knows about the shard. A shard accessed by 3 of 10 regions goes from 10 round-trips to 3. Nothing super impressive but maybe worth it?

This is a happy path optimization, because if the coordinator has moved, it doesn't know about what regions knows about the shards, so we only do this for shards that the current instance of the coordinator allocated, and fallback to BeginHandOff/BeginHandOffAck to all regions for that scenario (not worth putting in ddata/persist it).