### PR TITLE
perf: use StackWalker for logger class detection

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/internal/LoggerClassTest.scala
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/internal/LoggerClassTest.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal
+
+import org.junit.Test
+import org.scalatestplus.junit.JUnitSuite
+
+class LoggerClassTest extends JUnitSuite {
+  @Test
+  def testLoggerClass(): Unit = {
+    // LoggerClass.detectLoggerClassFromStack(Void.TYPE) frames prefixed with
+    // akka.actor.typed.internal, so we can either move this test, or indirect the call
+    // through a lambda-based method:
+    val value = Some(()).map(_ => LoggerClass.detectLoggerClassFromStack(Void.TYPE))
+    assert(value.get == classOf[Option[_]])
+  }
+}

--- a/akka-actor-typed/src/main/mima-filters/2.10.17.backwards.excludes/32917-stackwalker.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.10.17.backwards.excludes/32917-stackwalker.excludes
@@ -1,0 +1,2 @@
+# Internal API
+ProblemFilters.exclude[MissingClassProblem]("akka.actor.typed.internal.LoggerClass$TrickySecurityManager")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/LoggerClass.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/LoggerClass.scala
@@ -5,50 +5,28 @@
 package akka.actor.typed.internal
 
 import scala.util.control.NonFatal
-
 import akka.annotation.InternalApi
-import akka.util.OptionVal
+import java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE
 
 /**
  * INTERNAL API
  */
 @InternalApi
 private[akka] object LoggerClass {
-
-  // just to get access to the class context
-  private final class TrickySecurityManager extends SecurityManager {
-    def getClassStack: Array[Class[_]] = getClassContext
-  }
-
   private val defaultPrefixesToSkip = List("scala.runtime", "akka.actor.typed.internal")
 
   /**
    * Try to extract a logger class from the call stack, if not possible the provided default is used
    */
   def detectLoggerClassFromStack(default: Class[_], additionalPrefixesToSkip: List[String] = Nil): Class[_] = {
-    // TODO use stack walker API when we no longer need to support Java 8
     try {
-      def skip(name: String): Boolean = {
-        def loop(skipList: List[String]): Boolean = skipList match {
-          case Nil => false
-          case head :: tail =>
-            if (name.startsWith(head)) true
-            else loop(tail)
-        }
+      val walker = StackWalker.getInstance(RETAIN_CLASS_REFERENCE)
+      val skipList = additionalPrefixesToSkip ::: defaultPrefixesToSkip
+      def isInternal(clazz: Class[_]) = skipList.exists(clazz.getName.startsWith)
 
-        loop(additionalPrefixesToSkip ::: defaultPrefixesToSkip)
+      walker.walk { frames =>
+        frames.map[Class[_]](f => f.getDeclaringClass).filter(cls => !isInternal(cls)).findFirst().orElse(default)
       }
-
-      val trace = new TrickySecurityManager().getClassStack
-      var suitableClass: OptionVal[Class[_]] = OptionVal.None
-      var idx = 1 // skip this method/class and right away
-      while (suitableClass.isEmpty && idx < trace.length) {
-        val clazz = trace(idx)
-        val name = clazz.getName
-        if (!skip(name)) suitableClass = OptionVal.Some(clazz)
-        idx += 1
-      }
-      suitableClass.getOrElse(default)
     } catch {
       case NonFatal(_) => default
     }

--- a/akka-actor/src/main/mima-filters/2.10.17.backwards.excludes/32917-stackwalker.excludes
+++ b/akka-actor/src/main/mima-filters/2.10.17.backwards.excludes/32917-stackwalker.excludes
@@ -1,0 +1,2 @@
+# Internal API
+ProblemFilters.exclude[MissingClassProblem]("akka.actor.typed.internal.LoggerClass$TrickySecurityManager")


### PR DESCRIPTION
* Replace legacy SecurityManager-based stack walking with Java 9+ StackWalker API
* Improve performance by lazily streaming stack frames instead of capturing full class context
* Remove TrickySecurityManager internal utility which is no longer needed
* Add JUnit test case to verify logger detection through indirect call frames
