### PR TITLE
chore: Shut shards down on Sharded Daemon Process scale down

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ShardedDaemonProcessRescaleEmptyShardsSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ShardedDaemonProcessRescaleEmptyShardsSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.scaladsl
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.ShardRegion.CurrentShardRegionState
+import akka.cluster.sharding.typed.ChangeNumberOfProcesses
+import akka.cluster.sharding.typed.GetShardRegionState
+import akka.cluster.sharding.typed.ShardedDaemonProcessCommand
+import akka.cluster.sharding.typed.ShardedDaemonProcessContext
+import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.Join
+import akka.pattern.StatusReply
+
+object ShardedDaemonProcessRescaleEmptyShardsSpec {
+  def config = ConfigFactory.parseString("""
+      akka.actor.provider = cluster
+      akka.actor.testkit.typed.single-expect-default = 10s
+
+      akka.remote.artery.canonical.port = 0
+      akka.remote.artery.canonical.hostname = 127.0.0.1
+
+      akka.cluster.jmx.multi-mbeans-in-same-jvm = on
+
+      akka.cluster.sharded-daemon-process.keep-alive-interval = 1s
+      akka.cluster.sharded-daemon-process.keep-alive-throttle-interval = 20ms
+
+      akka.coordinated-shutdown.terminate-actor-system = off
+      akka.coordinated-shutdown.run-by-actor-system-terminate = off
+      """)
+
+  object Worker {
+    sealed trait Command
+    case object Stop extends Command
+
+    case class Started(id: Int, totalCount: Int, selfRef: ActorRef[Command])
+    case class Stopping(selfRef: ActorRef[Command])
+
+    def apply(id: Int, totalCount: Int, probe: ActorRef[Any]): Behavior[Command] = Behaviors.setup { ctx =>
+      probe ! Started(id, totalCount, ctx.self)
+      Behaviors.receiveMessage {
+        case Stop =>
+          probe ! Stopping(ctx.self)
+          Behaviors.stopped
+      }
+    }
+  }
+}
+
+class ShardedDaemonProcessRescaleEmptyShardsSpec
+    extends ScalaTestWithActorTestKit(ShardedDaemonProcessRescaleEmptyShardsSpec.config)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import ShardedDaemonProcessRescaleEmptyShardsSpec._
+
+  private val workerLifecycleProbe: TestProbe[Any] = createTestProbe[Any]()
+
+  private val daemonProcessName = "empty-shards-repro"
+
+  // SDP names its EntityTypeKey internally as "sharded-daemon-process-<name>"
+  private val typeKey: EntityTypeKey[Worker.Command] =
+    EntityTypeKey[Worker.Command](s"sharded-daemon-process-$daemonProcessName")
+
+  "ShardedDaemonProcess scale-down" must {
+
+    "form a single-node cluster" in {
+      val probe = createTestProbe()
+      Cluster(system).manager ! Join(Cluster(system).selfMember.address)
+      probe.awaitAssert(Cluster(system).selfMember.status should ===(MemberStatus.Up), 3.seconds)
+    }
+
+    "not leave empty shards behind after scaling down from 4 to 2" in {
+      val sdp: ActorRef[ShardedDaemonProcessCommand] =
+        ShardedDaemonProcess(system).initWithContext[Worker.Command](
+          daemonProcessName,
+          4,
+          (ctx: ShardedDaemonProcessContext) => Worker(ctx.processNumber, ctx.totalProcesses, workerLifecycleProbe.ref),
+          ShardedDaemonProcessSettings(system),
+          Some(Worker.Stop),
+          None)
+
+      val initiallyStarted = (1 to 4).map(_ => workerLifecycleProbe.expectMessageType[Worker.Started]).toSet
+      initiallyStarted.map(_.id) should ===(Set(0, 1, 2, 3))
+
+      val stateProbe = TestProbe[CurrentShardRegionState]()
+
+      // baseline: 4 shards, each with one entity
+      stateProbe.awaitAssert({
+        ClusterSharding(system).shardState ! GetShardRegionState(typeKey, stateProbe.ref)
+        val state = stateProbe.receiveMessage()
+        state.shards.size should ===(4)
+        state.shards.foreach { s =>
+          s.entityIds.size should ===(1)
+        }
+      }, 10.seconds)
+
+      // scale down to 2
+      val rescaleProbe = createTestProbe[StatusReply[Done]]()
+      sdp ! ChangeNumberOfProcesses(2, rescaleProbe.ref)
+
+      (1 to 4).foreach(_ => workerLifecycleProbe.expectMessageType[Worker.Stopping])
+      val newlyStarted = (1 to 2).map(_ => workerLifecycleProbe.expectMessageType[Worker.Started]).toSet
+      newlyStarted.map(_.id) should ===(Set(0, 1))
+      rescaleProbe.expectMessage(StatusReply.Ack)
+
+      // After scale-down, the region should host exactly the 2 new shards.
+      // If old-revision shards are re-allocated as empty Shard actors, this will fail.
+      stateProbe.awaitAssert({
+        ClusterSharding(system).shardState ! GetShardRegionState(typeKey, stateProbe.ref)
+        val state = stateProbe.receiveMessage()
+        val nonEmptyShards = state.shards.filter(_.entityIds.nonEmpty)
+        val emptyShards = state.shards.filter(_.entityIds.isEmpty)
+        withClue(s"nonEmpty=$nonEmptyShards empty=$emptyShards: ") {
+          nonEmptyShards.size should ===(2)
+          emptyShards shouldBe empty
+        }
+      }, 15.seconds)
+    }
+  }
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1030,6 +1030,8 @@ abstract class ShardCoordinator(
         if (ok) {
           log.debug("{}: Shard [{}] deallocation completed successfully.", typeName, shard)
 
+          val wasExplicitlyStopped = waitingForShardsToStop.contains(shard)
+
           // ack to external trigger of rebalance/stop
           waitingForShardsToStop.get(shard) match {
             case Some(waiting) =>
@@ -1045,7 +1047,13 @@ abstract class ShardCoordinator(
               state = state.updated(evt)
               clearRebalanceInProgress(shard)
               allocateShardHomesForRememberEntities()
-              self.tell(GetShardHome(shard), ignoreRef)
+              // Explicit StopShards should not eagerly re-allocate the shard, otherwise
+              // a fresh empty Shard actor would be spawned in some region (e.g. SDP scale-down
+              // would leave orphan old-revision shards behind). Let it stay homeless until
+              // an entity request naturally arrives.
+              if (!wasExplicitlyStopped) {
+                self.tell(GetShardHome(shard), ignoreRef)
+              }
             }
           } else {
             clearRebalanceInProgress(shard)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RebalanceReallocatesShardSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RebalanceReallocatesShardSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import akka.cluster.sharding.ShardRegion.CurrentShardRegionState
+import akka.cluster.sharding.ShardRegion.GetShardRegionState
+import akka.testkit.AkkaSpec
+import akka.testkit.TestProbe
+import akka.testkit.WithLogCapturing
+
+object RebalanceReallocatesShardSpec {
+
+  def config =
+    ConfigFactory.parseString("""
+        akka.loglevel = DEBUG
+        akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+        akka.actor.provider = "cluster"
+        akka.remote.artery.canonical.port = 0
+        akka.remote.artery.canonical.hostname = "127.0.0.1"
+        akka.test.single-expect-default = 5 s
+        akka.cluster.sharding.distributed-data.durable.keys = []
+        akka.cluster.sharding.remember-entities = off
+        akka.cluster.sharding.rebalance-interval = 500ms
+        akka.cluster.sharding.verbose-debug-logging = on
+        akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+        akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
+        akka.cluster.jmx.enabled = off
+        """)
+
+  val shardTypeName = "rebalance-realloc-entities"
+  val numberOfShards = 2
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: Int => (msg.toString, msg)
+    case _        => throw new IllegalArgumentException()
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: Int                    => (msg % numberOfShards).toString
+    case ShardRegion.StartEntity(id) => (id.toLong % numberOfShards).toString
+    case _                           => throw new IllegalArgumentException()
+  }
+
+  class EntityActor extends Actor with ActorLogging {
+    override def receive: Receive = {
+      case _ =>
+        log.debug("ping")
+        sender() ! context.self
+    }
+  }
+
+  // Strategy with externally controllable rebalance set. allocateShard always assigns
+  // to the first known region (a single-node test has exactly one).
+  class ControllableAllocationStrategy(toRebalance: AtomicReference[Set[ShardRegion.ShardId]])
+      extends ShardAllocationStrategy {
+
+    override def allocateShard(
+        requester: ActorRef,
+        shardId: ShardRegion.ShardId,
+        currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardRegion.ShardId]]): Future[ActorRef] =
+      Future.successful(currentShardAllocations.keys.head)
+
+    override def rebalance(
+        currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardRegion.ShardId]],
+        rebalanceInProgress: Set[ShardRegion.ShardId]): Future[Set[ShardRegion.ShardId]] =
+      Future.successful(toRebalance.getAndSet(Set.empty))
+  }
+}
+
+// Regression guard for the non-StopShards path through `ShardCoordinator.RebalanceDone`:
+// after a normal rebalance, the deallocated shard must be eagerly re-allocated by the
+// coordinator (via the synthetic `GetShardHome`), without waiting for an entity message.
+// The symmetric "do not re-allocate after StopShards" behavior is covered by
+// `ShardedDaemonProcessRescaleEmptyShardsSpec`.
+class RebalanceReallocatesShardSpec extends AkkaSpec(RebalanceReallocatesShardSpec.config) with WithLogCapturing {
+  import RebalanceReallocatesShardSpec._
+
+  private val toRebalance = new AtomicReference[Set[ShardRegion.ShardId]](Set.empty)
+
+  private val region = ClusterSharding(system).start(
+    shardTypeName,
+    Props[EntityActor](),
+    ClusterShardingSettings(system),
+    extractEntityId,
+    extractShardId,
+    new ControllableAllocationStrategy(toRebalance),
+    PoisonPill)
+
+  private val probe = TestProbe()
+
+  "RebalanceDone for a normal rebalance" must {
+
+    "form a single-node cluster" in {
+      Cluster(system).join(Cluster(system).selfAddress)
+      awaitAssert(Cluster(system).selfMember.status shouldEqual MemberStatus.Up, 5.seconds)
+    }
+
+    "eagerly re-allocate the deallocated shard without entity messages arriving" in {
+      // start one entity in each of two shards
+      region.tell(0, probe.ref) // -> shard "0"
+      val entity0 = probe.expectMsgType[ActorRef]
+      probe.watch(entity0)
+
+      region.tell(1, probe.ref) // -> shard "1"
+      val entity1 = probe.expectMsgType[ActorRef]
+      probe.watch(entity1)
+
+      probe.awaitAssert({
+        region.tell(GetShardRegionState, probe.ref)
+        val state = probe.expectMsgType[CurrentShardRegionState]
+        state.shards.map(s => s.shardId -> s.entityIds.size).toMap should ===(Map("0" -> 1, "1" -> 1))
+      }, 5.seconds)
+
+      // trigger rebalance of shard "0" via the custom strategy on the next rebalance tick
+      toRebalance.set(Set("0"))
+
+      // entity in shard "0" is terminated as part of the handoff
+      probe.expectTerminated(entity0, 10.seconds)
+
+      // No further entity messages are sent. Shard "0" must reappear in the region's state
+      // (with no entities) because the coordinator's RebalanceDone handler eagerly
+      // re-allocates non-StopShards rebalances via a synthetic GetShardHome.
+      probe.awaitAssert({
+        region.tell(GetShardRegionState, probe.ref)
+        val state = probe.expectMsgType[CurrentShardRegionState]
+        val byShard = state.shards.map(s => s.shardId -> s.entityIds.size).toMap
+        byShard.get("0") should ===(Some(0))
+        // shard "1" remains as before with its original entity
+        byShard.get("1") should ===(Some(1))
+      }, 10.seconds)
+    }
+  }
+}


### PR DESCRIPTION
When `ShardedDaemonProcess` scales down (e.g. 256 → 16), the coordinator's `RebalanceDone` handler unconditionally fires a synthetic `GetShardHome` after every handoff, including handoffs triggered by an explicit `StopShards`. This re-allocates the just-stopped shard, spawning a fresh empty `Shard` actor in some region. For SDP these orphans never receive any entity message (new revision uses different entity IDs) but stay around forever and participate in future rebalances.

In `ShardCoordinator.RebalanceDone`, skip the eager re-allocation when the shard was in `waitingForShardsToStop` (i.e. stopped via `StopShards`). Regular rebalance, graceful region shutdown, and region failure paths are unaffected, none of them populate `waitingForShardsToStop`.