### PR TITLE
fix: Emit RecoveryFailed on snapshot adapter errors

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -7,12 +7,7 @@ package akka.persistence.typed.internal
 import scala.collection.immutable
 
 import akka.actor.ActorRef
-import akka.actor.typed.Behavior
-import akka.actor.typed.PostStop
-import akka.actor.typed.PreRestart
-import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.ActorContext
-import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.persistence._
@@ -135,17 +130,6 @@ private[akka] trait JournalInteractions[C, E, S] {
 
   protected def requestRecoveryPermit(): Unit = {
     setup.persistence.recoveryPermitter.tell(RecoveryPermitter.RequestRecoveryPermit, setup.selfClassic)
-  }
-
-  /** Intended to be used in .onSignal(returnPermitOnStop) by behaviors */
-  protected def returnPermitOnStop
-      : PartialFunction[(ActorContext[InternalProtocol], Signal), Behavior[InternalProtocol]] = {
-    case (_, PostStop) =>
-      tryReturnRecoveryPermit("PostStop")
-      Behaviors.stopped
-    case (_, PreRestart) =>
-      tryReturnRecoveryPermit("PreRestart")
-      Behaviors.stopped
   }
 
   /** Mutates setup, by setting the `holdingRecoveryPermit` to false */

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -15,6 +15,8 @@ import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.Behavior
+import akka.actor.typed.PostStop
+import akka.actor.typed.PreRestart
 import akka.actor.typed.Signal
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
@@ -127,6 +129,17 @@ private[akka] final class ReplayingEvents[C, E, S](
     case PoisonPill =>
       state = state.copy(receivedPoisonPill = true)
       this
+    // PostStop and PreRestart return the recovery permit promptly (it is otherwise only returned via
+    // onRecoveryFailure/onRecoveryCompleted, or reclaimed by the RecoveryPermitter via death watch, which a
+    // restart doesn't trigger). They are still delivered to the user signal handler. Same as in ReplayingSnapshot.
+    case PostStop =>
+      tryReturnRecoveryPermit("PostStop")
+      setup.onSignal(state.state, PostStop, catchAndLog = true)
+      Behaviors.stopped
+    case PreRestart =>
+      tryReturnRecoveryPermit("PreRestart")
+      setup.onSignal(state.state, PreRestart, catchAndLog = true)
+      Behaviors.stopped
     case signal =>
       if (setup.onSignal(state.state, signal, catchAndLog = true)) this
       else Behaviors.unhandled

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -216,7 +216,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
       if (setup.isSnapshotOptional) {
         setup.internalLogger.info(
           "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true. " +
-            "Caused by: {}",
+          "Caused by: {}",
           setup.persistenceId,
           cause.toString)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -4,7 +4,9 @@
 
 package akka.persistence.typed.internal
 
-import akka.actor.typed.Behavior
+import scala.util.control.NonFatal
+
+import akka.actor.typed.{ Behavior, PostStop, PreRestart }
 import akka.actor.typed.internal.PoisonPill
 import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
 import akka.annotation.{ InternalApi, InternalStableApi }
@@ -79,13 +81,24 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           case _: AsyncEffectCompleted[_, _, _]      => Behaviors.unhandled
           case _: AsyncReplicationInterceptCompleted => Behaviors.unhandled
         }
-        .receiveSignal(returnPermitOnStop.orElse {
+        .receiveSignal {
           case (_, PoisonPill) =>
             stay(receivedPoisonPill = true)
+          // PostStop and PreRestart return the recovery permit promptly (the RecoveryPermitter would otherwise
+          // only reclaim it via death watch, which a restart doesn't trigger). They are still delivered to the
+          // user signal handler, consistently with the other recovery phases (e.g. ReplayingEvents).
+          case (_, PostStop) =>
+            tryReturnRecoveryPermit("PostStop")
+            setup.onSignal(setup.emptyState, PostStop, catchAndLog = true)
+            Behaviors.stopped
+          case (_, PreRestart) =>
+            tryReturnRecoveryPermit("PreRestart")
+            setup.onSignal(setup.emptyState, PreRestart, catchAndLog = true)
+            Behaviors.stopped
           case (_, signal) =>
             if (setup.onSignal(setup.emptyState, signal, catchAndLog = true)) Behaviors.same
             else Behaviors.unhandled
-        })
+        }
     }
     stay(receivedPoisonPillInPreviousPhase)
   }
