### PR TITLE
fix: prevent dead letters from Write commands racing with TCP connection close

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpDeadLetterOnClosedConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpDeadLetterOnClosedConnectionSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.io
+
+import scala.concurrent.duration._
+
+import akka.actor.DeadLetter
+import akka.io.Tcp._
+import akka.testkit.{ AkkaSpec, TestProbe }
+import akka.testkit.WithLogCapturing
+import akka.util.ByteString
+
+/**
+ * Verifies that a TCP Write racing with a peer-initiated connection close does NOT
+ * produce dead letters — the scenario observed when HAProxy runs SSL health checks in
+ * TCP mode: HAProxy opens a TLS connection, completes the handshake, then immediately
+ * closes the socket.  Any in-flight Write from the server side should be silently
+ * dropped (e.g. via DeadLetterSuppression) rather than showing up as a dead letter.
+ */
+class TcpDeadLetterOnClosedConnectionSpec extends AkkaSpec("""
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.io.tcp.trace-logging = on
+    akka.log-dead-letters = on
+    """) with TcpIntegrationSpecSupport with WithLogCapturing {
+
+  "Tcp" should {
+
+    "not produce a dead letter when Write is sent to a connection actor after the peer closed it" in new TestSetup {
+      val (clientHandler, clientConnection, serverHandler, serverConnection) = establishNewClientConnection()
+
+      // Subscribe to dead letters before triggering the race
+      val deadLetterProbe = TestProbe()
+      system.eventStream.subscribe(deadLetterProbe.ref, classOf[DeadLetter])
+      watch(serverConnection)
+
+      // Simulate HAProxy closing the connection abruptly after the health-check handshake
+      clientHandler.send(clientConnection, Abort)
+      clientHandler.expectMsg(Aborted)
+
+      // Server side sees the abrupt close
+      serverHandler.expectMsgType[ErrorClosed]
+
+      // Immediately send a Write without waiting for the actor to fully terminate —
+      // this mirrors the Akka HTTP stream pipeline sending a response while the
+      // connection teardown is in progress. The actor must absorb this with
+      // CommandFailed rather than letting it become a dead letter.
+      serverHandler.send(serverConnection, Write(ByteString("health-check-response")))
+
+      deadLetterProbe.expectNoMessage(500.millis)
+
+      // The connection actor must eventually terminate
+      expectTerminated(serverConnection, 5.seconds)
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -44,6 +44,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   private[this] var readingSuspended = pullMode
   private[this] var interestedInResume: Option[ActorRef] = None
   private[this] var closedMessage: Option[CloseInformation] = None // for ConnectionClosed message in postStop
+  private[this] var notifiedOnClose = false // true when interested parties were already notified in stopWith
   private var watchedActor: ActorRef = context.system.deadLetters
   private var registration: Option[ChannelRegistration] = None
 
@@ -199,11 +200,25 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
   /** stopWith sets this state while waiting for the SelectionHandler to execute the `cancelAndClose` thunk */
   def unregistering: Receive = {
-    case Unregistered => context.stop(self) // postStop will notify interested parties
-    case _            =>
+    case Unregistered =>
+      // NIO cleanup done; linger briefly so any in-flight WriteCommands that race with
+      // the connection close (e.g. from an Akka HTTP stream) are answered with CommandFailed
+      // instead of silently landing in dead letters.
+      context.setReceiveTimeout(TcpConnection.DrainTimeout)
+      context.become(draining)
+    case _ =>
     // Ignore everything else, we might end up here without user interaction, e.g. if the peer sends a RST packet
     // In this case, we notify the user handler, which might have already concurrently sent us more commands
     // that we can only drop at this point.
+  }
+
+  /** post-close drain: absorbs any writes that race with connection teardown */
+  def draining: Receive = {
+    case write: WriteCommand =>
+      if (TraceLogging) log.debug("Dropping write to already-closed connection")
+      sender() ! CommandFailed(write)
+    case ReceiveTimeout => context.stop(self) // postStop will notify interested parties
+    case _              => // ignore
   }
 
   // AUXILIARIES and IMPLEMENTATION
@@ -389,6 +404,12 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       case None =>
         context.stop(self)
       case Some(reg) =>
+        // Eagerly notify interested parties before the actor stops. This ensures they
+        // receive the close event while the actor is still alive in the `draining` state,
+        // so any writes they send in response are answered with CommandFailed instead of
+        // silently becoming dead letters.
+        closeInfo.notificationsTo.foreach(_ ! closeInfo.closedEvent)
+        notifiedOnClose = true
         context.become(unregistering)
         reg.cancelAndClose(() => self ! Unregistered)
     }
@@ -409,6 +430,9 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
       for {
         msg <- closedMessage
         ref <- interestedInClose
+        // Skip actors already notified eagerly in stopWith (e.g. the connection handler),
+        // but still notify the pending write commander if it differs from those already notified.
+        if !notifiedOnClose || !msg.notificationsTo.contains(ref)
       } ref ! msg.closedEvent
 
     if (!channel.isOpen || isCommandFailed || registration.isEmpty)
@@ -581,6 +605,9 @@ private[io] object TcpConnection {
   }
 
   val doNothing: () => Unit = () => ()
+
+  /** How long the connection actor lingers after close to absorb in-flight writes. */
+  val DrainTimeout: FiniteDuration = 100.milliseconds
 
   val DroppingWriteBecauseWritingIsSuspendedException =
     new IOException("Dropping write because writing is suspended") with NoStackTrace


### PR DESCRIPTION
When a peer closes a TCP connection (e.g. an HAProxy SSL health check that opens and immediately closes the socket), the connection actor's close notification was sent from postStop — after the actor was fully terminated.

Any WriteCommand sent by a higher-level stream (e.g. Akka HTTP) between the peer close and the actor's death would land in dead letters with no way to intercept them.

  Fix:
  - Eagerly notify interested parties (handler, close commander) inside stopWith
    before entering the unregistering state, so they receive the close event
    while the actor is still alive.
  - After NIO deregistration completes (Unregistered), transition to a new
    draining state instead of stopping immediately. The draining state answers
    any in-flight WriteCommands with CommandFailed and stops after a short
    idle timeout (100 ms).
  - Guard the postStop notification to skip actors already notified eagerly,
    while still delivering the close event to a pending write's commander if
    it differs from the connection handler.