### PR TITLE
fix: Avoid shard restart in case of slow RememberEntitiesStore recovery

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -31,7 +31,6 @@ import akka.cluster.sharding.ShardRegion.ShardsUpdated
 import akka.cluster.sharding.internal.EntityPassivationStrategy
 import akka.cluster.sharding.internal.RememberEntitiesProvider
 import akka.cluster.sharding.internal.RememberEntitiesShardStore
-import akka.cluster.sharding.internal.RememberEntitiesShardStore.GetEntities
 import akka.cluster.sharding.internal.RememberEntityStarterManager
 import akka.cluster.sharding.internal.ShardingFlightRecorder
 import akka.coordination.lease.scaladsl.Lease
@@ -557,10 +556,7 @@ private[akka] class Shard(
       case Some(store) =>
         log.debug("{}: Waiting for load of entity ids using [{}] to complete", typeName, store)
         store ! RememberEntitiesShardStore.GetEntities
-        timers.startSingleTimer(
-          RememberEntityTimeoutKey,
-          RememberEntityTimeout(GetEntities),
-          settings.tuningParameters.waitingForStateTimeout)
+        // The store is a local child actor that is expected to always reply, unless it stops because it failed.
         context.become(awaitingRememberedEntities())
       case None =>
         shardInitialized()
@@ -569,9 +565,8 @@ private[akka] class Shard(
 
   def awaitingRememberedEntities(): Receive = {
     case RememberEntitiesShardStore.RememberedEntities(entityIds) =>
-      timers.cancel(RememberEntityTimeoutKey)
       onEntitiesRemembered(entityIds)
-    case RememberEntityTimeout(GetEntities) =>
+    case _: RememberEntityStoreCrashed =>
       loadingEntityIdsFailed()
     case me: MemberEvent =>
       receiveMemberEvent(me)
@@ -587,9 +582,8 @@ private[akka] class Shard(
 
   def loadingEntityIdsFailed(): Unit = {
     log.error(
-      "{}: Failed to load initial entity ids from remember entities store within [{}], stopping shard for backoff and restart",
-      typeName,
-      settings.tuningParameters.waitingForStateTimeout.pretty)
+      "{}: The remember entities store stopped while loading initial entity ids, stopping shard for backoff and restart",
+      typeName)
     // parent ShardRegion supervisor will notice that it terminated and will start it again, after backoff
     context.stop(self)
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/RememberEntitiesStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/RememberEntitiesStore.scala
@@ -29,6 +29,10 @@ private[akka] trait RememberEntitiesProvider {
 
   /**
    * Called once per started shard to create the remember entities shard store
+   *
+   * The store is created as a child of the shard and the shard death-watches it. On any failure the store must
+   * stop itself rather than stay alive without responding, see [[RememberEntitiesShardStore]] for the contract.
+   *
    * @return an actor that handles the protocol defined in [[RememberEntitiesShardStore]]
    */
   def shardStoreProps(shardId: ShardId): Props
@@ -39,7 +43,14 @@ private[akka] trait RememberEntitiesProvider {
  *
  * Could potentially become an open SPI in the future.
  *
- * Implementations are responsible for each of the methods failing the returned future after a timeout.
+ * Protocol contract for implementations (the store is a local child actor of the shard, which death-watches it):
+ *  - In response to [[GetEntities]] the store must eventually reply with [[RememberedEntities]]. The shard does
+ *    not put a timeout on this, because the load can legitimately be slow (e.g. when many shards recover their
+ *    stores concurrently during a rolling restart). Therefore, if the store cannot load its state (e.g. failed
+ *    recovery) it must stop itself; the shard detects the termination via death watch and is restarted after a
+ *    backoff. A store that stays alive without replying would leave the shard stuck.
+ *  - In response to [[Update]] the store must eventually reply with [[UpdateDone]] (the shard does bound this
+ *    with `updating-state-timeout`) or stop itself on failure.
  */
 @InternalApi
 private[akka] object RememberEntitiesShardStore {
@@ -51,6 +62,8 @@ private[akka] object RememberEntitiesShardStore {
   // responses for Update
   final case class UpdateDone(started: Set[EntityId], stopped: Set[EntityId])
 
+  // The store must reply with RememberedEntities, or stop itself if it cannot load the state (e.g. failed
+  // recovery). The shard does not time out this request; it relies on the death watch of the store instead.
   case object GetEntities extends Command
   final case class RememberedEntities(entities: Set[EntityId])
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -118,7 +118,11 @@ object RememberEntitiesFailureSpec {
           case Some(StopStore)  => context.stop(self)
           case Some(Delay(howLong)) =>
             log.debug("Delaying initial entities listing with {}", howLong)
-            timers.startSingleTimer("get-entities-delay", Delayed(sender(), Set.empty), howLong)
+            // a slow but correct store: reply with the proper message once the delay elapses
+            timers.startSingleTimer(
+              "get-entities-delay",
+              Delayed(sender(), RememberEntitiesShardStore.RememberedEntities(Set.empty)),
+              howLong)
         }
       case RememberEntitiesShardStore.Update(started, stopped) =>
         failUpdate match {
@@ -128,7 +132,11 @@ object RememberEntitiesFailureSpec {
           case Some(StopStore)  => context.stop(self)
           case Some(Delay(howLong)) =>
             log.debug("Delaying response for AddEntity with {}", howLong)
-            timers.startSingleTimer("add-entity-delay", Delayed(sender(), Set.empty), howLong)
+            // a slow but correct store: reply with the proper message once the delay elapses
+            timers.startSingleTimer(
+              "add-entity-delay",
+              Delayed(sender(), RememberEntitiesShardStore.UpdateDone(started, stopped)),
+              howLong)
         }
       case FailUpdateEntity(whichWay) =>
         failUpdate = Some(whichWay)
@@ -396,6 +404,81 @@ class RememberEntitiesFailureSpec
         }, 5.seconds)
 
         system.stop(sharding)
+      }
+    }
+
+    "not restart the shard when the initial remember entities load is slower than waiting-for-state-timeout" in {
+      // Simulates a slow concurrent recovery (e.g. many shard stores replaying at once during a rolling
+      // restart). The store is a local child actor that will eventually reply, so the shard must wait for
+      // it rather than time out and restart. The delay is longer than the default waiting-for-state-timeout
+      // (2s), which previously tripped the load timeout and put the shard into a restart/backoff loop.
+      val storeProbe = TestProbe()
+      system.eventStream.subscribe(storeProbe.ref, classOf[ShardStoreCreated])
+
+      failShardGetEntities = Map("1" -> Delay(3.seconds))
+      try {
+        val sharding = ClusterSharding(system).start(
+          "slowInitialLoad",
+          Props[EntityActor](),
+          ClusterShardingSettings(system).withRememberEntities(true),
+          extractEntityId,
+          extractShardId)
+
+        val probe = TestProbe()
+        sharding.tell(EntityEnvelope(1, "hello-1"), probe.ref)
+
+        // the shard store for shard "1" is created once
+        storeProbe.expectMsgType[ShardStoreCreated]
+
+        // the message is delivered once the slow load completes (~3s), without the shard restarting
+        probe.expectMsg(6.seconds, "hello-1")
+
+        // no second store was created, i.e. the shard did not restart and re-create its store during the load
+        storeProbe.expectNoMessage()
+
+        system.stop(sharding)
+      } finally {
+        failShardGetEntities = Map.empty
+      }
+    }
+
+    "restart the shard if the remember entities store stops while loading initial entity ids" in {
+      val storeProbe = TestProbe()
+      system.eventStream.subscribe(storeProbe.ref, classOf[ShardStoreCreated])
+
+      // keep the store silent so the shard stays in the initial load state (awaiting remembered entities)
+      failShardGetEntities = Map("1" -> NoResponse)
+      try {
+        val sharding = ClusterSharding(system).start(
+          "storeStopDuringLoad",
+          Props[EntityActor](),
+          ClusterShardingSettings(system).withRememberEntities(true),
+          extractEntityId,
+          extractShardId)
+
+        val probe = TestProbe()
+        sharding.tell(EntityEnvelope(1, "hello-1"), probe.ref)
+
+        // the shard has created its store and is now waiting for the (silent) load to complete
+        val store1 = storeProbe.expectMsgType[ShardStoreCreated].store
+
+        // let subsequent loads succeed, then simulate a failed store (e.g. failed recovery) by stopping it
+        // while the shard is still loading. The shard watches the store and must restart rather than hang.
+        failShardGetEntities = Map.empty
+        system.stop(store1)
+
+        // a new store is created for the restarted shard
+        storeProbe.expectMsgType[ShardStoreCreated]
+
+        // and the shard recovers and can serve the entity
+        awaitAssert({
+          sharding.tell(EntityEnvelope(1, "hello-1"), probe.ref)
+          probe.expectMsg("hello-1")
+        }, 5.seconds)
+
+        system.stop(sharding)
+      } finally {
+        failShardGetEntities = Map.empty
       }
     }
 


### PR DESCRIPTION
When many remember entities shards are started at the same time there will be many concurrent recoveries of RememberEntitiesStore. All limited by the recovery permits. Instead of timeout and restart this will wait until the store replies to the GetEntities request.

In case of crash stop of the store, the parent Shard will notice via death watch.