@@ -196,20 +209,31 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           eventsReplayed = 0))
     }
 
+    // When the snapshot can't be used (the store failed to load it, or the snapshot adapter / metadata
+    // extraction threw while transforming it) either replay all events when the snapshot is optional, or
+    // fail recovery (emitting RecoveryFailed). Same handling regardless of whether the load or the adapter failed.
+    def handleSnapshotFailure(cause: Throwable, toSnr: Long): Behavior[InternalProtocol] =
+      if (setup.isSnapshotOptional) {
+        setup.internalLogger.info(
+          "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true",
+          setup.persistenceId)
+
+        loadSnapshotResult(snapshot = None, toSnr)
+      } else {
+        onRecoveryFailure(cause)
+      }
+
     response match {
       case LoadSnapshotResult(snapshot, toSnr) =>
-        loadSnapshotResult(snapshot, toSnr)
+        try {
+          loadSnapshotResult(snapshot, toSnr)
+        } catch {
+          case NonFatal(cause) =>
+            handleSnapshotFailure(cause, toSnr)
+        }
 
       case LoadSnapshotFailed(cause) =>
-        if (setup.isSnapshotOptional) {
-          setup.internalLogger.info(
-            "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true",
-            setup.persistenceId)
-
-          loadSnapshotResult(snapshot = None, setup.recovery.toClassic.toSequenceNr)
-        } else {
-          onRecoveryFailure(cause)
-        }
+        handleSnapshotFailure(cause, setup.recovery.toClassic.toSequenceNr)
 
       case _ =>
         Behaviors.unhandled

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -215,8 +215,10 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
     def handleSnapshotFailure(cause: Throwable, toSnr: Long): Behavior[InternalProtocol] =
       if (setup.isSnapshotOptional) {
         setup.internalLogger.info(
-          "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true",
-          setup.persistenceId)
+          "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true. " +
+            "Caused by: {}",
+          setup.persistenceId,
+          cause.toString)
 
         loadSnapshotResult(snapshot = None, toSnr)
       } else {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotAdapterFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotAdapterFailureSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.PostStop
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.RecoveryCompleted
+import akka.persistence.typed.RecoveryFailed
+import akka.persistence.typed.SnapshotAdapter
+import akka.persistence.typed.SnapshotCompleted
+import akka.persistence.typed.internal.JournalFailureException
+import akka.serialization.jackson.CborSerializable
+
+object SnapshotAdapterFailureSpec {
+
+  // a second snapshot store, identical to the local one but with snapshot-is-optional = true
+  private val conf: Config = ConfigFactory.parseString(s"""
+      akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+      akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+      akka.persistence.snapshot-store.local.dir = "target/SnapshotAdapterFailureSpec-${UUID.randomUUID().toString}"
+      optional-snapshot-store = $${akka.persistence.snapshot-store.local}
+      optional-snapshot-store.snapshot-is-optional = true
+      optional-snapshot-store.dir = "target/SnapshotAdapterFailureSpec-optional-${UUID.randomUUID().toString}"
+    """).withFallback(ConfigFactory.defaultReference()).resolve()
+
+  final case class State(value: String) extends CborSerializable
+
+  // toJournal is identity, fromJournal always throws to simulate a failing migration/transformation
+  private val failingAdapter: SnapshotAdapter[State] = new SnapshotAdapter[State] {
+    override def toJournal(state: State): Any = state
+    override def fromJournal(from: Any): State =
+      throw new RuntimeException("snapshot adapter failure")
+  }
+}
+
+class SnapshotAdapterFailureSpec
+    extends ScalaTestWithActorTestKit(SnapshotAdapterFailureSpec.conf)
+    with AnyWordSpecLike
+    with LogCapturing {
+  import SnapshotAdapterFailureSpec._
+
+  private val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"sa-${pidCounter.incrementAndGet()}")
+
+  private def behavior(
+      pid: PersistenceId,
+      snapshotPluginId: String,
+      probe: ActorRef[String],
+      failureProbe: ActorRef[Throwable]): EventSourcedBehavior[String, String, State] =
+    EventSourcedBehavior[String, String, State](
+      pid,
+      State(""),
+      commandHandler = { (state, command) =>
+        command match {
+          case "get" =>
+            probe.tell(s"state[${state.value}]")
+            Effect.none
+          case _ =>
+            Effect.persist(command)
+        }
+      },
+      eventHandler = { (state, event) =>
+        State(state.value + "|" + event)
+      })
+      .snapshotAdapter(failingAdapter)
+      .withSnapshotPluginId(snapshotPluginId)
+      .snapshotWhen { (_, event, _) =>
+        event == "snap"
+      }
+      .receiveSignal {
+        case (state, RecoveryCompleted) => probe.tell(s"recovered[${state.value}]")
+        case (_, _: SnapshotCompleted)  => probe.tell("snapshot-saved")
+        case (_, RecoveryFailed(cause)) => failureProbe.tell(cause)
+        case (_, PostStop)              => probe.tell("stopped")
+      }
+
+  "Snapshot recovery when the snapshot adapter fails" must {
+
+    "fail recovery and signal RecoveryFailed when fromJournal throws" in {
+      val pid = nextPid()
+      val probe = createTestProbe[String]()
+      val failureProbe = createTestProbe[Throwable]()
+
+      // first incarnation saves a snapshot (fromJournal is never called since there is no snapshot yet)
+      val ref1 = spawn(behavior(pid, "akka.persistence.snapshot-store.local", probe.ref, failureProbe.ref))
+      probe.expectMessage("recovered[]")
+      ref1 ! "a"
+      ref1 ! "snap"
+      probe.expectMessage("snapshot-saved")
+      testKit.stop(ref1)
+      probe.expectMessage("stopped")
+
+      // second incarnation loads the snapshot, the adapter throws -> RecoveryFailed + JournalFailureException + stop.
+      // PostStop is delivered to the user signal handler in the snapshot recovery phase too (consistent with
+      // event recovery failures), so "stopped" is observed (and not "recovered[...]", since recovery failed).
+      LoggingTestKit.error[JournalFailureException].expect {
+        spawn(behavior(pid, "akka.persistence.snapshot-store.local", probe.ref, failureProbe.ref))
+        failureProbe.expectMessageType[RuntimeException].getMessage shouldBe "snapshot adapter failure"
+        probe.expectMessage("stopped")
+      }
+    }
+
+    "replay all events when fromJournal throws and snapshot-is-optional=true" in {
+      val pid = nextPid()
+      val probe = createTestProbe[String]()
+      val failureProbe = createTestProbe[Throwable]()
+
+      // first incarnation saves a snapshot in the optional snapshot store
+      val ref1 = spawn(behavior(pid, "optional-snapshot-store", probe.ref, failureProbe.ref))
+      probe.expectMessage("recovered[]")
+      ref1 ! "a"
+      ref1 ! "b"
+      ref1 ! "snap"
+      probe.expectMessage("snapshot-saved")
+      testKit.stop(ref1)
+      probe.expectMessage("stopped")
+
+      // second incarnation: the adapter throws, but since the snapshot is optional all events are replayed
+      val ref2 = spawn(behavior(pid, "optional-snapshot-store", probe.ref, failureProbe.ref))
+      probe.expectMessage("recovered[|a|b|snap]")
+      failureProbe.expectNoMessage() // RecoveryFailed was not signalled
+      ref2 ! "get"
+      probe.expectMessage("state[|a|b|snap]")
+      testKit.stop(ref2)
+    }
+  }
+}

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -742,8 +742,10 @@ private[persistence] trait Eventsourced
         case LoadSnapshotFailed(cause) =>
           if (isSnapshotOptional) {
             log.info(
-              "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true",
-              persistenceId)
+              "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true. " +
+                "Caused by: {}",
+              persistenceId,
+              cause.toString)
             loadSnapshotResult(snapshot = None, recovery.toSequenceNr)
           } else {
             timeoutCancellable.cancel()

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -743,7 +743,7 @@ private[persistence] trait Eventsourced
           if (isSnapshotOptional) {
             log.info(
               "Snapshot load error for persistenceId [{}]. Replaying all events since snapshot-is-optional=true. " +
-                "Caused by: {}",
+              "Caused by: {}",
               persistenceId,
               cause.toString)
             loadSnapshotResult(snapshot = None, recovery.toSequenceNr)


### PR DESCRIPTION
- exception from snapshot adapter was not caught, no RecoveryFailed signal emitted
- PostStop/PreRestart signals were swallowed in the snapshot recovery phase
- unify the load-failed and adapter-failed paths
- return permit from PostStop and PreRestart
