### PR TITLE
chore: dead block in error path SessionVerifier

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ssl/SessionVerifier.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ssl/SessionVerifier.scala
@@ -50,18 +50,19 @@ private[ssl] final class PeerSubjectVerifier(peerCertificate: X509Certificate) e
     val mySubjectNames = X509Readers.getAllSubjectNames(peerCertificate)
     if (session.getPeerCertificates.length == 0) {
       Some(new IllegalArgumentException("No peer certificates"))
-    }
-    session.getPeerCertificates()(0) match {
-      case x509: X509Certificate =>
-        val peerSubjectNames =
-          X509Readers.getAllSubjectNames(x509)
-        if (mySubjectNames.exists(peerSubjectNames)) None
-        else
-          Some(
-            new IllegalArgumentException(
-              s"None of the peer subject names $peerSubjectNames were in local subject names $mySubjectNames"))
-      case other =>
-        Some(new IllegalArgumentException(s"Unknown certificate type: ${other.getClass}"))
+    } else {
+      session.getPeerCertificates()(0) match {
+        case x509: X509Certificate =>
+          val peerSubjectNames =
+            X509Readers.getAllSubjectNames(x509)
+          if (mySubjectNames.exists(peerSubjectNames)) None
+          else
+            Some(
+              new IllegalArgumentException(
+                s"None of the peer subject names $peerSubjectNames were in local subject names $mySubjectNames"))
+        case other =>
+          Some(new IllegalArgumentException(s"Unknown certificate type: ${other.getClass}"))
+      }
     }
   }
 


### PR DESCRIPTION
Would anyway catch a latter exception, but I think this is how it was meant.