### PR TITLE
bump: Jackson and Jackson Databind 2.18.8 (was 2.18.6)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val nettyVersion = "4.2.15.Final"
   val protobufJavaVersion = "3.25.5" // also sync with protocVersion in Protobuf.scala
   val logbackVersion = "1.5.18"
-  val jacksonCoreVersion = "2.18.6" // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
+  val jacksonCoreVersion = "2.18.8" // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
   val jacksonDatabindVersion = jacksonCoreVersion // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
 
   // Also update URLs in link-validator.conf


### PR DESCRIPTION
There might be a 2.18.9 release incoming in the next days which fixes another CVE.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.18
- https://github.com/FasterXML/jackson-core/tags
- https://github.com/akka/akka-core/pull/32902
